### PR TITLE
fix(content type schema list): prevent an error if an empty list

### DIFF
--- a/src/commands/content-type-schema/list.spec.ts
+++ b/src/commands/content-type-schema/list.spec.ts
@@ -70,6 +70,45 @@ describe('content-item-schema list command', (): void => {
     expect(mockRender).toHaveBeenCalled();
   });
 
+  it('should not render a table if there are no schemas for a hub', async (): Promise<void> => {
+    const yargArgs = {
+      $0: 'test',
+      _: ['test']
+    };
+    const config = {
+      clientId: 'client-id',
+      clientSecret: 'client-id',
+      hubId: 'hub-id'
+    };
+
+    const listResponse = {
+      toJson: (): { id: string }[] => [],
+      getItems: (): { id: string }[] => []
+    };
+    const mockList = jest.fn().mockResolvedValue(listResponse);
+
+    const mockGetHub = jest.fn().mockResolvedValue({
+      related: {
+        contentTypeSchema: {
+          list: mockList
+        }
+      }
+    });
+    (dynamicContentClientFactory as jest.Mock).mockReturnValue({
+      hubs: {
+        get: mockGetHub
+      }
+    });
+    mockDataPresenter.mockClear();
+
+    const argv = { ...yargArgs, ...config };
+    await handler(argv);
+
+    expect(mockGetHub).toBeCalledWith('hub-id');
+    expect(mockList).toBeCalledWith({});
+    expect(mockDataPresenter).toHaveBeenCalledTimes(0);
+  });
+
   it('should page the data', async (): Promise<void> => {
     const pagingOptions = { page: 3, size: 10, sort: 'createdDate,desc' };
 

--- a/src/commands/content-type-schema/list.ts
+++ b/src/commands/content-type-schema/list.ts
@@ -41,11 +41,15 @@ export const handler = async (argv: Arguments<ConfigurationParameters & Renderin
   const hub = await client.hubs.get(argv.hubId);
   const contentTypeSchemaList = await hub.related.contentTypeSchema.list(pagingOptions);
 
-  new DataPresenter(argv, contentTypeSchemaList)
-    .parse(contentTypeSchemaList =>
-      contentTypeSchemaList
-        .getItems()
-        .map(({ id, schemaId, version, validationLevel }) => ({ id, schemaId, version, validationLevel }))
-    )
-    .render();
+  if (contentTypeSchemaList.getItems().length > 0) {
+    new DataPresenter(argv, contentTypeSchemaList)
+      .parse(contentTypeSchemaList =>
+        contentTypeSchemaList
+          .getItems()
+          .map(({ id, schemaId, version, validationLevel }) => ({ id, schemaId, version, validationLevel }))
+      )
+      .render();
+  } else {
+    console.log('There are no content type schemas defined.');
+  }
 };


### PR DESCRIPTION
prevent a renderring error if the returned content type schemas list is empty