### PR TITLE
fix(content type schema export): catching json resolve error and disg…

### DIFF
--- a/src/commands/content-type-schema/__snapshots__/export.spec.ts.snap
+++ b/src/commands/content-type-schema/__snapshots__/export.spec.ts.snap
@@ -825,6 +825,25 @@ Array [
 ]
 `;
 
+exports[`content-type-schema export command resolveSchemaBodies should pass through the schema if schema body is not found 1`] = `
+Object {
+  "export-dir/export-filename-1.json": Object {
+    "body": "export-dir/schemas/export-filename-1.json",
+    "schemaId": "content-type-schema-id-1",
+    "validationLevel": "CONTENT_TYPE",
+  },
+}
+`;
+
+exports[`content-type-schema export command resolveSchemaBodies should pass through the schema if schema body is not found 2`] = `
+Array [
+  Array [
+    "export-dir/schemas/export-filename-1.json",
+    "./export-dir/schemas",
+  ],
+]
+`;
+
 exports[`content-type-schema export command resolveSchemaBodies should resolve the schema body 1`] = `
 Object {
   "export-dir/export-filename-1.json": Object {

--- a/src/commands/content-type-schema/export.spec.ts
+++ b/src/commands/content-type-schema/export.spec.ts
@@ -698,7 +698,6 @@ describe('content-type-schema export command', (): void => {
 
     beforeEach(() => {
       jsonResolverSpy = jest.spyOn(resolveJsonService, 'jsonResolver');
-      jsonResolverSpy.mockResolvedValue(resolvedJson);
     });
 
     afterEach(() => {
@@ -713,7 +712,21 @@ describe('content-type-schema export command', (): void => {
           validationLevel: ValidationLevel.CONTENT_TYPE
         })
       };
+      jsonResolverSpy.mockResolvedValueOnce(resolvedJson);
+      const res = await resolveSchemaBodies(exportedContentTypeSchemas, './export-dir');
+      expect(res).toMatchSnapshot();
+      expect(jsonResolverSpy.mock.calls).toMatchSnapshot();
+    });
 
+    it('should pass through the schema if schema body is not found', async () => {
+      const exportedContentTypeSchemas = {
+        'export-dir/export-filename-1.json': new ContentTypeSchema({
+          schemaId: 'content-type-schema-id-1',
+          body: `export-dir/schemas/export-filename-1.json`,
+          validationLevel: ValidationLevel.CONTENT_TYPE
+        })
+      };
+      jsonResolverSpy.mockRejectedValueOnce(new Error('File not found'));
       const res = await resolveSchemaBodies(exportedContentTypeSchemas, './export-dir');
       expect(res).toMatchSnapshot();
       expect(jsonResolverSpy.mock.calls).toMatchSnapshot();

--- a/src/commands/content-type-schema/export.ts
+++ b/src/commands/content-type-schema/export.ts
@@ -62,9 +62,13 @@ export const resolveSchemaBodies = async (
   schemas: { [p: string]: ContentTypeSchema },
   dir: string
 ): Promise<{ [p: string]: ContentTypeSchema }> => {
-  Object.values(schemas).forEach(async schema => {
-    schema.body = await jsonResolver(schema.body, `${dir}${path.sep}schemas`);
-  });
+  const schemaValues = Object.values(schemas);
+
+  for (const schema of schemaValues) {
+    try {
+      schema.body = await jsonResolver(schema.body, `${dir}${path.sep}schemas`);
+    } catch {}
+  }
   return schemas;
 };
 


### PR DESCRIPTION
…arding

We still want to carry out the export if the schema body json file does not exist so catching the
error and allowing exectution to continue.  Also replaced .forEach with a for of loop to avoid
existing async issues (schemas being returned before the chema reference are being updated by the
forEach)