### PR TITLE
fix(content-type-schema import): if schema-id is missing it will fall…

### DIFF
--- a/src/services/resolve-schema-body.spec.ts
+++ b/src/services/resolve-schema-body.spec.ts
@@ -5,9 +5,14 @@ import { jsonResolver } from '../common/json-resolver/json-resolver';
 jest.mock('../common/json-resolver/json-resolver');
 
 describe('resolveSchemaBody', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
   it('should allow undefined body', async () => {
     const schemas = { 'filename.json': new ContentTypeSchema() };
     const [result, errors] = await resolveSchemaBody(schemas, __dirname);
+
+    expect(jsonResolver).not.toHaveBeenCalled();
     expect(result).toMatchInlineSnapshot(`
       Object {
         "filename.json": Object {},
@@ -17,15 +22,35 @@ describe('resolveSchemaBody', () => {
   });
 
   it('should resolve body as string', async () => {
-    const stringifiedBody = JSON.stringify('{"prop": 123}');
+    const stringifiedBody = JSON.stringify({ prop: 123 });
     const mockJsonResolver = jsonResolver as jest.Mock;
     mockJsonResolver.mockResolvedValueOnce(stringifiedBody);
     const schemas = { 'filename.json': new ContentTypeSchema({ body: 'filename.json' }) };
     const [result, errors] = await resolveSchemaBody(schemas, __dirname);
+
+    expect(jsonResolver).toHaveBeenCalledWith('filename.json', __dirname);
     expect(result).toMatchInlineSnapshot(`
       Object {
         "filename.json": Object {
-          "body": "\\"{\\\\\\"prop\\\\\\": 123}\\"",
+          "body": "{\\"prop\\":123}",
+        },
+      }
+    `);
+    expect(errors).toMatchInlineSnapshot(`Object {}`);
+  });
+
+  it('should resolve the schemaId if its not present on ContentTypeSchema', async () => {
+    const mockJsonResolver = jsonResolver as jest.Mock;
+    mockJsonResolver.mockResolvedValueOnce(JSON.stringify({ id: 'http://example.com/schema.json' }));
+    const schemas = { 'schema.json': new ContentTypeSchema({ body: 'filename.json', schemaId: undefined }) };
+    const [result, errors] = await resolveSchemaBody(schemas, __dirname);
+
+    expect(jsonResolver).toHaveBeenCalledWith('filename.json', __dirname);
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "schema.json": Object {
+          "body": "{\\"id\\":\\"http://example.com/schema.json\\"}",
+          "schemaId": "http://example.com/schema.json",
         },
       }
     `);
@@ -37,6 +62,8 @@ describe('resolveSchemaBody', () => {
     mockJsonResolver.mockRejectedValueOnce(new Error('File not found'));
     const schemas = { 'filename.json': new ContentTypeSchema({ body: 'filename.json' }) };
     const [result, errors] = await resolveSchemaBody(schemas, __dirname);
+
+    expect(jsonResolver).toHaveBeenCalledWith('filename.json', __dirname);
     expect(result).toMatchInlineSnapshot(`
       Object {
         "filename.json": Object {

--- a/src/services/resolve-schema-body.ts
+++ b/src/services/resolve-schema-body.ts
@@ -9,14 +9,22 @@ export const resolveSchemaBody = async (
   dir: string
 ): Promise<[ContentTypeSchemaFiles, ResolveSchemaBodyErrors]> => {
   const errors: ResolveSchemaBodyErrors = {};
-  for (const [key, schema] of Object.entries(schemas)) {
-    if (schema.body) {
+  const resolved: ContentTypeSchemaFiles = {};
+  for (const [filename, contentTypeSchema] of Object.entries(schemas)) {
+    if (contentTypeSchema.body) {
       try {
-        schema.body = await jsonResolver(schema.body, dir);
+        contentTypeSchema.body = await jsonResolver(contentTypeSchema.body, dir);
+        if (!contentTypeSchema.schemaId) {
+          const parsedBody = JSON.parse(contentTypeSchema.body);
+          if (parsedBody.id) {
+            contentTypeSchema.schemaId = parsedBody.id;
+          }
+        }
       } catch (err) {
-        errors[key] = err;
+        errors[filename] = err;
       }
     }
+    resolved[filename] = contentTypeSchema;
   }
-  return [schemas, errors];
+  return [resolved, errors];
 };


### PR DESCRIPTION
…back to the id in the body