### PR TITLE
Add Archive/Unarchive for 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -758,14 +758,12 @@
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
-      "dev": true
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
     },
     "@types/glob": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
       "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
-      "dev": true,
       "requires": {
         "@types/events": "*",
         "@types/minimatch": "*",
@@ -827,20 +825,27 @@
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-      "dev": true
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
       "version": "12.7.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
-      "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==",
-      "dev": true
+      "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
+    },
+    "@types/rimraf": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.0.tgz",
+      "integrity": "sha512-7WhJ0MdpFgYQPXlF4Dx+DhgvlPCfz/x5mHaeDQAKhcenvQP1KCpLQ18JklAqeGMYSAT2PxLpzd0g2/HE7fj7hQ==",
+      "requires": {
+        "@types/glob": "*",
+        "@types/node": "*"
+      }
     },
     "@types/semver": {
       "version": "6.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2600,9 +2600,9 @@
       "dev": true
     },
     "dc-management-sdk-js": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dc-management-sdk-js/-/dc-management-sdk-js-1.4.1.tgz",
-      "integrity": "sha512-aYGcu5FyJoFO7xwxix+MTyL/rqPdoRmnRraGD1n5JfzyPJTyYpUsxSqEY3Nmxg776IQ8oQ9Umv2STkWRhDH7wA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/dc-management-sdk-js/-/dc-management-sdk-js-1.6.0.tgz",
+      "integrity": "sha512-PeljqzGMM7YG983YLt6ukX+DDMWAjmkguSUFjdCl2SycaZk7HIIRjdBAxti4HOYPzo2r0VAJ2nw7b7Z91P6SGg==",
       "requires": {
         "@types/es6-promise": "^3.3.0",
         "@types/node": "^10.3.5",
@@ -2611,9 +2611,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.4",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.4.tgz",
-          "integrity": "sha512-F2pgg+LcIr/elguz+x+fdBX5KeZXGUOp7TV8M0TVIrDezYLFRNt8oMTyps0VQ1kj5WGGoR18RdxnRDHXrIFHMQ=="
+          "version": "10.17.28",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
+          "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "typescript": "^3.6.3"
   },
   "dependencies": {
+    "@types/rimraf": "^3.0.0",
     "axios": "^0.18.1",
     "chalk": "^2.4.2",
     "dc-management-sdk-js": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@types/rimraf": "^3.0.0",
     "axios": "^0.18.1",
     "chalk": "^2.4.2",
-    "dc-management-sdk-js": "^1.4.1",
+    "dc-management-sdk-js": "^1.6.0",
     "lodash": "^4.17.15",
     "table": "^5.4.6",
     "yargs": "^14.0.0"

--- a/src/commands/content-repository.ts
+++ b/src/commands/content-repository.ts
@@ -11,4 +11,5 @@ export const builder = (yargs: Argv): Argv =>
     .demandCommand()
     .help();
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
 export const handler = (): void => {};

--- a/src/commands/content-type-schema.ts
+++ b/src/commands/content-type-schema.ts
@@ -11,4 +11,5 @@ export const builder = (yargs: Argv): Argv =>
     .demandCommand()
     .help();
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
 export const handler = (): void => {};

--- a/src/commands/content-type-schema/__mocks__/readline.ts
+++ b/src/commands/content-type-schema/__mocks__/readline.ts
@@ -1,0 +1,19 @@
+let responseQueue: string[] = [];
+
+module.exports = {
+  createInterface: jest.fn().mockReturnValue({
+    question: jest.fn().mockImplementation((questionText, cb) => {
+      if (responseQueue.length == 0) {
+        throw new Error('Too many responses given.');
+      }
+      cb(responseQueue[0]);
+      responseQueue.splice(0, 1);
+    }),
+    close: (): boolean => true
+  }),
+  setResponses: (responses: string[]): void => {
+    responseQueue = responses;
+  },
+  addResponse: (response: string): number => responseQueue.push(response),
+  responsesLeft: (): number => responseQueue.length
+};

--- a/src/commands/content-type-schema/archive.spec.ts
+++ b/src/commands/content-type-schema/archive.spec.ts
@@ -1,0 +1,410 @@
+import { builder, command, handler, LOG_FILENAME } from './archive';
+import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
+import { ContentTypeSchema, Hub } from 'dc-management-sdk-js';
+import Yargs from 'yargs/yargs';
+import MockPage from '../../common/dc-management-sdk-js/mock-page';
+import { exists, readFile, rmdir } from 'fs';
+import { promisify } from 'util';
+import readline from 'readline';
+
+jest.mock('readline');
+
+jest.mock('../../services/dynamic-content-client-factory');
+
+describe('content-item-schema archive command', () => {
+  afterEach((): void => {
+    jest.restoreAllMocks();
+  });
+
+  it('should command should defined', function() {
+    expect(command).toEqual('archive [id]');
+  });
+
+  describe('builder tests', function() {
+    it('should configure yargs', function() {
+      const argv = Yargs(process.argv.slice(2));
+      const spyPositional = jest.spyOn(argv, 'positional').mockReturnThis();
+      const spyOption = jest.spyOn(argv, 'option').mockReturnThis();
+
+      builder(argv);
+
+      expect(spyPositional).toHaveBeenCalledWith('id', {
+        type: 'string',
+        describe:
+          'The ID of a schema to be archived. Note that this is different from the schema ID - which is in a URL format. If neither this or schemaId are provided, this command will archive ALL content type schemas in the hub.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('schemaId', {
+        type: 'string',
+        describe:
+          'The Schema ID of a Content Type Schema to be archived.\nA regex can be provided to select multiple schemas with similar IDs (eg /.header.\\.json/).\nA single --schemaId option may be given to archive a single content type schema.\nMultiple --schemaId options may be given to archive multiple content type schemas at the same time, or even multiple regex.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('f', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'If present, there will be no confirmation prompt before archiving the found content.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('s', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'If present, no log file will be produced.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('ignoreError', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'If present, archive requests that fail will not abort the process.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('logFile', {
+        type: 'string',
+        default: LOG_FILENAME,
+        describe: 'Path to a log file to write to.'
+      });
+    });
+  });
+
+  describe('handler tests', function() {
+    const yargArgs = {
+      $0: 'test',
+      _: ['test'],
+      json: true
+    };
+    const config = {
+      clientId: 'client-id',
+      clientSecret: 'client-id',
+      hubId: 'hub-id'
+    };
+
+    function generateMockSchemaList(
+      names: string[],
+      enrich: (schema: ContentTypeSchema) => void
+    ): MockPage<ContentTypeSchema> {
+      const contentTypeSchemaResponse: ContentTypeSchema[] = names.map(name => {
+        const mockArchive = jest.fn();
+
+        const archiveResponse = new ContentTypeSchema({ schemaId: name });
+        archiveResponse.related.archive = mockArchive;
+
+        mockArchive.mockResolvedValue(archiveResponse);
+
+        enrich(archiveResponse);
+        return archiveResponse;
+      });
+
+      return new MockPage(ContentTypeSchema, contentTypeSchemaResponse);
+    }
+
+    function injectSchemaMocks(names: string[], enrich: (schema: ContentTypeSchema) => void): void {
+      const mockHubGet = jest.fn();
+      const mockHubList = jest.fn();
+
+      (dynamicContentClientFactory as jest.Mock).mockReturnValue({
+        hubs: {
+          get: mockHubGet
+        }
+      });
+
+      const mockHub = new Hub();
+      mockHub.related.contentTypeSchema.list = mockHubList;
+      mockHubGet.mockResolvedValue(mockHub);
+
+      mockHubList.mockResolvedValue(generateMockSchemaList(names, enrich));
+    }
+
+    it("should ask if the user wishes to archive the content, and do so when providing 'y'", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const targets: (() => Promise<ContentTypeSchema>)[] = [];
+      const skips: (() => Promise<ContentTypeSchema>)[] = [];
+
+      injectSchemaMocks(['http://schemas.com/schema1', 'http://schemas.com/schema2'], schema => {
+        if (schema.schemaId === 'http://schemas.com/schema2') {
+          targets.push(schema.related.archive);
+        } else {
+          skips.push(schema.related.archive);
+        }
+      });
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        logFile: LOG_FILENAME(),
+        schemaId: 'http://schemas.com/schema2',
+        silent: true
+      };
+      await handler(argv);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((readline as any).responsesLeft()).toEqual(0);
+
+      // Should have archived relevant content, since we said yes.
+      targets.forEach(target => expect(target).toHaveBeenCalled());
+      skips.forEach(skip => expect(skip).not.toHaveBeenCalled());
+    });
+
+    it("should abort when answering 'n' to the question", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['n']);
+
+      const targets: (() => Promise<ContentTypeSchema>)[] = [];
+      const skips: (() => Promise<ContentTypeSchema>)[] = [];
+
+      injectSchemaMocks(['http://schemas.com/schema1', 'http://schemas.com/schema2'], schema => {
+        if (schema.schemaId === 'http://schemas.com/schema2') {
+          targets.push(schema.related.archive);
+        } else {
+          skips.push(schema.related.archive);
+        }
+      });
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        logFile: LOG_FILENAME(),
+        schemaId: 'http://schemas.com/schema2',
+        silent: true
+      };
+      await handler(argv);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((readline as any).responsesLeft()).toEqual(0);
+
+      // No content should have been archived.
+      targets.forEach(target => expect(target).not.toHaveBeenCalled());
+      skips.forEach(skip => expect(skip).not.toHaveBeenCalled());
+    });
+
+    it('should archive without asking if --force is provided', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['input', 'ignored']);
+
+      const targets: (() => Promise<ContentTypeSchema>)[] = [];
+      const skips: (() => Promise<ContentTypeSchema>)[] = [];
+
+      injectSchemaMocks(['http://schemas.com/schema1', 'http://schemas.com/schema2'], schema => {
+        if (schema.schemaId === 'http://schemas.com/schema2') {
+          targets.push(schema.related.archive);
+        } else {
+          skips.push(schema.related.archive);
+        }
+      });
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        logFile: LOG_FILENAME(),
+        schemaId: 'http://schemas.com/schema2',
+        silent: true,
+        force: true
+      };
+      await handler(argv);
+
+      // We expect our mocked responses to still be present, as the user will not be asked to continue.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((readline as any).responsesLeft()).toEqual(2);
+
+      // Should have archived relevant content, since we forced operation.
+      targets.forEach(target => expect(target).toHaveBeenCalled());
+      skips.forEach(skip => expect(skip).not.toHaveBeenCalled());
+    });
+
+    it('should archive a content-type-schema by id', async () => {
+      const mockGet = jest.fn();
+      let mockArchive: (() => Promise<ContentTypeSchema>) | undefined;
+      const mockHubGet = jest.fn();
+      const mockHubList = jest.fn();
+
+      (dynamicContentClientFactory as jest.Mock).mockReturnValue({
+        contentTypeSchemas: {
+          get: mockGet
+        },
+        hubs: {
+          get: mockHubGet
+        }
+      });
+      const plainListContentTypeSchema = {
+        id: '1',
+        body: '{}',
+        schemaId: 'schemaId1'
+      };
+      const archiveResponse = new ContentTypeSchema(plainListContentTypeSchema);
+
+      const mockHub = new Hub();
+      mockHub.related.contentTypeSchema.list = mockHubList;
+      mockHubGet.mockResolvedValue(mockHub);
+
+      mockHubList.mockResolvedValue(
+        generateMockSchemaList(['schemaId1', 'schemaId2'], schema => {
+          if (schema.schemaId == 'schemaId1') {
+            mockArchive = schema.related.archive;
+          }
+        })
+      );
+
+      mockGet.mockResolvedValue(archiveResponse);
+
+      const argv = {
+        ...yargArgs,
+        id: 'content-type-schema-id',
+        ...config,
+        logFile: LOG_FILENAME(),
+        force: true,
+        silent: true
+      };
+      await handler(argv);
+
+      expect(mockGet).toHaveBeenCalledWith('content-type-schema-id');
+      expect(mockArchive).toHaveBeenCalled();
+    });
+
+    it('should archive a content-type-schema by schema id with --schemaId', async () => {
+      const targets: (() => Promise<ContentTypeSchema>)[] = [];
+      const skips: (() => Promise<ContentTypeSchema>)[] = [];
+
+      injectSchemaMocks(['http://schemas.com/schema1', 'http://schemas.com/schema2'], schema => {
+        if (schema.schemaId === 'http://schemas.com/schema2') {
+          targets.push(schema.related.archive);
+        } else {
+          skips.push(schema.related.archive);
+        }
+      });
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        logFile: LOG_FILENAME(),
+        schemaId: 'http://schemas.com/schema2',
+        force: true,
+        silent: true
+      };
+      await handler(argv);
+
+      targets.forEach(target => expect(target).toHaveBeenCalled());
+      skips.forEach(skip => expect(skip).not.toHaveBeenCalled());
+    });
+
+    it('should archive content-type-schemas by regex on schema id with --schemaId', async () => {
+      const targets: (() => Promise<ContentTypeSchema>)[] = [];
+      const skips: (() => Promise<ContentTypeSchema>)[] = [];
+
+      injectSchemaMocks(
+        [
+          'http://schemas.com/schema1',
+          'http://schemas.com/schema2',
+          'http://schemas.com/schemaBanana',
+          'http://schemas.com/schemaMatch1',
+          'http://schemas.com/schemaMatch2'
+        ],
+        schema => {
+          if (schema.schemaId?.indexOf('schemaMatch') !== -1) {
+            targets.push(schema.related.archive);
+          } else {
+            skips.push(schema.related.archive);
+          }
+        }
+      );
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        logFile: LOG_FILENAME(),
+        schemaId: '/schemaMatch/',
+        force: true,
+        silent: true
+      };
+      await handler(argv);
+
+      targets.forEach(target => expect(target).toHaveBeenCalled());
+      skips.forEach(skip => expect(skip).not.toHaveBeenCalled());
+    });
+
+    it('should attempt to archive all content when no option is provided', async () => {
+      const targets: (() => Promise<ContentTypeSchema>)[] = [];
+
+      injectSchemaMocks(
+        [
+          'http://schemas.com/schema1',
+          'http://schemas.com/schema2',
+          'http://schemas.com/schemaBanana',
+          'http://schemas.com/schemaMatch1',
+          'http://schemas.com/schemaMatch2'
+        ],
+        schema => {
+          targets.push(schema.related.archive);
+        }
+      );
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        logFile: LOG_FILENAME(),
+        force: true,
+        silent: true
+      };
+      await handler(argv);
+
+      targets.forEach(target => expect(target).toHaveBeenCalled());
+    });
+
+    it('should output archived content to a well formatted log file with specified path in --logFile', async () => {
+      // First, ensure the log does not already exist.
+      if (await promisify(exists)('temp/test.log')) {
+        await promisify(rmdir)('temp', { recursive: true });
+      }
+
+      const targets: string[] = [];
+
+      injectSchemaMocks(
+        [
+          'http://schemas.com/schema1',
+          'http://schemas.com/schema2',
+          'http://schemas.com/schemaBanana',
+          'http://schemas.com/schemaMatch1',
+          'http://schemas.com/schemaMatch2'
+        ],
+        schema => {
+          if (schema.schemaId?.indexOf('schemaMatch') !== -1) {
+            targets.push(schema.schemaId ?? '');
+          }
+        }
+      );
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        logFile: 'temp/test.log',
+        schemaId: '/schemaMatch/',
+        force: true
+      };
+      await handler(argv);
+
+      const logExists = await promisify(exists)('temp/test.log');
+
+      expect(logExists).toBeTruthy();
+
+      // Log should contain the two schema that match.
+
+      const log = await promisify(readFile)('temp/test.log', 'utf8');
+
+      const logLines = log.split('\n');
+      let total = 0;
+      logLines.forEach(line => {
+        if (line.startsWith('//')) return;
+        const lineSplit = line.split(' ');
+        if (lineSplit.length == 2) {
+          expect(lineSplit[0]).toEqual('ARCHIVE');
+          expect(targets.indexOf(lineSplit[1])).not.toEqual(-1);
+          total++;
+        }
+      });
+
+      expect(total).toEqual(2);
+
+      await promisify(rmdir)('temp', { recursive: true });
+    });
+  });
+});

