### PR TITLE
refactor(dc-management-sdk-js): replaced deprecated method calls

### DIFF
--- a/src/commands/content-repository/list.spec.ts
+++ b/src/commands/content-repository/list.spec.ts
@@ -122,7 +122,7 @@ describe('content-type-schema list command', (): void => {
         status: 'ACTIVE',
         type: 'CONTENT'
       });
-      const result = itemMapFn(contentRepository.toJson());
+      const result = itemMapFn(contentRepository.toJSON());
       expect(result).toEqual({
         contentTypes: 'id2, http://example.com/scheam2.json',
         features: 'slots',

--- a/src/commands/content-type-schema/get.ts
+++ b/src/commands/content-type-schema/get.ts
@@ -25,5 +25,5 @@ export const handler = async (
   const client = dynamicContentClientFactory(argv);
 
   const contentTypeSchema: ContentTypeSchema = await client.contentTypeSchemas.get(argv.id);
-  new DataPresenter(contentTypeSchema.toJson()).render({ json: argv.json, tableUserConfig: singleItemTableOptions });
+  new DataPresenter(contentTypeSchema.toJSON()).render({ json: argv.json, tableUserConfig: singleItemTableOptions });
 };

--- a/src/commands/content-type-schema/list.spec.ts
+++ b/src/commands/content-type-schema/list.spec.ts
@@ -108,7 +108,7 @@ describe('content-type-schema list command', (): void => {
         validationLevel: 'validationLevel',
         body: '{}'
       });
-      const result = itemMapFn(contentTypeSchema.toJson());
+      const result = itemMapFn(contentTypeSchema.toJSON());
       expect(result).toEqual({
         id: 'id',
         schemaId: 'schemaId',

--- a/src/commands/content-type-schema/list.ts
+++ b/src/commands/content-type-schema/list.ts
@@ -27,7 +27,7 @@ export const handler = async (argv: Arguments<ConfigurationParameters & Renderin
   const contentTypeSchemaList = await paginator(hub.related.contentTypeSchema.list);
 
   if (contentTypeSchemaList.length > 0) {
-    new DataPresenter(contentTypeSchemaList.map(value => value.toJson())).render({
+    new DataPresenter(contentTypeSchemaList.map(value => value.toJSON())).render({
       json: argv.json,
       itemMapFn: itemMapFn
     });

--- a/src/commands/content-type/get.ts
+++ b/src/commands/content-type/get.ts
@@ -25,7 +25,7 @@ export const handler = async (
   const client = dynamicContentClientFactory(argv);
 
   const contentType: ContentType = await client.contentTypes.get(argv.id);
-  new DataPresenter(contentType.toJson()).render({
+  new DataPresenter(contentType.toJSON()).render({
     json: argv.json,
     tableUserConfig: singleItemTableOptions
   });

--- a/src/commands/content-type/list.ts
+++ b/src/commands/content-type/list.ts
@@ -28,7 +28,7 @@ export const handler = async (
   const hub = await client.hubs.get(argv.hubId);
   const contentTypeList = await paginator(hub.related.contentTypes.list, extractSortable(argv));
 
-  new DataPresenter(contentTypeList.map(value => value.toJson())).render({
+  new DataPresenter(contentTypeList.map(value => value.toJSON())).render({
     json: argv.json,
     itemMapFn: itemMapFn
   });

--- a/src/commands/content-type/register.spec.ts
+++ b/src/commands/content-type/register.spec.ts
@@ -165,7 +165,7 @@ describe('content-type register command', () => {
       await handler(argv);
 
       expect(mockGetHub).toBeCalledWith('hub-id');
-      expect(mockRegister).toHaveBeenCalledWith(expect.objectContaining(registerResponse.toJson()));
+      expect(mockRegister).toHaveBeenCalledWith(expect.objectContaining(registerResponse.toJSON()));
       expect(mockDataPresenter).toHaveBeenCalledWith(plainContentType);
       expect(mockDataPresenter.mock.instances[0].render).toHaveBeenCalledWith({
         json: argv.json,

--- a/src/commands/content-type/register.ts
+++ b/src/commands/content-type/register.ts
@@ -62,7 +62,7 @@ export const handler = async (
   });
   const registeredContentType = await hub.related.contentTypes.register(contentType);
 
-  new DataPresenter(registeredContentType.toJson()).render({
+  new DataPresenter(registeredContentType.toJSON()).render({
     json: argv.json,
     tableUserConfig: singleItemTableOptions
   });

--- a/src/commands/content-type/update.spec.ts
+++ b/src/commands/content-type/update.spec.ts
@@ -95,8 +95,8 @@ describe('content-type register update', () => {
       await handler(argv);
 
       expect(mockGetContentType).toHaveBeenCalledWith('content-type-id');
-      expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining(mutatedContentType.toJson()));
-      expect(mockDataPresenter).toHaveBeenCalledWith(mutatedContentType.toJson());
+      expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining(mutatedContentType.toJSON()));
+      expect(mockDataPresenter).toHaveBeenCalledWith(mutatedContentType.toJSON());
       expect(mockDataPresenter.prototype.render).toHaveBeenCalled();
     });
 
@@ -126,8 +126,8 @@ describe('content-type register update', () => {
       await handler(argv);
 
       expect(mockGetContentType).toHaveBeenCalledWith('content-type-id');
-      expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining(mutatedContentType.toJson()));
-      expect(mockDataPresenter).toHaveBeenCalledWith(mutatedContentType.toJson());
+      expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining(mutatedContentType.toJSON()));
+      expect(mockDataPresenter).toHaveBeenCalledWith(mutatedContentType.toJSON());
       expect(mockDataPresenter.prototype.render).toHaveBeenCalled();
     });
 
@@ -152,8 +152,8 @@ describe('content-type register update', () => {
       await handler(argv);
 
       expect(mockGetContentType).toHaveBeenCalledWith('content-type-id');
-      expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining(mutatedContentType.toJson()));
-      expect(mockDataPresenter).toHaveBeenCalledWith(mutatedContentType.toJson());
+      expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining(mutatedContentType.toJSON()));
+      expect(mockDataPresenter).toHaveBeenCalledWith(mutatedContentType.toJSON());
       expect(mockDataPresenter.prototype.render).toHaveBeenCalled();
     });
 
@@ -175,8 +175,8 @@ describe('content-type register update', () => {
       await handler(argv);
 
       expect(mockGetContentType).toHaveBeenCalledWith('content-type-id');
-      expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining(mutatedContentType.toJson()));
-      expect(mockDataPresenter).toHaveBeenCalledWith(mutatedContentType.toJson());
+      expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining(mutatedContentType.toJSON()));
+      expect(mockDataPresenter).toHaveBeenCalledWith(mutatedContentType.toJSON());
       expect(mockDataPresenter.prototype.render).toHaveBeenCalled();
     });
   });

--- a/src/commands/content-type/update.ts
+++ b/src/commands/content-type/update.ts
@@ -65,7 +65,7 @@ export const handler = async (
   });
   const updatedContentType = await contentType.related.update(mutatedContentType);
 
-  new DataPresenter(updatedContentType.toJson()).render({
+  new DataPresenter(updatedContentType.toJSON()).render({
     json: argv.json,
     tableUserConfig: singleItemTableOptions
   });


### PR DESCRIPTION
toJson() --> toJSON()