--- a/src/commands/content-type-schema/archive.spec.ts
+++ b/src/commands/content-type-schema/archive.spec.ts
@@ -215,16 +215,11 @@ describe('content-item-schema archive command', () => {
 
     it('should archive a content-type-schema by id', async () => {
       const mockGet = jest.fn();
-      let mockArchive: (() => Promise<ContentTypeSchema>) | undefined;
-      const mockHubGet = jest.fn();
-      const mockHubList = jest.fn();
+      const mockArchive = jest.fn();
 
       (dynamicContentClientFactory as jest.Mock).mockReturnValue({
         contentTypeSchemas: {
           get: mockGet
-        },
-        hubs: {
-          get: mockHubGet
         }
       });
       const plainListContentTypeSchema = {
@@ -234,19 +229,9 @@ describe('content-item-schema archive command', () => {
       };
       const archiveResponse = new ContentTypeSchema(plainListContentTypeSchema);
 
-      const mockHub = new Hub();
-      mockHub.related.contentTypeSchema.list = mockHubList;
-      mockHubGet.mockResolvedValue(mockHub);
-
-      mockHubList.mockResolvedValue(
-        generateMockSchemaList(['schemaId1', 'schemaId2'], schema => {
-          if (schema.schemaId == 'schemaId1') {
-            mockArchive = schema.related.archive;
-          }
-        })
-      );
-
+      archiveResponse.related.archive = mockArchive;
       mockGet.mockResolvedValue(archiveResponse);
+      mockArchive.mockResolvedValue(archiveResponse);
 
       const argv = {
         ...yargArgs,

--- a/src/commands/content-type-schema/archive.spec.ts
+++ b/src/commands/content-type-schema/archive.spec.ts
@@ -3,8 +3,7 @@ import dynamicContentClientFactory from '../../services/dynamic-content-client-f
 import { ContentTypeSchema, Hub } from 'dc-management-sdk-js';
 import Yargs from 'yargs/yargs';
 import MockPage from '../../common/dc-management-sdk-js/mock-page';
-import rmdir from 'rimraf';
-import { exists, readFile } from 'fs';
+import { exists, readFile, unlink } from 'fs';
 import { promisify } from 'util';
 import readline from 'readline';
 
@@ -338,8 +337,8 @@ describe('content-item-schema archive command', () => {
 
     it('should output archived content to a well formatted log file with specified path in --logFile', async () => {
       // First, ensure the log does not already exist.
-      if (await promisify(exists)('temp/test.log')) {
-        await promisify(rmdir)('temp');
+      if (await promisify(exists)('temp/schema-archive-test.log')) {
+        await promisify(unlink)('temp/schema-archive-test.log');
       }
 
       const targets: string[] = [];
@@ -362,19 +361,19 @@ describe('content-item-schema archive command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        logFile: 'temp/test.log',
+        logFile: 'temp/schema-archive-test.log',
         schemaId: '/schemaMatch/',
         force: true
       };
       await handler(argv);
 
-      const logExists = await promisify(exists)('temp/test.log');
+      const logExists = await promisify(exists)('temp/schema-archive-test.log');
 
       expect(logExists).toBeTruthy();
 
       // Log should contain the two schema that match.
 
-      const log = await promisify(readFile)('temp/test.log', 'utf8');
+      const log = await promisify(readFile)('temp/schema-archive-test.log', 'utf8');
 
       const logLines = log.split('\n');
       let total = 0;
@@ -390,7 +389,7 @@ describe('content-item-schema archive command', () => {
 
       expect(total).toEqual(2);
 
-      await promisify(rmdir)('temp');
+      await promisify(unlink)('temp/schema-archive-test.log');
     });
   });
 });

--- a/src/commands/content-type-schema/archive.ts
+++ b/src/commands/content-type-schema/archive.ts
@@ -93,7 +93,7 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
     if (revertLog != null) {
       try {
         const log = await new ArchiveLog().loadFromFile(revertLog);
-        const ids = log.getData('ARCHIVE');
+        const ids = log.getData('UNARCHIVE');
         schemas = schemas.filter(schema => ids.indexOf(schema.schemaId || '') != -1);
         if (schemas.length != ids.length) {
           missingContent = true;
@@ -117,11 +117,7 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
   });
 
   if (!force) {
-    const yes = await confirmArchive(
-      'Providing no ID or filter will archive ALL content type schemas! Are you sure you want to do this? (y/n)\n',
-      allContent,
-      missingContent
-    );
+    const yes = await confirmArchive('archive', 'content type schema', allContent, missingContent);
     if (!yes) {
       return;
     }

--- a/src/commands/content-type-schema/archive.ts
+++ b/src/commands/content-type-schema/archive.ts
@@ -94,7 +94,7 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
       try {
         const log = await new ArchiveLog().loadFromFile(revertLog);
         const ids = log.getData('UNARCHIVE');
-        schemas = schemas.filter(schema => ids.indexOf(schema.schemaId || '') != -1);
+        schemas = schemas.filter(schema => ids.indexOf(schema.schemaId as string) != -1);
         if (schemas.length != ids.length) {
           missingContent = true;
         }
@@ -104,7 +104,9 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
       }
     } else if (schemaId != null) {
       const schemaIdArray: string[] = Array.isArray(schemaId) ? schemaId : [schemaId];
-      schemas = schemas.filter(schema => schemaIdArray.findIndex(id => equalsOrRegex(schema.schemaId || '', id)) != -1);
+      schemas = schemas.filter(
+        schema => schemaIdArray.findIndex(id => equalsOrRegex(schema.schemaId as string, id)) != -1
+      );
     } else {
       console.log('No filter, ID or log file was given, so archiving all content.');
       allContent = true;

--- a/src/commands/content-type-schema/archive.ts
+++ b/src/commands/content-type-schema/archive.ts
@@ -99,7 +99,7 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
           missingContent = true;
         }
       } catch (e) {
-        console.log(`Fatal error - could not read archive log. Error: \n${e.toString()}`);
+        console.log(`Fatal error - could not read unarchive log. Error: \n${e.toString()}`);
         return;
       }
     } else if (schemaId != null) {
@@ -139,9 +139,9 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
       log.addComment(e.toString());
 
       if (ignoreError) {
-        console.log(`Failed to unarchive ${schemas[i].schemaId}, continuing. Error: \n${e.toString()}`);
+        console.log(`Failed to archive ${schemas[i].schemaId}, continuing. Error: \n${e.toString()}`);
       } else {
-        console.log(`Failed to unarchive ${schemas[i].schemaId}, aborting. Error: \n${e.toString()}`);
+        console.log(`Failed to archive ${schemas[i].schemaId}, aborting. Error: \n${e.toString()}`);
         break;
       }
     }

--- a/src/commands/content-type-schema/archive.ts
+++ b/src/commands/content-type-schema/archive.ts
@@ -111,6 +111,11 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
     }
   }
 
+  if (schemas.length == 0) {
+    console.log('Nothing found to archive, aborting.');
+    return;
+  }
+
   console.log('The following content will be archived:');
   schemas.forEach(schema => {
     console.log('  ' + schema.schemaId);

--- a/src/commands/content-type-schema/archive.ts
+++ b/src/commands/content-type-schema/archive.ts
@@ -5,7 +5,6 @@ import dynamicContentClientFactory from '../../services/dynamic-content-client-f
 import { ArchiveLog } from '../../common/archive/archive-log';
 import paginator from '../../common/dc-management-sdk-js/paginator';
 import { equalsOrRegex } from '../../common/filter/filter';
-import readline, { ReadLine } from 'readline';
 import { getDefaultLogPath, confirmArchive } from '../../common/archive/archive-helpers';
 import ArchiveOptions from '../../common/archive/archive-options';
 

--- a/src/commands/content-type-schema/archive.ts
+++ b/src/commands/content-type-schema/archive.ts
@@ -1,0 +1,177 @@
+import { Arguments, Argv } from 'yargs';
+import { ConfigurationParameters } from '../configure';
+import { ContentTypeSchema } from 'dc-management-sdk-js';
+import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
+import paginator from '../../common/dc-management-sdk-js/paginator';
+import { equalsOrRegex } from '../../common/filter/filter';
+import readline, { ReadLine } from 'readline';
+import { promisify } from 'util';
+import { join, dirname } from 'path';
+import { exists, mkdir, writeFile } from 'fs';
+
+export const command = 'archive [id]';
+
+export const desc = 'Archive Content Type Schemas';
+
+export const LOG_FILENAME = (platform: string = process.platform): string =>
+  join(
+    process.env[platform == 'win32' ? 'USERPROFILE' : 'HOME'] || __dirname,
+    '.amplience',
+    'logs/schema-archive-<DATE>.log'
+  );
+
+export const builder = (yargs: Argv): void => {
+  yargs
+    .positional('id', {
+      type: 'string',
+      describe:
+        'The ID of a schema to be archived. Note that this is different from the schema ID - which is in a URL format. If neither this or schemaId are provided, this command will archive ALL content type schemas in the hub.'
+    })
+    .option('schemaId', {
+      type: 'string',
+      describe:
+        'The Schema ID of a Content Type Schema to be archived.\nA regex can be provided to select multiple schemas with similar IDs (eg /.header.\\.json/).\nA single --schemaId option may be given to archive a single content type schema.\nMultiple --schemaId options may be given to archive multiple content type schemas at the same time, or even multiple regex.'
+    })
+    .alias('f', 'force')
+    .option('f', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'If present, there will be no confirmation prompt before archiving the found content.'
+    })
+    .alias('s', 'silent')
+    .option('s', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'If present, no log file will be produced.'
+    })
+    .option('ignoreError', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'If present, archive requests that fail will not abort the process.'
+    })
+    .option('logFile', {
+      type: 'string',
+      default: LOG_FILENAME,
+      describe: 'Path to a log file to write to.'
+    });
+};
+
+export interface ArchiveOptions {
+  id?: string;
+  logFile: string;
+  force?: boolean;
+  schemaId?: string | string[];
+  ignoreError?: boolean;
+}
+
+function asyncQuestion(rl: ReadLine, question: string): Promise<string> {
+  return new Promise(resolve => {
+    rl.question(question, resolve);
+  });
+}
+
+export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationParameters>): Promise<void> => {
+  const { id, logFile, force, silent, ignoreError } = argv;
+  let { schemaId } = argv;
+  const client = dynamicContentClientFactory(argv);
+
+  if (id != null && schemaId != null) {
+    console.log('Please specify either a schema ID or an ID - not both.');
+    return;
+  }
+
+  if (id != null) {
+    try {
+      // Get the schema ID and use the other path, to avoid code duplication.
+      const contentTypeSchema: ContentTypeSchema = await client.contentTypeSchemas.get(id);
+      schemaId = contentTypeSchema.schemaId;
+    } catch (e) {
+      console.log(`Fatal error: could not find schema with ID ${id}. Error: \n${e.toString()}`);
+      return;
+    }
+  }
+
+  let schemas: ContentTypeSchema[];
+  try {
+    const hub = await client.hubs.get(argv.hubId);
+    schemas = await paginator(hub.related.contentTypeSchema.list);
+  } catch (e) {
+    console.log(
+      `Fatal error: could not retrieve content type schemas to archive. Is your hub correct? Error: \n${e.toString()}`
+    );
+    return;
+  }
+
+  if (schemaId != null) {
+    const schemaIdArray: string[] = schemaId ? (Array.isArray(schemaId) ? schemaId : [schemaId]) : [];
+    schemas = schemas.filter(schema => schemaIdArray.findIndex(id => equalsOrRegex(schema.schemaId || '', id)) != -1);
+  }
+
+  console.log('The following content will be archived:');
+  schemas.forEach(schema => {
+    console.log('  ' + schema.schemaId);
+  });
+
+  if (!force) {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+      terminal: false
+    });
+
+    const question =
+      schemaId == null
+        ? 'Providing no ID or filter will archive ALL content type schemas! Are you sure you want to do this? (y/n)\n'
+        : 'Are you sure you want to archive these content type schemas? (y/n)\n';
+
+    const answer: string = await asyncQuestion(rl, question);
+    rl.close();
+    const yes = answer.length > 0 && answer[0].toLowerCase() == 'y';
+    if (!yes) {
+      return;
+    }
+  }
+
+  const timestamp = Date.now().toString();
+
+  const logFileName = logFile.replace('<DATE>', timestamp);
+
+  let log = `// Content Type Schema Archive Log - ${timestamp}\n`;
+
+  let successCount = 0;
+
+  for (let i = 0; i < schemas.length; i++) {
+    try {
+      await schemas[i].related.archive();
+      successCount++;
+    } catch (e) {
+      log += `// ARCHIVE FAILED: ${schemas[i].schemaId}\n`;
+      if (ignoreError) {
+        console.log(`Failed to unarchive ${schemas[i].schemaId}, continuing. Error: \n${e.toString()}`);
+      } else {
+        console.log(`Failed to unarchive ${schemas[i].schemaId}, aborting. Error: \n${e.toString()}`);
+        break;
+      }
+    }
+
+    log += `ARCHIVE ${schemas[i].schemaId}\n`;
+  }
+
+  if (!silent) {
+    try {
+      const dir = dirname(logFileName);
+      if (!(await promisify(exists)(dir))) {
+        await promisify(mkdir)(dir);
+      }
+      await promisify(writeFile)(logFileName, log);
+      console.log(`Archive log written to "${logFileName}".`);
+    } catch {
+      console.log('Could not write archive log.');
+    }
+  }
+
+  console.log(`Archived ${successCount} content type schemas.`);
+};
+
+// log format:
+// ARCHIVE <content type id>

--- a/src/commands/content-type-schema/import.spec.ts
+++ b/src/commands/content-type-schema/import.spec.ts
@@ -306,6 +306,7 @@ describe('content-type-schema import command', (): void => {
 
       const processSchemasSpy = jest
         .spyOn(importModule, 'processSchemas')
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
         .mockImplementation(async (): Promise<void> => {});
 
       await handler(argv);

--- a/src/commands/content-type-schema/unarchive.spec.ts
+++ b/src/commands/content-type-schema/unarchive.spec.ts
@@ -89,7 +89,8 @@ describe('content-item-schema unarchive command', () => {
 
     function generateMockSchemaList(
       names: string[],
-      enrich: (schema: ContentTypeSchema) => void
+      enrich: (schema: ContentTypeSchema) => void,
+      failUnarchive?: boolean
     ): MockPage<ContentTypeSchema> {
       const contentTypeSchemaResponse: ContentTypeSchema[] = names.map(name => {
         const mockUnarchive = jest.fn();
@@ -97,7 +98,12 @@ describe('content-item-schema unarchive command', () => {
         const unarchiveResponse = new ContentTypeSchema({ schemaId: name });
         unarchiveResponse.related.unarchive = mockUnarchive;
 
-        mockUnarchive.mockResolvedValue(unarchiveResponse);
+        mockUnarchive.mockImplementation(() => {
+          if (failUnarchive) {
+            throw new Error('Simulated request failure.');
+          }
+          return Promise.resolve(unarchiveResponse);
+        });
 
         enrich(unarchiveResponse);
         return unarchiveResponse;
@@ -106,7 +112,11 @@ describe('content-item-schema unarchive command', () => {
       return new MockPage(ContentTypeSchema, contentTypeSchemaResponse);
     }
 
-    function injectSchemaMocks(names: string[], enrich: (schema: ContentTypeSchema) => void): void {
+    function injectSchemaMocks(
+      names: string[],
+      enrich: (schema: ContentTypeSchema) => void,
+      failUnarchive?: boolean
+    ): void {
       const mockHubGet = jest.fn();
       const mockHubList = jest.fn();
 
@@ -120,7 +130,7 @@ describe('content-item-schema unarchive command', () => {
       mockHub.related.contentTypeSchema.list = mockHubList;
       mockHubGet.mockResolvedValue(mockHub);
 
-      mockHubList.mockResolvedValue(generateMockSchemaList(names, enrich));
+      mockHubList.mockResolvedValue(generateMockSchemaList(names, enrich, failUnarchive));
     }
 
     it("should ask if the user wishes to unarchive the content, and do so when providing 'y'", async () => {
@@ -309,7 +319,7 @@ describe('content-item-schema unarchive command', () => {
         logFile: LOG_FILENAME(),
         slient: true,
         force: true,
-        schemaId: '/schemaMatch/'
+        schemaId: ['/schemaMatch/'] // Pass as an array to cover that case too.
       };
       await handler(argv);
 
@@ -353,7 +363,8 @@ describe('content-item-schema unarchive command', () => {
       const log =
         '// Schema log test file\n' +
         'ARCHIVE http://schemas.com/schemaMatch1\n' +
-        'ARCHIVE http://schemas.com/schemaMatch2';
+        'ARCHIVE http://schemas.com/schemaMatch2\n' +
+        'ARCHIVE http://schemas.com/missing';
 
       const dir = dirname(logFileName);
       if (!(await promisify(exists)(dir))) {
@@ -451,6 +462,188 @@ describe('content-item-schema unarchive command', () => {
       expect(total).toEqual(2);
 
       await promisify(unlink)(logFileName);
+    });
+
+    it('should report a failed unarchive in the provided --logFile and exit immediately', async () => {
+      // First, ensure the log does not already exist.
+      if (await promisify(exists)('temp/schema-unarchive-failed.log')) {
+        await promisify(unlink)('temp/schema-unarchive-failed.log');
+      }
+
+      const targets: string[] = [];
+
+      injectSchemaMocks(
+        [
+          'http://schemas.com/schema1',
+          'http://schemas.com/schema2',
+          'http://schemas.com/schemaBanana',
+          'http://schemas.com/schemaMatch1',
+          'http://schemas.com/schemaMatch2'
+        ],
+        schema => {
+          if ((schema.schemaId || '').indexOf('schemaMatch') !== -1) {
+            targets.push(schema.schemaId || '');
+          }
+        },
+        true
+      );
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        logFile: 'temp/schema-unarchive-failed.log',
+        schemaId: '/schemaMatch/',
+        force: true
+      };
+      await handler(argv);
+
+      const logExists = await promisify(exists)('temp/schema-unarchive-failed.log');
+
+      expect(logExists).toBeTruthy();
+
+      // Log should contain the two schema that match (as failures)
+
+      const log = await promisify(readFile)('temp/schema-unarchive-failed.log', 'utf8');
+
+      const logLines = log.split('\n');
+      let total = 0;
+      logLines.forEach(line => {
+        if (line.indexOf('UNARCHIVE FAILED') !== -1) {
+          total++;
+        }
+      });
+
+      expect(total).toEqual(1); // Does not continue to archive the next one
+
+      await promisify(unlink)('temp/schema-unarchive-failed.log');
+    });
+
+    it('should skip failed unarchives when --ignoreError is provided, but log all failures', async () => {
+      // First, ensure the log does not already exist.
+      if (await promisify(exists)('temp/schema-unarchive-skip.log')) {
+        await promisify(unlink)('temp/schema-unarchive-skip.log');
+      }
+
+      const targets: string[] = [];
+
+      injectSchemaMocks(
+        [
+          'http://schemas.com/schema1',
+          'http://schemas.com/schema2',
+          'http://schemas.com/schemaBanana',
+          'http://schemas.com/schemaMatch1',
+          'http://schemas.com/schemaMatch2'
+        ],
+        schema => {
+          if ((schema.schemaId || '').indexOf('schemaMatch') !== -1) {
+            targets.push(schema.schemaId || '');
+          }
+        },
+        true
+      );
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        logFile: 'temp/schema-unarchive-skip.log',
+        schemaId: '/schemaMatch/',
+        ignoreError: true,
+        force: true
+      };
+      await handler(argv);
+
+      const logExists = await promisify(exists)('temp/schema-unarchive-skip.log');
+
+      expect(logExists).toBeTruthy();
+
+      // Log should contain the two schema that match (as failures)
+
+      const log = await promisify(readFile)('temp/schema-unarchive-skip.log', 'utf8');
+
+      const logLines = log.split('\n');
+      let total = 0;
+      logLines.forEach(line => {
+        if (line.indexOf('UNARCHIVE FAILED') !== -1) {
+          total++;
+        }
+      });
+
+      expect(total).toEqual(2); // Fails to archive each matching type.
+
+      await promisify(unlink)('temp/schema-unarchive-skip.log');
+    });
+
+    it('should exit cleanly when no content can be unarchived', async () => {
+      injectSchemaMocks([], () => {});
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        logFile: LOG_FILENAME(),
+        force: true,
+        silent: true
+      };
+      await handler(argv);
+    });
+
+    it('should exit cleanly when revert log is missing', async () => {
+      const argv = {
+        ...yargArgs,
+        ...config,
+        logFile: LOG_FILENAME(),
+        force: true,
+        silent: true,
+        revertLog: 'doesntExist.txt'
+      };
+      await handler(argv);
+    });
+
+    it('should exit cleanly when hub is not configured, or on invalid input.', async () => {
+      // Content list/get is not init, so it will throw.
+
+      const mockHubGet = jest.fn();
+
+      (dynamicContentClientFactory as jest.Mock).mockReturnValue({
+        hubs: {
+          get: mockHubGet
+        }
+      });
+
+      const mockHub = new Hub();
+      mockHubGet.mockResolvedValue(mockHub);
+
+      // All
+      const argv = {
+        ...yargArgs,
+        ...config,
+        logFile: LOG_FILENAME(),
+        force: true,
+        silent: true
+      };
+      await handler(argv);
+
+      // Id
+      const argv2 = {
+        ...yargArgs,
+        ...config,
+        logFile: LOG_FILENAME(),
+        force: true,
+        silent: true,
+        id: 'test'
+      };
+      await handler(argv2);
+
+      // Id and Schema id
+      const argv3 = {
+        ...yargArgs,
+        ...config,
+        logFile: LOG_FILENAME(),
+        force: true,
+        silent: true,
+        id: 'test',
+        schemaId: 'conflict'
+      };
+      await handler(argv3);
     });
   });
 });

--- a/src/commands/content-type-schema/unarchive.spec.ts
+++ b/src/commands/content-type-schema/unarchive.spec.ts
@@ -42,6 +42,18 @@ describe('content-item-schema unarchive command', () => {
         requiresArg: true
       });
 
+      expect(spyOption).toHaveBeenCalledWith('f', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'If present, there will be no confirmation prompt before unarchiving the found content.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('s', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'If present, no log file will be produced.'
+      });
+
       expect(spyOption).toHaveBeenCalledWith('revertLog', {
         type: 'string',
         describe:
@@ -53,6 +65,12 @@ describe('content-item-schema unarchive command', () => {
         type: 'boolean',
         boolean: true,
         describe: 'If present, unarchive requests that fail will not abort the process.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('logFile', {
+        type: 'string',
+        default: LOG_FILENAME,
+        describe: 'Path to a log file to write to.'
       });
     });
   });

--- a/src/commands/content-type-schema/unarchive.spec.ts
+++ b/src/commands/content-type-schema/unarchive.spec.ts
@@ -1,0 +1,286 @@
+// TESTS
+// should unarchive a content-type-schema by id
+// should unarchive a content-type-schema by schema id with --schemaId
+// should unarchive content-type-schemas by regex on schema id with --schemaId
+// should unarchive content-type-schemas specified in the provided --revertLog
+
+import { builder, command, handler } from './unarchive';
+import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
+import { ContentTypeSchema, Hub } from 'dc-management-sdk-js';
+import Yargs from 'yargs/yargs';
+import MockPage from '../../common/dc-management-sdk-js/mock-page';
+import { dirname } from 'path';
+import { exists, writeFile, mkdir, rmdir } from 'fs';
+import { promisify } from 'util';
+
+jest.mock('readline');
+
+jest.mock('../../services/dynamic-content-client-factory');
+
+describe('content-item-schema unarchive command', () => {
+  afterEach((): void => {
+    jest.restoreAllMocks();
+  });
+
+  it('should command should defined', function() {
+    expect(command).toEqual('unarchive [id]');
+  });
+
+  describe('builder tests', function() {
+    it('should configure yargs', function() {
+      const argv = Yargs(process.argv.slice(2));
+      const spyPositional = jest.spyOn(argv, 'positional').mockReturnThis();
+      const spyOption = jest.spyOn(argv, 'option').mockReturnThis();
+
+      builder(argv);
+
+      expect(spyPositional).toHaveBeenCalledWith('id', {
+        type: 'string',
+        describe:
+          'The ID of a schema to be unarchived. Note that this is different from the schema ID - which is in a URL format.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('schemaId', {
+        type: 'string',
+        describe:
+          'The Schema ID of a Content Type Schema to be unarchived.\nA regex can be provided to \nA single --schemaId option may be given to unarchive a single content type schema.\nMultiple --schemaId options may be given to unarchive multiple content type schemas at the same time.',
+        requiresArg: true
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('revertLog', {
+        type: 'string',
+        describe:
+          'Path to a log file containing content archived in a previous run of the archive command.\nWhen provided, unarchives all schemas listed as archived in the log file.',
+        requiresArg: false
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('ignoreError', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'If present, unarchive requests that fail will not abort the process.'
+      });
+    });
+  });
+
+  describe('handler tests', function() {
+    const yargArgs = {
+      $0: 'test',
+      _: ['test'],
+      json: true
+    };
+    const config = {
+      clientId: 'client-id',
+      clientSecret: 'client-id',
+      hubId: 'hub-id'
+    };
+
+    function generateMockSchemaList(
+      names: string[],
+      enrich: (schema: ContentTypeSchema) => void
+    ): MockPage<ContentTypeSchema> {
+      const contentTypeSchemaResponse: ContentTypeSchema[] = names.map(name => {
+        const mockUnarchive = jest.fn();
+
+        const unarchiveResponse = new ContentTypeSchema({ schemaId: name });
+        unarchiveResponse.related.unarchive = mockUnarchive;
+
+        mockUnarchive.mockResolvedValue(unarchiveResponse);
+
+        enrich(unarchiveResponse);
+        return unarchiveResponse;
+      });
+
+      return new MockPage(ContentTypeSchema, contentTypeSchemaResponse);
+    }
+
+    function injectSchemaMocks(names: string[], enrich: (schema: ContentTypeSchema) => void): void {
+      const mockHubGet = jest.fn();
+      const mockHubList = jest.fn();
+
+      (dynamicContentClientFactory as jest.Mock).mockReturnValue({
+        hubs: {
+          get: mockHubGet
+        }
+      });
+
+      const mockHub = new Hub();
+      mockHub.related.contentTypeSchema.list = mockHubList;
+      mockHubGet.mockResolvedValue(mockHub);
+
+      mockHubList.mockResolvedValue(generateMockSchemaList(names, enrich));
+    }
+
+    it('should unarchive a content-type-schema by id', async () => {
+      const mockGet = jest.fn();
+      let mockUnarchive: (() => Promise<ContentTypeSchema>) | undefined;
+      const mockHubGet = jest.fn();
+      const mockHubList = jest.fn();
+
+      (dynamicContentClientFactory as jest.Mock).mockReturnValue({
+        contentTypeSchemas: {
+          get: mockGet
+        },
+        hubs: {
+          get: mockHubGet
+        }
+      });
+
+      const plainListContentTypeSchema = {
+        id: '1',
+        body: '{}',
+        schemaId: 'schemaId1'
+      };
+      const unarchiveResponse = new ContentTypeSchema(plainListContentTypeSchema);
+
+      const mockHub = new Hub();
+      mockHub.related.contentTypeSchema.list = mockHubList;
+      mockHubGet.mockResolvedValue(mockHub);
+
+      mockHubList.mockResolvedValue(
+        generateMockSchemaList(['schemaId1', 'schemaId2'], schema => {
+          if (schema.schemaId == 'schemaId1') {
+            mockUnarchive = schema.related.unarchive;
+          }
+        })
+      );
+
+      mockGet.mockResolvedValue(unarchiveResponse);
+
+      const argv = {
+        ...yargArgs,
+        id: 'content-type-schema-id',
+        ...config
+      };
+      await handler(argv);
+
+      expect(mockGet).toHaveBeenCalledWith('content-type-schema-id');
+      expect(mockUnarchive).toHaveBeenCalled();
+    });
+
+    it('should unarchive a content-type-schema by schema id with --schemaId', async () => {
+      const targets: (() => Promise<ContentTypeSchema>)[] = [];
+      const skips: (() => Promise<ContentTypeSchema>)[] = [];
+
+      injectSchemaMocks(['http://schemas.com/schema1', 'http://schemas.com/schema2'], schema => {
+        if (schema.schemaId === 'http://schemas.com/schema2') {
+          targets.push(schema.related.unarchive);
+        } else {
+          skips.push(schema.related.unarchive);
+        }
+      });
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        schemaId: 'http://schemas.com/schema2'
+      };
+      await handler(argv);
+
+      targets.forEach(target => expect(target).toHaveBeenCalled());
+      skips.forEach(skip => expect(skip).not.toHaveBeenCalled());
+    });
+
+    it('should unarchive content-type-schemas by regex on schema id with --schemaId', async () => {
+      const targets: (() => Promise<ContentTypeSchema>)[] = [];
+      const skips: (() => Promise<ContentTypeSchema>)[] = [];
+
+      injectSchemaMocks(
+        [
+          'http://schemas.com/schema1',
+          'http://schemas.com/schema2',
+          'http://schemas.com/schemaBanana',
+          'http://schemas.com/schemaMatch1',
+          'http://schemas.com/schemaMatch2'
+        ],
+        schema => {
+          if (schema.schemaId?.indexOf('schemaMatch') !== -1) {
+            targets.push(schema.related.unarchive);
+          } else {
+            skips.push(schema.related.unarchive);
+          }
+        }
+      );
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        schemaId: '/schemaMatch/'
+      };
+      await handler(argv);
+
+      targets.forEach(target => expect(target).toHaveBeenCalled());
+      skips.forEach(skip => expect(skip).not.toHaveBeenCalled());
+    });
+
+    it('should attempt to unarchive all content when no option is provided', async () => {
+      const targets: (() => Promise<ContentTypeSchema>)[] = [];
+
+      injectSchemaMocks(
+        [
+          'http://schemas.com/schema1',
+          'http://schemas.com/schema2',
+          'http://schemas.com/schemaBanana',
+          'http://schemas.com/schemaMatch1',
+          'http://schemas.com/schemaMatch2'
+        ],
+        schema => {
+          targets.push(schema.related.unarchive);
+        }
+      );
+
+      const argv = {
+        ...yargArgs,
+        ...config
+      };
+      await handler(argv);
+
+      targets.forEach(target => expect(target).toHaveBeenCalled());
+    });
+
+    it('should unarchive content-type-schemas specified in the provided --revertLog', async () => {
+      const targets: (() => Promise<ContentTypeSchema>)[] = [];
+      const skips: (() => Promise<ContentTypeSchema>)[] = [];
+
+      const logFileName = 'temp/unarchive.log';
+      const log =
+        '// Schema log test file\n' +
+        'ARCHIVE http://schemas.com/schemaMatch1\n' +
+        'ARCHIVE http://schemas.com/schemaMatch2';
+
+      const dir = dirname(logFileName);
+      if (!(await promisify(exists)(dir))) {
+        await promisify(mkdir)(dir);
+      }
+      await promisify(writeFile)(logFileName, log);
+
+      injectSchemaMocks(
+        [
+          'http://schemas.com/schema1',
+          'http://schemas.com/schema2',
+          'http://schemas.com/schemaBanana',
+          'http://schemas.com/schemaMatch1',
+          'http://schemas.com/schemaMatch2'
+        ],
+        schema => {
+          if (schema.schemaId?.indexOf('schemaMatch') !== -1) {
+            targets.push(schema.related.unarchive);
+          } else {
+            skips.push(schema.related.unarchive);
+          }
+        }
+      );
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        revertLog: logFileName
+      };
+      await handler(argv);
+
+      await promisify(rmdir)('temp', { recursive: true });
+
+      targets.forEach(target => expect(target).toHaveBeenCalled());
+      skips.forEach(skip => expect(skip).not.toHaveBeenCalled());
+    });
+  });
+});

--- a/src/commands/content-type-schema/unarchive.spec.ts
+++ b/src/commands/content-type-schema/unarchive.spec.ts
@@ -1,16 +1,11 @@
-// TESTS
-// should unarchive a content-type-schema by id
-// should unarchive a content-type-schema by schema id with --schemaId
-// should unarchive content-type-schemas by regex on schema id with --schemaId
-// should unarchive content-type-schemas specified in the provided --revertLog
-
 import { builder, command, handler } from './unarchive';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
 import { ContentTypeSchema, Hub } from 'dc-management-sdk-js';
 import Yargs from 'yargs/yargs';
 import MockPage from '../../common/dc-management-sdk-js/mock-page';
+import rmdir from 'rimraf';
 import { dirname } from 'path';
-import { exists, writeFile, mkdir, rmdir } from 'fs';
+import { exists, writeFile, mkdir } from 'fs';
 import { promisify } from 'util';
 
 jest.mock('readline');
@@ -193,7 +188,7 @@ describe('content-item-schema unarchive command', () => {
           'http://schemas.com/schemaMatch2'
         ],
         schema => {
-          if (schema.schemaId?.indexOf('schemaMatch') !== -1) {
+          if ((schema.schemaId || '').indexOf('schemaMatch') !== -1) {
             targets.push(schema.related.unarchive);
           } else {
             skips.push(schema.related.unarchive);
@@ -262,7 +257,7 @@ describe('content-item-schema unarchive command', () => {
           'http://schemas.com/schemaMatch2'
         ],
         schema => {
-          if (schema.schemaId?.indexOf('schemaMatch') !== -1) {
+          if ((schema.schemaId || '').indexOf('schemaMatch') !== -1) {
             targets.push(schema.related.unarchive);
           } else {
             skips.push(schema.related.unarchive);
@@ -277,7 +272,7 @@ describe('content-item-schema unarchive command', () => {
       };
       await handler(argv);
 
-      await promisify(rmdir)('temp', { recursive: true });
+      await promisify(rmdir)('temp');
 
       targets.forEach(target => expect(target).toHaveBeenCalled());
       skips.forEach(skip => expect(skip).not.toHaveBeenCalled());

--- a/src/commands/content-type-schema/unarchive.ts
+++ b/src/commands/content-type-schema/unarchive.ts
@@ -135,7 +135,7 @@ export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationPa
       log.addAction('UNARCHIVE', schemas[i].schemaId || 'unknown');
       successCount++;
     } catch (e) {
-      log.addComment(`ARCHIVE FAILED: ${schemas[i].schemaId}`);
+      log.addComment(`UNARCHIVE FAILED: ${schemas[i].schemaId}`);
       log.addComment(e.toString());
 
       if (ignoreError) {

--- a/src/commands/content-type-schema/unarchive.ts
+++ b/src/commands/content-type-schema/unarchive.ts
@@ -1,0 +1,128 @@
+import { Arguments, Argv } from 'yargs';
+import { ConfigurationParameters } from '../configure';
+import { ContentTypeSchema } from 'dc-management-sdk-js';
+import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
+import { equalsOrRegex } from '../../common/filter/filter';
+import paginator from '../../common/dc-management-sdk-js/paginator';
+import { readFile } from 'fs';
+import { promisify } from 'util';
+
+export const command = 'unarchive [id]';
+
+export const desc = 'Unarchive Content Type Schemas';
+
+export const builder = (yargs: Argv): void => {
+  yargs
+    .positional('id', {
+      type: 'string',
+      describe:
+        'The ID of a schema to be unarchived. Note that this is different from the schema ID - which is in a URL format.'
+    })
+    .option('schemaId', {
+      type: 'string',
+      describe:
+        'The Schema ID of a Content Type Schema to be unarchived.\nA regex can be provided to \nA single --schemaId option may be given to unarchive a single content type schema.\nMultiple --schemaId options may be given to unarchive multiple content type schemas at the same time.',
+      requiresArg: true
+    })
+    .option('revertLog', {
+      type: 'string',
+      describe:
+        'Path to a log file containing content archived in a previous run of the archive command.\nWhen provided, unarchives all schemas listed as archived in the log file.',
+      requiresArg: false
+    })
+    .option('ignoreError', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'If present, unarchive requests that fail will not abort the process.'
+    });
+};
+
+export interface UnarchiveOptions {
+  id?: string;
+  schemaId?: string | string[];
+  revertLog?: string;
+  ignoreError?: boolean;
+}
+
+async function schemaIdsFromLog(revertLog: string): Promise<string[]> {
+  const log = await promisify(readFile)(revertLog, 'utf8');
+  const logLines = log.split('\n');
+  const schemaIds: string[] = [];
+  logLines.forEach(line => {
+    if (line.startsWith('//')) return;
+    const lineSplit = line.split(' ');
+    if (lineSplit.length > 0) {
+      switch (lineSplit[0]) {
+        case 'ARCHIVE':
+          // Archive content with schema ID
+          if (lineSplit.length > 1) {
+            schemaIds.push(lineSplit[1]);
+          }
+          break;
+      }
+    }
+  });
+  return schemaIds;
+}
+
+export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationParameters>): Promise<void> => {
+  const { id, schemaId, revertLog, ignoreError } = argv;
+  const client = dynamicContentClientFactory(argv);
+
+  if (id != null && schemaId != null) {
+    console.log('Please specify either a schema ID or an ID - not both.');
+    return;
+  }
+
+  let schemaIds: string[] = [];
+
+  if (revertLog != null) {
+    try {
+      schemaIds = await schemaIdsFromLog(revertLog);
+    } catch (e) {
+      console.log(`Fatal error - could not read archive log. Error: \n${e.toString()}`);
+      return;
+    }
+  } else if (schemaId != null) {
+    schemaIds = schemaId ? (Array.isArray(schemaId) ? schemaId : [schemaId]) : [];
+  } else if (id != null) {
+    const contentTypeSchema: ContentTypeSchema = await client.contentTypeSchemas.get(id);
+    schemaIds = [contentTypeSchema.schemaId ?? ''];
+  }
+
+  let schemas: ContentTypeSchema[];
+  try {
+    const hub = await client.hubs.get(argv.hubId);
+    schemas = await paginator(hub.related.contentTypeSchema.list);
+  } catch (e) {
+    console.log(
+      `Fatal error: could not retrieve content type schemas to unarchive. Is your hub correct? Error: \n${e.toString()}`
+    );
+    return;
+  }
+
+  if (schemaIds.length > 0) {
+    schemas = schemas.filter(schema => schemaIds.findIndex(id => equalsOrRegex(schema.schemaId || '', id)) != -1);
+  } else {
+    console.log('No filter, ID or log file was given, so unarchiving all content.');
+  }
+
+  let successCount = 0;
+
+  for (let i = 0; i < schemas.length; i++) {
+    try {
+      await schemas[i].related.unarchive();
+      successCount++;
+    } catch (e) {
+      if (ignoreError) {
+        console.log(`Failed to unarchive ${schemas[i].schemaId}, continuing. Error: \n${e.toString()}`);
+      } else {
+        console.log(`Failed to unarchive ${schemas[i].schemaId}, aborting. Error: \n${e.toString()}`);
+        return;
+      }
+    }
+    console.log('Unarchived: ' + schemas[i].schemaId);
+  }
+
+  console.log(`Unarchived ${successCount} content type schemas.`);
+};

--- a/src/commands/content-type-schema/unarchive.ts
+++ b/src/commands/content-type-schema/unarchive.ts
@@ -94,7 +94,7 @@ export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationPa
       try {
         const log = await new ArchiveLog().loadFromFile(revertLog);
         const ids = log.getData('ARCHIVE');
-        schemas = schemas.filter(schema => ids.indexOf(schema.schemaId || '') != -1);
+        schemas = schemas.filter(schema => ids.indexOf(schema.schemaId as string) != -1);
         if (schemas.length != ids.length) {
           missingContent = true;
         }
@@ -103,8 +103,8 @@ export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationPa
         return;
       }
     } else if (schemaId != null) {
-      const schemaIds: string[] = schemaId ? (Array.isArray(schemaId) ? schemaId : [schemaId]) : [];
-      schemas = schemas.filter(schema => schemaIds.findIndex(id => equalsOrRegex(schema.schemaId || '', id)) != -1);
+      const schemaIds: string[] = Array.isArray(schemaId) ? schemaId : [schemaId];
+      schemas = schemas.filter(schema => schemaIds.findIndex(id => equalsOrRegex(schema.schemaId as string, id)) != -1);
     } else {
       allContent = true;
       console.log('No filter, ID or log file was given, so unarchiving all content.');
@@ -137,7 +137,7 @@ export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationPa
     try {
       await schemas[i].related.unarchive();
 
-      log.addAction('UNARCHIVE', schemas[i].schemaId || 'unknown');
+      log.addAction('UNARCHIVE', schemas[i].schemaId as string);
       successCount++;
     } catch (e) {
       log.addComment(`UNARCHIVE FAILED: ${schemas[i].schemaId}`);
@@ -147,7 +147,7 @@ export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationPa
         console.log(`Failed to unarchive ${schemas[i].schemaId}, continuing. Error: \n${e.toString()}`);
       } else {
         console.log(`Failed to unarchive ${schemas[i].schemaId}, aborting. Error: \n${e.toString()}`);
-        return;
+        break;
       }
     }
     console.log('Unarchived: ' + schemas[i].schemaId);

--- a/src/commands/content-type-schema/unarchive.ts
+++ b/src/commands/content-type-schema/unarchive.ts
@@ -111,6 +111,11 @@ export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationPa
     }
   }
 
+  if (schemas.length == 0) {
+    console.log('Nothing found to unarchive, aborting.');
+    return;
+  }
+
   console.log('The following content will be unarchived:');
   schemas.forEach(schema => {
     console.log('  ' + schema.schemaId);

--- a/src/commands/content-type-schema/unarchive.ts
+++ b/src/commands/content-type-schema/unarchive.ts
@@ -129,7 +129,7 @@ export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationPa
   }
 
   const timestamp = Date.now().toString();
-  const log = new ArchiveLog(`Content Type Schema Archive Log - ${timestamp}\n`);
+  const log = new ArchiveLog(`Content Type Schema Unarchive Log - ${timestamp}\n`);
 
   let successCount = 0;
 

--- a/src/commands/content-type-schema/unarchive.ts
+++ b/src/commands/content-type-schema/unarchive.ts
@@ -38,7 +38,7 @@ export const builder = (yargs: Argv): void => {
     .option('f', {
       type: 'boolean',
       boolean: true,
-      describe: 'If present, there will be no confirmation prompt before archiving the found content.'
+      describe: 'If present, there will be no confirmation prompt before unarchiving the found content.'
     })
     .alias('s', 'silent')
     .option('s', {
@@ -117,11 +117,7 @@ export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationPa
   });
 
   if (!force) {
-    const yes = await confirmArchive(
-      'Providing no ID or filter will unarchive ALL content type schemas! Are you sure you want to do this? (y/n)\n',
-      allContent,
-      missingContent
-    );
+    const yes = await confirmArchive('unarchive', 'content type schema', allContent, missingContent);
     if (!yes) {
       return;
     }

--- a/src/commands/content-type.ts
+++ b/src/commands/content-type.ts
@@ -11,4 +11,5 @@ export const builder = (yargs: Argv): Argv =>
     .demandCommand()
     .help();
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
 export const handler = (): void => {};

--- a/src/commands/content-type/archive.spec.ts
+++ b/src/commands/content-type/archive.spec.ts
@@ -3,8 +3,7 @@ import dynamicContentClientFactory from '../../services/dynamic-content-client-f
 import { ContentType, Hub } from 'dc-management-sdk-js';
 import Yargs from 'yargs/yargs';
 import MockPage from '../../common/dc-management-sdk-js/mock-page';
-import rmdir from 'rimraf';
-import { exists, readFile } from 'fs';
+import { exists, readFile, unlink } from 'fs';
 import { promisify } from 'util';
 import readline from 'readline';
 
@@ -370,8 +369,8 @@ describe('content-type archive command', () => {
 
     it('should output archived content to a well formatted log file with specified path in --logFile', async () => {
       // First, ensure the log does not already exist.
-      if (await promisify(exists)('temp/test.log')) {
-        await promisify(rmdir)('temp');
+      if (await promisify(exists)('temp/type-archive-test.log')) {
+        await promisify(unlink)('temp/type-archive-test.log');
       }
 
       const targets: string[] = [];
@@ -394,19 +393,19 @@ describe('content-type archive command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        logFile: 'temp/test.log',
+        logFile: 'temp/type-archive-test.log',
         schemaId: '/schemaMatch/',
         force: true
       };
       await handler(argv);
 
-      const logExists = await promisify(exists)('temp/test.log');
+      const logExists = await promisify(exists)('temp/type-archive-test.log');
 
       expect(logExists).toBeTruthy();
 
       // Log should contain the two schema that match.
 
-      const log = await promisify(readFile)('temp/test.log', 'utf8');
+      const log = await promisify(readFile)('temp/type-archive-test.log', 'utf8');
 
       const logLines = log.split('\n');
       let total = 0;
@@ -422,7 +421,7 @@ describe('content-type archive command', () => {
 
       expect(total).toEqual(2);
 
-      await promisify(rmdir)('temp');
+      await promisify(unlink)('temp/type-archive-test.log');
     });
   });
 });

--- a/src/commands/content-type/archive.ts
+++ b/src/commands/content-type/archive.ts
@@ -95,7 +95,7 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
       try {
         const log = await new ArchiveLog().loadFromFile(revertLog);
         const ids = log.getData('UNARCHIVE');
-        types = types.filter(type => ids.indexOf(type.id || '') != -1);
+        types = types.filter(type => ids.indexOf(type.id as string) != -1);
         if (types.length != ids.length) {
           missingContent = true;
         }
@@ -105,7 +105,9 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
       }
     } else if (schemaId != null) {
       const schemaIdArray: string[] = Array.isArray(schemaId) ? schemaId : [schemaId];
-      types = types.filter(type => schemaIdArray.findIndex(id => equalsOrRegex(type.contentTypeUri || '', id)) != -1);
+      types = types.filter(
+        type => schemaIdArray.findIndex(id => equalsOrRegex(type.contentTypeUri as string, id)) != -1
+      );
     } else {
       allContent = true;
       console.log('No filter, ID or log file was given, so archiving all content.');

--- a/src/commands/content-type/archive.ts
+++ b/src/commands/content-type/archive.ts
@@ -112,6 +112,11 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
     }
   }
 
+  if (types.length == 0) {
+    console.log('Nothing found to archive, aborting.');
+    return;
+  }
+
   console.log('The following content will be archived:');
   types.forEach(type => {
     const settings = type.settings;

--- a/src/commands/content-type/archive.ts
+++ b/src/commands/content-type/archive.ts
@@ -100,7 +100,7 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
           missingContent = true;
         }
       } catch (e) {
-        console.log(`Fatal error - could not read archive log. Error: \n${e.toString()}`);
+        console.log(`Fatal error - could not read unarchive log. Error: \n${e.toString()}`);
         return;
       }
     } else if (schemaId != null) {
@@ -144,9 +144,9 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
       log.addComment(e.toString());
 
       if (ignoreError) {
-        console.log(`Failed to unarchive ${label}, continuing. Error: \n${e.toString()}`);
+        console.log(`Failed to archive ${label}, continuing. Error: \n${e.toString()}`);
       } else {
-        console.log(`Failed to unarchive ${label}, aborting. Error: \n${e.toString()}`);
+        console.log(`Failed to archive ${label}, aborting. Error: \n${e.toString()}`);
         break;
       }
     }

--- a/src/commands/content-type/archive.ts
+++ b/src/commands/content-type/archive.ts
@@ -31,7 +31,7 @@ export const builder = (yargs: Argv): void => {
     .option('revertLog', {
       type: 'string',
       describe:
-        'Path to a log file containing content unarchived in a previous run of the unarchive command.\nWhen provided, archives all schemas listed as unarchived in the log file.',
+        'Path to a log file containing content unarchived in a previous run of the unarchive command.\nWhen provided, archives all types listed as unarchived in the log file.',
       requiresArg: false
     })
     .alias('f', 'force')
@@ -119,11 +119,7 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
   });
 
   if (!force) {
-    const yes = await confirmArchive(
-      'Providing no ID or filter will archive ALL content types! Are you sure you want to do this? (y/n)\n',
-      allContent,
-      missingContent
-    );
+    const yes = await confirmArchive('archive', 'content types', allContent, missingContent);
     if (!yes) {
       return;
     }

--- a/src/commands/content-type/archive.ts
+++ b/src/commands/content-type/archive.ts
@@ -5,7 +5,6 @@ import dynamicContentClientFactory from '../../services/dynamic-content-client-f
 import { ArchiveLog } from '../../common/archive/archive-log';
 import paginator from '../../common/dc-management-sdk-js/paginator';
 import { equalsOrRegex } from '../../common/filter/filter';
-import readline, { ReadLine } from 'readline';
 
 import { getDefaultLogPath, confirmArchive } from '../../common/archive/archive-helpers';
 import ArchiveOptions from '../../common/archive/archive-options';

--- a/src/commands/content-type/unarchive.spec.ts
+++ b/src/commands/content-type/unarchive.spec.ts
@@ -48,10 +48,28 @@ describe('content-type unarchive command', () => {
         requiresArg: false
       });
 
+      expect(spyOption).toHaveBeenCalledWith('f', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'If present, there will be no confirmation prompt before unarchiving the found content.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('s', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'If present, no log file will be produced.'
+      });
+
       expect(spyOption).toHaveBeenCalledWith('ignoreError', {
         type: 'boolean',
         boolean: true,
         describe: 'If present, unarchive requests that fail will not abort the process.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('logFile', {
+        type: 'string',
+        default: LOG_FILENAME,
+        describe: 'Path to a log file to write to.'
       });
     });
   });

--- a/src/commands/content-type/unarchive.spec.ts
+++ b/src/commands/content-type/unarchive.spec.ts
@@ -1,11 +1,11 @@
-import { builder, command, handler } from './unarchive';
+import { builder, command, handler, LOG_FILENAME } from './unarchive';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
 import { ContentType, Hub } from 'dc-management-sdk-js';
 import Yargs from 'yargs/yargs';
 import MockPage from '../../common/dc-management-sdk-js/mock-page';
 import { dirname } from 'path';
 import rmdir from 'rimraf';
-import { exists, writeFile, mkdir } from 'fs';
+import { exists, writeFile, mkdir, readFile } from 'fs';
 import { promisify } from 'util';
 
 jest.mock('readline');
@@ -135,6 +135,8 @@ describe('content-type unarchive command', () => {
 
       const argv = {
         ...yargArgs,
+        logFile: LOG_FILENAME(),
+        slient: true,
         id: 'content-type-id',
         ...config
       };
@@ -165,6 +167,8 @@ describe('content-type unarchive command', () => {
       const argv = {
         ...yargArgs,
         ...config,
+        logFile: LOG_FILENAME(),
+        slient: true,
         schemaId: 'http://schemas.com/schema2'
       };
       await handler(argv);
@@ -197,6 +201,8 @@ describe('content-type unarchive command', () => {
       const argv = {
         ...yargArgs,
         ...config,
+        logFile: LOG_FILENAME(),
+        slient: true,
         schemaId: '/schemaMatch/'
       };
       await handler(argv);
@@ -223,7 +229,9 @@ describe('content-type unarchive command', () => {
 
       const argv = {
         ...yargArgs,
-        ...config
+        ...config,
+        logFile: LOG_FILENAME(),
+        slient: true
       };
       await handler(argv);
 
@@ -263,6 +271,8 @@ describe('content-type unarchive command', () => {
       const argv = {
         ...yargArgs,
         ...config,
+        logFile: LOG_FILENAME(),
+        slient: true,
         revertLog: logFileName
       };
       await handler(argv);
@@ -271,6 +281,63 @@ describe('content-type unarchive command', () => {
 
       targets.forEach(target => expect(target).toHaveBeenCalled());
       skips.forEach(skip => expect(skip).not.toHaveBeenCalled());
+    });
+
+    it('should output unarchived content to a well formatted log file with specified path in --logFile', async () => {
+      // First, ensure the log does not already exist.
+      if (await promisify(exists)('temp/test.log')) {
+        await promisify(rmdir)('temp');
+      }
+
+      const targets: string[] = [];
+
+      injectTypeMocks(
+        [
+          { name: 'Schema 1', schemaId: 'http://schemas.com/schema1' },
+          { name: 'Schema 2', schemaId: 'http://schemas.com/schema2' },
+          { name: 'Schema Banana', schemaId: 'http://schemas.com/schemaBanana' },
+          { name: 'Schema Match 1', schemaId: 'http://schemas.com/schemaMatch1', id: 'id1' },
+          { name: 'Schema Match 2', schemaId: 'http://schemas.com/schemaMatch2', id: 'id2' }
+        ],
+        type => {
+          if ((type.contentTypeUri || '').indexOf('schemaMatch') !== -1) {
+            targets.push(type.id || '');
+          }
+        }
+      );
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        logFile: 'temp/test.log',
+        schemaId: '/schemaMatch/',
+        force: true
+      };
+      await handler(argv);
+
+      const logExists = await promisify(exists)('temp/test.log');
+
+      expect(logExists).toBeTruthy();
+
+      // Log should contain the two schema that match.
+
+      const log = await promisify(readFile)('temp/test.log', 'utf8');
+
+      const logLines = log.split('\n');
+      let total = 0;
+      logLines.forEach(line => {
+        if (line.startsWith('//')) return;
+        const lineSplit = line.split(' ');
+        if (lineSplit.length == 2) {
+          expect(lineSplit[0]).toEqual('UNARCHIVE');
+          expect(targets.indexOf(lineSplit[1])).not.toEqual(-1);
+          total++;
+        }
+      });
+
+      expect(total).toEqual(2);
+
+      await promisify(rmdir)('temp');
     });
   });
 });

--- a/src/commands/content-type/unarchive.spec.ts
+++ b/src/commands/content-type/unarchive.spec.ts
@@ -1,0 +1,276 @@
+import { builder, command, handler } from './unarchive';
+import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
+import { ContentType, Hub } from 'dc-management-sdk-js';
+import Yargs from 'yargs/yargs';
+import MockPage from '../../common/dc-management-sdk-js/mock-page';
+import { dirname } from 'path';
+import rmdir from 'rimraf';
+import { exists, writeFile, mkdir } from 'fs';
+import { promisify } from 'util';
+
+jest.mock('readline');
+
+jest.mock('../../services/dynamic-content-client-factory');
+
+describe('content-type unarchive command', () => {
+  afterEach((): void => {
+    jest.restoreAllMocks();
+  });
+
+  it('should command should defined', function() {
+    expect(command).toEqual('unarchive [id]');
+  });
+
+  describe('builder tests', function() {
+    it('should configure yargs', function() {
+      const argv = Yargs(process.argv.slice(2));
+      const spyPositional = jest.spyOn(argv, 'positional').mockReturnThis();
+      const spyOption = jest.spyOn(argv, 'option').mockReturnThis();
+
+      builder(argv);
+
+      expect(spyPositional).toHaveBeenCalledWith('id', {
+        type: 'string',
+        describe: 'The ID of a content type to be unarchived.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('schemaId', {
+        type: 'string',
+        describe:
+          "The Schema ID of a Content Type's Schema to be unarchived.\nA regex can be provided to select multiple types with similar or matching schema IDs (eg /.header.\\.json/).\nA single --schemaId option may be given to match a single content type schema.\nMultiple --schemaId options may be given to match multiple content type schemas at the same time, or even multiple regex.",
+        requiresArg: true
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('revertLog', {
+        type: 'string',
+        describe:
+          'Path to a log file containing content archived in a previous run of the archive command.\nWhen provided, unarchives all content types listed as archived in the log file.',
+        requiresArg: false
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('ignoreError', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'If present, unarchive requests that fail will not abort the process.'
+      });
+    });
+  });
+
+  describe('handler tests', function() {
+    const yargArgs = {
+      $0: 'test',
+      _: ['test'],
+      json: true
+    };
+    const config = {
+      clientId: 'client-id',
+      clientSecret: 'client-id',
+      hubId: 'hub-id'
+    };
+
+    function generateMockTypeList(
+      templates: { name: string; schemaId: string; id?: string }[],
+      enrich: (type: ContentType) => void
+    ): MockPage<ContentType> {
+      const contentTypeResponse: ContentType[] = templates.map(template => {
+        const mockUnarchive = jest.fn();
+
+        const unarchiveResponse = new ContentType({
+          settings: { label: template.name },
+          contentTypeUri: template.schemaId,
+          id: template.id
+        });
+        unarchiveResponse.related.unarchive = mockUnarchive;
+
+        mockUnarchive.mockResolvedValue(unarchiveResponse);
+
+        enrich(unarchiveResponse);
+        return unarchiveResponse;
+      });
+
+      return new MockPage(ContentType, contentTypeResponse);
+    }
+
+    function injectTypeMocks(
+      templates: { name: string; schemaId: string; id?: string }[],
+      enrich: (type: ContentType) => void
+    ): void {
+      const mockHubGet = jest.fn();
+      const mockHubList = jest.fn();
+
+      (dynamicContentClientFactory as jest.Mock).mockReturnValue({
+        hubs: {
+          get: mockHubGet
+        }
+      });
+
+      const mockHub = new Hub();
+      mockHub.related.contentTypes.list = mockHubList;
+      mockHubGet.mockResolvedValue(mockHub);
+
+      mockHubList.mockResolvedValue(generateMockTypeList(templates, enrich));
+    }
+
+    it('should unarchive a content-type by id', async () => {
+      const mockGet = jest.fn();
+      const mockUnarchive = jest.fn();
+
+      (dynamicContentClientFactory as jest.Mock).mockReturnValue({
+        contentTypes: {
+          get: mockGet
+        }
+      });
+
+      const plainListContentType = {
+        id: 'content-type-id',
+        body: '{}',
+        contentTypeUri: 'schemaId1'
+      };
+      const unarchiveResponse = new ContentType(plainListContentType);
+
+      unarchiveResponse.related.unarchive = mockUnarchive;
+
+      mockGet.mockResolvedValue(unarchiveResponse);
+      mockUnarchive.mockResolvedValue(unarchiveResponse);
+
+      const argv = {
+        ...yargArgs,
+        id: 'content-type-id',
+        ...config
+      };
+      await handler(argv);
+
+      expect(mockGet).toHaveBeenCalledWith('content-type-id');
+      expect(mockUnarchive).toHaveBeenCalled();
+    });
+
+    it('should unarchive a content-type by schema id with --schemaId', async () => {
+      const targets: (() => Promise<ContentType>)[] = [];
+      const skips: (() => Promise<ContentType>)[] = [];
+
+      injectTypeMocks(
+        [
+          { name: 'Schema 1', schemaId: 'http://schemas.com/schema1' },
+          { name: 'Schema 2', schemaId: 'http://schemas.com/schema2' }
+        ],
+        type => {
+          if (type.contentTypeUri === 'http://schemas.com/schema2') {
+            targets.push(type.related.unarchive);
+          } else {
+            skips.push(type.related.unarchive);
+          }
+        }
+      );
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        schemaId: 'http://schemas.com/schema2'
+      };
+      await handler(argv);
+
+      targets.forEach(target => expect(target).toHaveBeenCalled());
+      skips.forEach(skip => expect(skip).not.toHaveBeenCalled());
+    });
+
+    it('should unarchive content-types by regex on schema id with --schemaId', async () => {
+      const targets: (() => Promise<ContentType>)[] = [];
+      const skips: (() => Promise<ContentType>)[] = [];
+
+      injectTypeMocks(
+        [
+          { name: 'Schema 1', schemaId: 'http://schemas.com/schema1' },
+          { name: 'Schema 2', schemaId: 'http://schemas.com/schema2' },
+          { name: 'Schema Banana', schemaId: 'http://schemas.com/schemaBanana' },
+          { name: 'Schema Match 1', schemaId: 'http://schemas.com/schemaMatch1' },
+          { name: 'Schema Match 2', schemaId: 'http://schemas.com/schemaMatch2' }
+        ],
+        type => {
+          if ((type.contentTypeUri || '').indexOf('schemaMatch') !== -1) {
+            targets.push(type.related.unarchive);
+          } else {
+            skips.push(type.related.unarchive);
+          }
+        }
+      );
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        schemaId: '/schemaMatch/'
+      };
+      await handler(argv);
+
+      targets.forEach(target => expect(target).toHaveBeenCalled());
+      skips.forEach(skip => expect(skip).not.toHaveBeenCalled());
+    });
+
+    it('should attempt to unarchive all content when no option is provided', async () => {
+      const targets: (() => Promise<ContentType>)[] = [];
+
+      injectTypeMocks(
+        [
+          { name: 'Schema 1', schemaId: 'http://schemas.com/schema1' },
+          { name: 'Schema 2', schemaId: 'http://schemas.com/schema2' },
+          { name: 'Schema Banana', schemaId: 'http://schemas.com/schemaBanana' },
+          { name: 'Schema Match 1', schemaId: 'http://schemas.com/schemaMatch1' },
+          { name: 'Schema Match 2', schemaId: 'http://schemas.com/schemaMatch2' }
+        ],
+        type => {
+          targets.push(type.related.unarchive);
+        }
+      );
+
+      const argv = {
+        ...yargArgs,
+        ...config
+      };
+      await handler(argv);
+
+      targets.forEach(target => expect(target).toHaveBeenCalled());
+    });
+
+    it('should unarchive content-types specified in the provided --revertLog', async () => {
+      const targets: (() => Promise<ContentType>)[] = [];
+      const skips: (() => Promise<ContentType>)[] = [];
+
+      const logFileName = 'temp/unarchive.log';
+      const log = '// Type log test file\n' + 'ARCHIVE id1\n' + 'ARCHIVE id2';
+
+      const dir = dirname(logFileName);
+      if (!(await promisify(exists)(dir))) {
+        await promisify(mkdir)(dir);
+      }
+      await promisify(writeFile)(logFileName, log);
+
+      injectTypeMocks(
+        [
+          { name: 'Schema 1', schemaId: 'http://schemas.com/schema1' },
+          { name: 'Schema 2', schemaId: 'http://schemas.com/schema2' },
+          { name: 'Schema Banana', schemaId: 'http://schemas.com/schemaBanana' },
+          { name: 'Schema Match 1', schemaId: 'http://schemas.com/schemaMatch1', id: 'id1' },
+          { name: 'Schema Match 2', schemaId: 'http://schemas.com/schemaMatch2', id: 'id2' }
+        ],
+        type => {
+          if ((type.contentTypeUri || '').indexOf('schemaMatch') !== -1) {
+            targets.push(type.related.unarchive);
+          } else {
+            skips.push(type.related.unarchive);
+          }
+        }
+      );
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        revertLog: logFileName
+      };
+      await handler(argv);
+
+      await promisify(rmdir)('temp');
+
+      targets.forEach(target => expect(target).toHaveBeenCalled());
+      skips.forEach(skip => expect(skip).not.toHaveBeenCalled());
+    });
+  });
+});

--- a/src/commands/content-type/unarchive.ts
+++ b/src/commands/content-type/unarchive.ts
@@ -86,7 +86,7 @@ export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationPa
       console.log(
         `Fatal error: could not retrieve content types to unarchive. Is your hub correct? Error: \n${e.toString()}`
       );
-      throw e;
+      return;
     }
 
     if (revertLog != null) {
@@ -103,7 +103,9 @@ export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationPa
       }
     } else if (schemaId != null) {
       const schemaIds: string[] = Array.isArray(schemaId) ? schemaId : [schemaId];
-      types = types.filter(schema => schemaIds.findIndex(id => equalsOrRegex(schema.contentTypeUri || '', id)) != -1);
+      types = types.filter(
+        schema => schemaIds.findIndex(id => equalsOrRegex(schema.contentTypeUri as string, id)) != -1
+      );
     } else {
       allContent = true;
       console.log('No filter, ID or log file was given, so unarchiving all content.');
@@ -149,7 +151,7 @@ export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationPa
         console.log(`Failed to unarchive ${label}, continuing. Error: \n${e.toString()}`);
       } else {
         console.log(`Failed to unarchive ${label}, aborting. Error: \n${e.toString()}`);
-        return;
+        break;
       }
     }
     console.log('Unarchived: ' + label);

--- a/src/commands/content-type/unarchive.ts
+++ b/src/commands/content-type/unarchive.ts
@@ -110,12 +110,14 @@ export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationPa
     }
   }
 
+  console.log('The following content will be unarchived:');
+  types.forEach(type => {
+    const settings = type.settings;
+    console.log('  ' + (settings === undefined ? 'unknown' : settings.label));
+  });
+
   if (!force) {
-    const yes = await confirmArchive(
-      'Providing no ID or filter will unarchive ALL content type schemas! Are you sure you want to do this? (y/n)\n',
-      allContent,
-      missingContent
-    );
+    const yes = await confirmArchive('unarchive', 'content types', allContent, missingContent);
     if (!yes) {
       return;
     }

--- a/src/commands/content-type/unarchive.ts
+++ b/src/commands/content-type/unarchive.ts
@@ -1,0 +1,120 @@
+import { Arguments, Argv } from 'yargs';
+import { ConfigurationParameters } from '../configure';
+import { ContentType, DynamicContent } from 'dc-management-sdk-js';
+import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
+import { ArchiveLog } from '../../common/archive/archive-log';
+import { equalsOrRegex } from '../../common/filter/filter';
+import paginator from '../../common/dc-management-sdk-js/paginator';
+
+export const command = 'unarchive [id]';
+
+export const desc = 'Unarchive Content Types';
+
+export const builder = (yargs: Argv): void => {
+  yargs
+    .positional('id', {
+      type: 'string',
+      describe: 'The ID of a content type to be unarchived.'
+    })
+    .option('schemaId', {
+      type: 'string',
+      describe:
+        "The Schema ID of a Content Type's Schema to be unarchived.\nA regex can be provided to select multiple types with similar or matching schema IDs (eg /.header.\\.json/).\nA single --schemaId option may be given to match a single content type schema.\nMultiple --schemaId options may be given to match multiple content type schemas at the same time, or even multiple regex.",
+      requiresArg: true
+    })
+    .option('revertLog', {
+      type: 'string',
+      describe:
+        'Path to a log file containing content archived in a previous run of the archive command.\nWhen provided, unarchives all content types listed as archived in the log file.',
+      requiresArg: false
+    })
+    .option('ignoreError', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'If present, unarchive requests that fail will not abort the process.'
+    });
+};
+
+export interface UnarchiveOptions {
+  id?: string;
+  schemaId?: string | string[];
+  revertLog?: string;
+  ignoreError?: boolean;
+}
+
+async function getAllTypes(client: DynamicContent, hubId: string): Promise<ContentType[]> {
+  try {
+    const hub = await client.hubs.get(hubId);
+    return paginator(hub.related.contentTypes.list);
+  } catch (e) {
+    console.log(
+      `Fatal error: could not retrieve content types to unarchive. Is your hub correct? Error: \n${e.toString()}`
+    );
+    throw e;
+  }
+}
+
+export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationParameters>): Promise<void> => {
+  const { id, schemaId, revertLog, ignoreError } = argv;
+  const client = dynamicContentClientFactory(argv);
+
+  if (id != null && schemaId != null) {
+    console.log('Please specify either a schema ID or an ID - not both.');
+    return;
+  }
+
+  let types: ContentType[];
+
+  if (id != null) {
+    try {
+      const contentType: ContentType = await client.contentTypes.get(id);
+      types = [contentType];
+    } catch (e) {
+      console.log(`Fatal error: could not find content type with ID ${id}. Error: \n${e.toString()}`);
+      return;
+    }
+  } else {
+    types = await getAllTypes(client, argv.hubId);
+    if (revertLog != null) {
+      try {
+        const log = await new ArchiveLog().loadFromFile(revertLog);
+        const ids = log.getData('ARCHIVE');
+        types = types.filter(type => ids.indexOf(type.id || '') != -1);
+        if (types.length != ids.length) {
+          // ask the user?
+        }
+      } catch (e) {
+        console.log(`Fatal error - could not read archive log. Error: \n${e.toString()}`);
+        return;
+      }
+    } else if (schemaId != null) {
+      const schemaIds: string[] = schemaId ? (Array.isArray(schemaId) ? schemaId : [schemaId]) : [];
+      if (schemaIds.length > 0) {
+        types = types.filter(schema => schemaIds.findIndex(id => equalsOrRegex(schema.contentTypeUri || '', id)) != -1);
+      }
+    } else {
+      console.log('No filter, ID or log file was given, so unarchiving all content.');
+    }
+  }
+
+  let successCount = 0;
+
+  for (let i = 0; i < types.length; i++) {
+    const settings = types[i].settings;
+    const label = settings === undefined ? 'unknown' : settings.label;
+    try {
+      await types[i].related.unarchive();
+      successCount++;
+    } catch (e) {
+      if (ignoreError) {
+        console.log(`Failed to unarchive ${label}, continuing. Error: \n${e.toString()}`);
+      } else {
+        console.log(`Failed to unarchive ${label}, aborting. Error: \n${e.toString()}`);
+        return;
+      }
+    }
+    console.log('Unarchived: ' + label);
+  }
+
+  console.log(`Unarchived ${successCount} content types.`);
+};

--- a/src/commands/content-type/unarchive.ts
+++ b/src/commands/content-type/unarchive.ts
@@ -9,7 +9,7 @@ import { getDefaultLogPath, confirmArchive } from '../../common/archive/archive-
 import UnarchiveOptions from '../../common/archive/unarchive-options';
 
 export const LOG_FILENAME = (platform: string = process.platform): string =>
-  getDefaultLogPath('schema', 'unarchive', platform);
+  getDefaultLogPath('type', 'unarchive', platform);
 
 export const command = 'unarchive [id]';
 
@@ -129,7 +129,7 @@ export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationPa
   }
 
   const timestamp = Date.now().toString();
-  const log = new ArchiveLog(`Content Type Schema Unarchive Log - ${timestamp}\n`);
+  const log = new ArchiveLog(`Content Type Unarchive Log - ${timestamp}\n`);
 
   let successCount = 0;
 

--- a/src/commands/content-type/unarchive.ts
+++ b/src/commands/content-type/unarchive.ts
@@ -110,6 +110,11 @@ export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationPa
     }
   }
 
+  if (types.length == 0) {
+    console.log('Nothing found to unarchive, aborting.');
+    return;
+  }
+
   console.log('The following content will be unarchived:');
   types.forEach(type => {
     const settings = type.settings;
@@ -137,7 +142,7 @@ export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationPa
       log.addAction('UNARCHIVE', types[i].id || 'unknown');
       successCount++;
     } catch (e) {
-      log.addComment(`ARCHIVE FAILED: ${types[i].id}`);
+      log.addComment(`UNARCHIVE FAILED: ${types[i].id}`);
       log.addComment(e.toString());
 
       if (ignoreError) {

--- a/src/common/archive/archive-helpers.ts
+++ b/src/common/archive/archive-helpers.ts
@@ -15,7 +15,12 @@ function asyncQuestion(rl: ReadLine, question: string): Promise<string> {
   });
 }
 
-export async function confirmArchive(message: string, allContent: boolean, missingContent: boolean): Promise<boolean> {
+export async function confirmArchive(
+  action: string,
+  type: string,
+  allContent: boolean,
+  missingContent: boolean
+): Promise<boolean> {
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
@@ -23,10 +28,10 @@ export async function confirmArchive(message: string, allContent: boolean, missi
   });
 
   const question = allContent
-    ? message
+    ? `Providing no ID or filter will ${action} ALL ${type}! Are you sure you want to do this? (y/n)\n`
     : missingContent
     ? 'Warning: Some content specified on the log is missing. Are you sure you want to continue? (y/n)\n'
-    : 'Are you sure you want to archive these content type schemas? (y/n)\n';
+    : `Are you sure you want to ${action} these ${type}? (y/n)\n`;
 
   const answer: string = await asyncQuestion(rl, question);
   rl.close();

--- a/src/common/archive/archive-helpers.ts
+++ b/src/common/archive/archive-helpers.ts
@@ -1,0 +1,34 @@
+import { join } from 'path';
+import readline, { ReadLine } from 'readline';
+
+export function getDefaultLogPath(type: string, action: string, platform: string = process.platform): string {
+  return join(
+    process.env[platform == 'win32' ? 'USERPROFILE' : 'HOME'] || __dirname,
+    '.amplience',
+    `logs/${type}-${action}-<DATE>.log`
+  );
+}
+
+function asyncQuestion(rl: ReadLine, question: string): Promise<string> {
+  return new Promise((resolve): void => {
+    rl.question(question, resolve);
+  });
+}
+
+export async function confirmArchive(message: string, allContent: boolean, missingContent: boolean): Promise<boolean> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: false
+  });
+
+  const question = allContent
+    ? message
+    : missingContent
+    ? 'Warning: Some content specified on the log is missing. Are you sure you want to continue? (y/n)\n'
+    : 'Are you sure you want to archive these content type schemas? (y/n)\n';
+
+  const answer: string = await asyncQuestion(rl, question);
+  rl.close();
+  return answer.length > 0 && answer[0].toLowerCase() == 'y';
+}

--- a/src/common/archive/archive-log.ts
+++ b/src/common/archive/archive-log.ts
@@ -52,16 +52,19 @@ export class ArchiveLog {
         await promisify(mkdir)(dir);
       }
       await promisify(writeFile)(path, log);
-      console.log(`Archive log written to "${path}".`);
+      console.log(`Log written to "${path}".`);
       return true;
     } catch {
-      console.log('Could not write archive log.');
+      console.log('Could not write log.');
       return false;
     }
   }
 
   addComment(comment: string): void {
-    this.items.push({ comment: true, data: comment });
+    const lines = comment.split('\n');
+    lines.forEach(line => {
+      this.items.push({ comment: true, data: line });
+    });
   }
 
   addAction(action: string, data: string): void {

--- a/src/common/archive/archive-log.ts
+++ b/src/common/archive/archive-log.ts
@@ -1,0 +1,74 @@
+import { readFile, writeFile, exists, mkdir } from 'fs';
+import { dirname } from 'path';
+import { promisify } from 'util';
+
+export interface ArchiveLogItem {
+  comment: boolean;
+  action?: string;
+  data: string;
+}
+
+export class ArchiveLog {
+  items: ArchiveLogItem[] = [];
+
+  constructor(public title?: string) {}
+
+  async loadFromFile(path: string): Promise<ArchiveLog> {
+    const log = await promisify(readFile)(path, 'utf8');
+    const logLines = log.split('\n');
+    this.items = [];
+    logLines.forEach(line => {
+      if (line.startsWith('//')) {
+        // The first comment is the title, all ones after it should be recorded as comment items.
+        const message = line.substring(2).trimLeft();
+        if (this.items.length == 0) {
+          this.title = message;
+        } else {
+          this.addComment(message);
+        }
+        return;
+      }
+      const lineSplit = line.split(' ');
+      if (lineSplit.length >= 2) {
+        this.addAction(lineSplit[0], lineSplit.slice(1).join(' '));
+      }
+    });
+    return this;
+  }
+
+  async writeToFile(path: string): Promise<boolean> {
+    try {
+      let log = `// ${this.title}\n`;
+      this.items.forEach(item => {
+        if (item.comment) {
+          log += `// ${item.data}\n`;
+        } else {
+          log += `${item.action} ${item.data}\n`;
+        }
+      });
+
+      const dir = dirname(path);
+      if (!(await promisify(exists)(dir))) {
+        await promisify(mkdir)(dir);
+      }
+      await promisify(writeFile)(path, log);
+      console.log(`Archive log written to "${path}".`);
+      return true;
+    } catch {
+      console.log('Could not write archive log.');
+      return false;
+    }
+  }
+
+  addComment(comment: string): void {
+    this.items.push({ comment: true, data: comment });
+  }
+
+  addAction(action: string, data: string): void {
+    this.items.push({ comment: false, action: action, data: data });
+  }
+
+  getData(action: string): string[] {
+    return this.items.filter(item => !item.comment && item.action === action).map(item => item.data);
+  }
+}

--- a/src/common/archive/archive-options.ts
+++ b/src/common/archive/archive-options.ts
@@ -1,0 +1,9 @@
+export default interface ArchiveOptions {
+  id?: string;
+  schemaId?: string | string[];
+  logFile: string;
+  revertLog?: string;
+  force?: boolean;
+  silent?: boolean;
+  ignoreError?: boolean;
+}

--- a/src/common/archive/unarchive-options.ts
+++ b/src/common/archive/unarchive-options.ts
@@ -1,0 +1,8 @@
+export default interface UnarchiveOptions {
+  id?: string;
+  schemaId?: string | string[];
+  logFile: string;
+  revertLog?: string;
+  silent?: boolean;
+  ignoreError?: boolean;
+}

--- a/src/common/dc-management-sdk-js/paginator.ts
+++ b/src/common/dc-management-sdk-js/paginator.ts
@@ -2,9 +2,13 @@ import { HalResource, Page, Pageable, Sortable } from 'dc-management-sdk-js';
 
 export const DEFAULT_SIZE = 100;
 
+interface StatusQuery {
+  status?: 'ARCHIVED' | 'ACTIVE' | 'DELETED';
+}
+
 const paginator = async <T extends HalResource>(
-  pagableFn: (options?: Pageable & Sortable) => Promise<Page<T>>,
-  options: Pageable & Sortable = {}
+  pagableFn: (options?: Pageable & Sortable & StatusQuery) => Promise<Page<T>>,
+  options: Pageable & Sortable & StatusQuery = {}
 ): Promise<T[]> => {
   const currentPage = await pagableFn({ ...options, size: DEFAULT_SIZE });
   if (

--- a/src/common/filter/filter.ts
+++ b/src/common/filter/filter.ts
@@ -1,0 +1,13 @@
+export function equalsOrRegex(value: string, compare: string): boolean {
+  if (compare.length > 1 && compare[0] == '/' && compare[compare.length - 1] == '/') {
+    // Regex format, try parse as a regex and return if the value is a match.
+    try {
+      const regExp = new RegExp(compare.substr(1, compare.length - 2));
+      return regExp.test(value);
+    } catch (e) {
+      console.error('Could not parse regex!');
+      throw e;
+    }
+  }
+  return value == compare;
+}


### PR DESCRIPTION
Adds archive and unarchive commands for content types, and content type schema.

You can archive by exact ID, or by schema ID (the URI) with either an exact or regex match. Regex arguments are passed with forward slashes on either side, though when they contain spaces they still must be passed with quotes surrounding them like any other string argument (eg. `"/regex with space/"`). Not providing any argument will perform the action on all content, which can be useful.

The user is given a summary of all actions that will be taken in the command line, and must answer (y/n) for the action to be taken. If the user passes the `--force` argument, the answer `y` will be assumed.

These commands output a "revert log", which is a log file that describes all the actions that were taken in a format both readable to people, and readable to the dc-cli itself to _revert_ any action taken at a later date. A log produced by an `archive` command can be used later by an `unarchive` command to undo all archives done by the previous action. This philosophy will carry forward into future PRs that have actions we might want to reverse.

The output location of the log file defaults to a a subfolder called `logs/` in the `.amplience/` folder used for configuration, but can be manually controlled with `--logFile <path>`. Either way, the log file path is printed when the command finishes executing, so that the user knows where their log is located. This log can be used in any future command by passing `--revertLog <path>`. Log files can be suppressed entirely by passing `--silent`.

Last thing - by default the command will abruptly end and output its log when it encounters an error archiving any content (for example, if their state has changed between finding the content to archive and archiving it). Using `--ignoreError` will continue regardless.

Likely needs a squash before merge, some of the commits are fixes to issues within the branch itself, and wouldn't have any value on the actual changelog.