### PR TITLE
feat: Import/Export Content Item commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3564,7 +3564,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3588,13 +3589,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3611,19 +3614,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3754,7 +3760,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3768,6 +3775,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3784,6 +3792,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3792,13 +3801,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3819,6 +3830,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3907,7 +3919,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3921,6 +3934,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4016,7 +4030,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4058,6 +4073,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4079,6 +4095,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4127,13 +4144,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7484,6 +7484,14 @@
         }
       }
     },
+    "sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "requires": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -8320,6 +8328,14 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
+    "truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "requires": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
     "ts-jest": {
       "version": "24.1.0",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-24.1.0.tgz",
@@ -8541,6 +8557,11 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3564,8 +3564,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3589,15 +3588,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3614,22 +3611,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3760,8 +3754,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3775,7 +3768,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3792,7 +3784,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3801,15 +3792,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3830,7 +3819,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3919,8 +3907,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3934,7 +3921,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4030,8 +4016,7 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4073,7 +4058,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4095,7 +4079,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4144,15 +4127,13 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -836,6 +836,27 @@
       "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==",
       "dev": true
     },
+    "@types/node-fetch": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
+      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -992,11 +1013,11 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+      "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
@@ -1145,8 +1166,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
@@ -1634,7 +1654,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -2725,8 +2744,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "detect-file": {
       "version": "1.0.0",
@@ -3256,9 +3274,9 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -6304,14 +6322,12 @@
     "mime-db": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
-      "dev": true
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
     },
     "mime-types": {
       "version": "2.1.24",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
       "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
-      "dev": true,
       "requires": {
         "mime-db": "1.40.0"
       }
@@ -6460,6 +6476,11 @@
         "lodash": "^4.17.13",
         "propagate": "^2.0.0"
       }
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -840,6 +840,7 @@
       "version": "2.5.7",
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
       "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+      "dev": true,
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -849,6 +850,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
           "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
@@ -1166,7 +1168,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "atob": {
       "version": "2.1.2",
@@ -1654,6 +1657,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -2744,7 +2748,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "detect-file": {
       "version": "1.0.0",
@@ -6322,12 +6327,14 @@
     "mime-db": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.24",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
       "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "dev": true,
       "requires": {
         "mime-db": "1.40.0"
       }

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "chalk": "^2.4.2",
     "dc-management-sdk-js": "^1.6.0",
     "lodash": "^4.17.15",
+    "sanitize-filename": "^1.6.3",
     "table": "^5.4.6",
     "yargs": "^14.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@types/chalk": "^2.2.0",
     "@types/jest": "^24.0.18",
     "@types/lodash": "^4.14.144",
+    "@types/node-fetch": "^2.5.7",
     "@types/rimraf": "^3.0.0",
     "@types/table": "^4.0.7",
     "@typescript-eslint/eslint-plugin": "^2.3.0",
@@ -109,10 +110,12 @@
     "typescript": "^3.6.3"
   },
   "dependencies": {
+    "ajv": "^6.12.3",
     "axios": "^0.18.1",
     "chalk": "^2.4.2",
     "dc-management-sdk-js": "^1.6.0",
     "lodash": "^4.17.15",
+    "node-fetch": "^2.6.0",
     "sanitize-filename": "^1.6.3",
     "table": "^5.4.6",
     "yargs": "^14.0.0"

--- a/src/__snapshots__/cli.spec.ts.snap
+++ b/src/__snapshots__/cli.spec.ts.snap
@@ -5,6 +5,7 @@ exports[`cli should create a yarg instance if one is not supplied 1`] = `
 
 Commands:
   dc-cli configure            Saves the configuration options to a file
+  dc-cli content-item         Content Item
   dc-cli content-repository   Content Repository
   dc-cli content-type-schema  Content Type Schema
   dc-cli content-type         Content Type

--- a/src/cli.spec.ts
+++ b/src/cli.spec.ts
@@ -2,8 +2,19 @@ import * as cli from './cli';
 import Yargs from 'yargs/yargs';
 import { configureCommandOptions } from './commands/configure';
 import YargsCommandBuilderOptions from './common/yargs/yargs-command-builder-options';
+import rmdir from 'rimraf';
 
 jest.mock('./commands/configure');
+
+function rimraf(dir: string): Promise<Error> {
+  return new Promise((resolve): void => {
+    rmdir(dir, resolve);
+  });
+}
+
+afterAll(() => {
+  rimraf('temp/');
+});
 
 describe('cli', (): void => {
   afterEach(() => {

--- a/src/commands/content-item.spec.ts
+++ b/src/commands/content-item.spec.ts
@@ -1,0 +1,12 @@
+import { builder } from './content-item';
+import YargsCommandBuilderOptions from '../common/yargs/yargs-command-builder-options';
+import Yargs from 'yargs/yargs';
+
+describe('content-item command', function() {
+  it('should include the commands in the content-item dir', () => {
+    const argv = Yargs(process.argv.slice(2));
+    const spyCommandDir = jest.spyOn(argv, 'commandDir').mockReturnValue(argv);
+    builder(argv);
+    expect(spyCommandDir).toHaveBeenCalledWith('content-item', YargsCommandBuilderOptions);
+  });
+});

--- a/src/commands/content-item.ts
+++ b/src/commands/content-item.ts
@@ -1,0 +1,15 @@
+import { Argv } from 'yargs';
+import YargsCommandBuilderOptions from '../common/yargs/yargs-command-builder-options';
+
+export const command = 'content-item';
+
+export const desc = 'Content Item';
+
+export const builder = (yargs: Argv): Argv =>
+  yargs
+    .commandDir('content-item', YargsCommandBuilderOptions)
+    .demandCommand()
+    .help();
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+export const handler = (): void => {};

--- a/src/commands/content-item/__mocks__/dependant-content-helper.ts
+++ b/src/commands/content-item/__mocks__/dependant-content-helper.ts
@@ -1,0 +1,53 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function dependsOn(itemIds: string[]): any {
+  return {
+    links: itemIds.map(id => ({
+      _meta: {
+        schema: 'http://bigcontent.io/cms/schema/v1/core#/definitions/content-link'
+      },
+      contentType: 'https://dev-solutions.s3.amazonaws.com/DynamicContentTypes/Accelerators/blog.json',
+      id: id
+    }))
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function dependantType(items: number): any {
+  return {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    $id: 'http://superbasic.com',
+
+    title: 'Title',
+    description: 'Description',
+
+    allOf: [
+      {
+        $ref: 'http://bigcontent.io/cms/schema/v1/core#/definitions/content'
+      }
+    ],
+
+    required: ['valid'],
+    type: 'object',
+    properties: {
+      links: {
+        title: 'title',
+        type: 'array',
+        minItems: items,
+        maxItems: items,
+        items: {
+          allOf: [
+            { $ref: 'http://bigcontent.io/cms/schema/v1/core#/definitions/content-link' },
+            {
+              properties: {
+                contentType: {
+                  enum: ['*']
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    propertyOrder: []
+  };
+}

--- a/src/commands/content-item/__mocks__/dependant-content-helper.ts
+++ b/src/commands/content-item/__mocks__/dependant-content-helper.ts
@@ -1,13 +1,30 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function dependsOn(itemIds: string[]): any {
+import { ContentDependancy } from '../../../common/content-item/content-dependancy-tree';
+
+function dependancy(id: string): ContentDependancy {
   return {
-    links: itemIds.map(id => ({
-      _meta: {
-        schema: 'http://bigcontent.io/cms/schema/v1/core#/definitions/content-link'
-      },
-      contentType: 'https://dev-solutions.s3.amazonaws.com/DynamicContentTypes/Accelerators/blog.json',
-      id: id
-    }))
+    _meta: {
+      schema: 'http://bigcontent.io/cms/schema/v1/core#/definitions/content-link'
+    },
+    contentType: 'https://dev-solutions.s3.amazonaws.com/DynamicContentTypes/Accelerators/blog.json',
+    id: id
+  };
+}
+
+function dependProps(itemProps: [string, string][]): object {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const result: any = {};
+  itemProps.forEach(element => {
+    result[element[0]] = dependancy(element[1]);
+  });
+  return result;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function dependsOn(itemIds: string[], itemProps?: [string, string][]): any {
+  itemProps = itemProps || [];
+  return {
+    links: itemIds.map(id => dependancy(id)),
+    ...dependProps(itemProps)
   };
 }
 

--- a/src/commands/content-item/__mocks__/export.ts
+++ b/src/commands/content-item/__mocks__/export.ts
@@ -4,6 +4,10 @@ import { Arguments } from 'yargs';
 
 export const calls: Arguments<ExportItemBuilderOptions & ConfigurationParameters>[] = [];
 
-export const handler = async (argv: Arguments<ExportItemBuilderOptions & ConfigurationParameters>): Promise<void> => {
+export const handler = async (
+  argv: Arguments<ExportItemBuilderOptions & ConfigurationParameters>
+): Promise<boolean> => {
   calls.push(argv);
+
+  return true;
 };

--- a/src/commands/content-item/__mocks__/export.ts
+++ b/src/commands/content-item/__mocks__/export.ts
@@ -1,0 +1,9 @@
+import { ExportItemBuilderOptions } from '../../../interfaces/export-item-builder-options.interface';
+import { ConfigurationParameters } from '../../configure';
+import { Arguments } from 'yargs';
+
+export const calls: Arguments<ExportItemBuilderOptions & ConfigurationParameters>[] = [];
+
+export const handler = async (argv: Arguments<ExportItemBuilderOptions & ConfigurationParameters>): Promise<void> => {
+  calls.push(argv);
+};

--- a/src/commands/content-item/__mocks__/import-revert.ts
+++ b/src/commands/content-item/__mocks__/import-revert.ts
@@ -1,0 +1,9 @@
+import { ImportItemBuilderOptions } from '../../../interfaces/import-item-builder-options.interface';
+import { ConfigurationParameters } from '../../configure';
+import { Arguments } from 'yargs';
+
+export const calls: Arguments<ImportItemBuilderOptions & ConfigurationParameters>[] = [];
+
+export const revert = async (argv: Arguments<ImportItemBuilderOptions & ConfigurationParameters>): Promise<void> => {
+  calls.push(argv);
+};

--- a/src/commands/content-item/__mocks__/import-revert.ts
+++ b/src/commands/content-item/__mocks__/import-revert.ts
@@ -4,6 +4,8 @@ import { Arguments } from 'yargs';
 
 export const calls: Arguments<ImportItemBuilderOptions & ConfigurationParameters>[] = [];
 
-export const revert = async (argv: Arguments<ImportItemBuilderOptions & ConfigurationParameters>): Promise<void> => {
+export const revert = async (argv: Arguments<ImportItemBuilderOptions & ConfigurationParameters>): Promise<boolean> => {
   calls.push(argv);
+
+  return true;
 };

--- a/src/commands/content-item/__mocks__/import.ts
+++ b/src/commands/content-item/__mocks__/import.ts
@@ -4,6 +4,10 @@ import { Arguments } from 'yargs';
 
 export const calls: Arguments<ImportItemBuilderOptions & ConfigurationParameters>[] = [];
 
-export const handler = async (argv: Arguments<ImportItemBuilderOptions & ConfigurationParameters>): Promise<void> => {
+export const handler = async (
+  argv: Arguments<ImportItemBuilderOptions & ConfigurationParameters>
+): Promise<boolean> => {
   calls.push(argv);
+
+  return true;
 };

--- a/src/commands/content-item/__mocks__/import.ts
+++ b/src/commands/content-item/__mocks__/import.ts
@@ -1,0 +1,9 @@
+import { ImportItemBuilderOptions } from '../../../interfaces/import-item-builder-options.interface';
+import { ConfigurationParameters } from '../../configure';
+import { Arguments } from 'yargs';
+
+export const calls: Arguments<ImportItemBuilderOptions & ConfigurationParameters>[] = [];
+
+export const handler = async (argv: Arguments<ImportItemBuilderOptions & ConfigurationParameters>): Promise<void> => {
+  calls.push(argv);
+};

--- a/src/commands/content-item/export.spec.ts
+++ b/src/commands/content-item/export.spec.ts
@@ -1,4 +1,4 @@
-import { builder, command, handler } from './export';
+import { builder, command, handler, LOG_FILENAME } from './export';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
 import Yargs from 'yargs/yargs';
 import { ItemTemplate, getItemInfo, getItemName, MockContent } from '../../common/dc-management-sdk-js/mock-content';
@@ -62,6 +62,12 @@ describe('content-item export command', () => {
         type: 'string',
         describe:
           'Export content with a given or matching Name. A regex can be provided, surrounded with forward slashes. Can be used in combination with other filters.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('logFile', {
+        type: 'string',
+        default: LOG_FILENAME,
+        describe: 'Path to a log file to write to.'
       });
     });
   });

--- a/src/commands/content-item/export.spec.ts
+++ b/src/commands/content-item/export.spec.ts
@@ -1,0 +1,571 @@
+import { builder, command, handler } from './export';
+import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
+import { Hub, ContentItem, ContentRepository, Folder } from 'dc-management-sdk-js';
+import Yargs from 'yargs/yargs';
+import MockPage from '../../common/dc-management-sdk-js/mock-page';
+import { exists } from 'fs';
+import { join } from 'path';
+import { promisify } from 'util';
+import readline from 'readline';
+
+import rmdir from 'rimraf';
+
+jest.mock('readline');
+jest.mock('../../services/dynamic-content-client-factory');
+
+function rimraf(dir: string): Promise<Error> {
+  return new Promise((resolve): void => {
+    rmdir(dir, resolve);
+  });
+}
+
+describe('content-item export command', () => {
+  afterEach((): void => {
+    jest.restoreAllMocks();
+  });
+
+  it('should command should defined', function() {
+    expect(command).toEqual('export <dir>');
+  });
+
+  describe('builder tests', function() {
+    it('should configure yargs', function() {
+      const argv = Yargs(process.argv.slice(2));
+      const spyPositional = jest.spyOn(argv, 'positional').mockReturnThis();
+      const spyOption = jest.spyOn(argv, 'option').mockReturnThis();
+
+      builder(argv);
+
+      expect(spyPositional).toHaveBeenCalledWith('dir', {
+        describe: 'Output directory for the exported Content Items',
+        type: 'string',
+        requiresArg: true
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('repoId', {
+        type: 'string',
+        describe:
+          'Export content from within a given repository. Directory structure will start at the specified repository. Will automatically export all contained folders.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('folderId', {
+        type: 'string',
+        describe:
+          'Export content from within a given folder. Directory structure will start at the specified folder. Can be used in addition to repoId.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('schemaId', {
+        type: 'string',
+        describe:
+          'Export content with a given or matching Schema ID. A regex can be provided, surrounded with forward slashes. Can be used in combination with other filters.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('name', {
+        type: 'string',
+        describe:
+          'Export content with a given or matching Name. A regex can be provided, surrounded with forward slashes. Can be used in combination with other filters.'
+      });
+    });
+  });
+
+  interface ItemTemplate {
+    label: string;
+    id?: string;
+    folderPath?: string;
+    repoId: string;
+    typeSchemaUri: string;
+  }
+
+  interface ItemInfo {
+    repos: string[];
+    baseFolders: string[];
+  }
+
+  describe('handler tests', function() {
+    const yargArgs = {
+      $0: 'test',
+      _: ['test'],
+      json: true
+    };
+    const config = {
+      clientId: 'client-id',
+      clientSecret: 'client-id',
+      hubId: 'hub-id'
+    };
+
+    beforeAll(async () => {
+      await rimraf('temp/export/');
+    });
+
+    function mockContentItems(templates: ItemTemplate[]): void {
+      const repoIds: string[] = [];
+      const folderTemplates: { name: string; id: string; repoId: string }[] = [];
+
+      // Generate items.
+      const items = templates.map(template => {
+        let folderName = '';
+        const folderId = template.folderPath;
+        if (folderId != null) {
+          const pathSplit = folderId.split('/');
+          folderName = pathSplit[pathSplit.length - 1];
+        }
+
+        const folderNullOrEmpty = folderId == null || folderId.length == 0;
+
+        const item = new ContentItem({
+          label: template.label,
+          status: 'ACTIVE',
+          id: template.id || '0',
+          folderId: folderNullOrEmpty ? null : folderId,
+          body: {
+            _meta: {
+              schema: template.typeSchemaUri
+            }
+          },
+
+          // Not meant to be here, but used later for sorting by repository
+          repoId: template.repoId
+        });
+
+        if (repoIds.indexOf(template.repoId) === -1) {
+          repoIds.push(template.repoId);
+        }
+
+        if (!folderNullOrEmpty && folderTemplates.findIndex(folder => folder.id == folderId) === -1) {
+          folderTemplates.push({ id: folderId || '', name: folderName, repoId: template.repoId });
+        }
+
+        return item;
+      });
+
+      // Generate folders.
+      const folderById = new Map<string, Folder>();
+
+      const folders: Folder[] = folderTemplates.map(folderTemplate => {
+        const folder = new Folder({
+          id: folderTemplate.id,
+          name: folderTemplate.name,
+          repoId: folderTemplate.repoId
+        });
+
+        const mockFolderList = jest.fn();
+        folder.related.contentItems.list = mockFolderList;
+        const mockFolderSubfolder = jest.fn();
+        folder.related.folders.list = mockFolderSubfolder;
+        const mockFolderParent = jest.fn();
+        folder.related.folders.parent = mockFolderParent;
+
+        mockFolderList.mockResolvedValue(
+          new MockPage(ContentItem, items.filter(item => item.folderId === folderTemplate.id))
+        );
+        mockFolderSubfolder.mockImplementation(() => {
+          const subfolders: Folder[] = [];
+          folderById.forEach((value, key) => {
+            if (key !== folderTemplate.id && key.startsWith(folderTemplate.id)) {
+              subfolders.push(value);
+            }
+          });
+          return Promise.resolve(new MockPage(Folder, subfolders));
+        });
+        mockFolderParent.mockImplementation(() => {
+          const slashInd = folderTemplate.id.lastIndexOf('/');
+          if (slashInd === -1) {
+            return null;
+          } else {
+            return Promise.resolve(folderById.get(folderTemplate.id.substring(0, slashInd)));
+          }
+        });
+
+        folderById.set(folderTemplate.id, folder);
+        return folder;
+      });
+
+      // Generate repositories.
+      const repoById = new Map<string, ContentRepository>();
+
+      const repos = repoIds.map(repoId => {
+        const repo = new ContentRepository({
+          id: repoId,
+          label: repoId
+        });
+
+        const mockItemList = jest.fn();
+        repo.related.contentItems.list = mockItemList;
+        const mockFolderList = jest.fn();
+        repo.related.folders.list = mockFolderList;
+
+        mockItemList.mockResolvedValue(
+          new MockPage(ContentItem, items.filter(item => (item as any).repoId === repoId))
+        );
+        mockFolderList.mockResolvedValue(
+          new MockPage(Folder, folders.filter(folder => (folder as any).repoId === repoId && folder.id == folder.name))
+        );
+
+        repoById.set(repoId, repo);
+        return repo;
+      });
+
+      const mockHub = new Hub();
+
+      const mockRepoGet = jest.fn(id => Promise.resolve(repoById.get(id)));
+
+      const mockRepoList = jest.fn().mockResolvedValue(new MockPage(ContentRepository, repos));
+
+      mockHub.related.contentRepositories.list = mockRepoList;
+
+      const mockFolderGet = jest.fn(id => Promise.resolve(folderById.get(id)));
+
+      const mockHubGet = jest.fn().mockResolvedValue(mockHub);
+
+      (dynamicContentClientFactory as jest.Mock).mockReturnValue({
+        hubs: {
+          get: mockHubGet
+        },
+        folders: {
+          get: mockFolderGet
+        },
+        contentRepositories: {
+          get: mockRepoGet
+        }
+      });
+    }
+
+    function getItemInfo(items: ItemTemplate[]): ItemInfo {
+      const repos: string[] = [];
+      const baseFolders: string[] = [];
+
+      items.forEach(item => {
+        if (repos.indexOf(item.repoId) === -1) {
+          repos.push(item.repoId);
+        }
+
+        if (item.folderPath != null) {
+          const folderFirstSlash = item.folderPath.indexOf('/');
+          const baseFolder = folderFirstSlash === -1 ? item.folderPath : item.folderPath.substring(0, folderFirstSlash);
+
+          if (baseFolder.length > 0 && baseFolders.indexOf(baseFolder) === -1) {
+            baseFolders.push(baseFolder);
+          }
+        }
+      });
+
+      return { repos, baseFolders };
+    }
+
+    function getItemName(baseDir: string, item: ItemTemplate, info: ItemInfo, validRepos?: string[]): string {
+      if (validRepos) {
+        let basePath = item.folderPath || '';
+        if (info.repos.length > 1 && validRepos.indexOf(item.repoId) !== -1) {
+          basePath = `${item.repoId}/${basePath}`;
+        }
+        return join(baseDir + basePath, item.label + '.json');
+      } else {
+        return join(baseDir + (item.folderPath || ''), item.label + '.json');
+      }
+    }
+
+    async function itemsExist(baseDir: string, items: ItemTemplate[], validRepos?: string[]): Promise<void> {
+      const info = getItemInfo(items);
+      for (let i = 0; i < items.length; i++) {
+        const itemName = getItemName(baseDir, items[i], info, validRepos);
+        const itemExists = await promisify(exists)(itemName);
+        if (!itemExists) debugger;
+        expect(itemExists).toBeTruthy();
+      }
+    }
+
+    async function itemsDontExist(baseDir: string, items: ItemTemplate[], validRepos?: string[]): Promise<void> {
+      const info = getItemInfo(items);
+      for (let i = 0; i < items.length; i++) {
+        const itemName = getItemName(baseDir, items[i], info, validRepos);
+        const itemExists = await promisify(exists)(itemName);
+        if (itemExists) debugger;
+        expect(itemExists).toBeFalsy();
+      }
+    }
+
+    it('should export all content when given only an output directory', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const templates: ItemTemplate[] = [
+        { label: 'item1', repoId: 'repo1', typeSchemaUri: 'http://type' },
+        { label: 'item2', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'folderTest' },
+        { label: 'item3', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'folderTest' },
+        { label: 'item4', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' }
+      ];
+
+      mockContentItems(templates);
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/export/all/'
+      };
+      await handler(argv);
+
+      await itemsExist('temp/export/all/', templates);
+
+      await rimraf('temp/export/all/');
+    });
+
+    it('should export content from a specific folder', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const exists: ItemTemplate[] = [
+        { label: 'item2', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'folder1' },
+        { label: 'item3', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'folder1/nested' }
+      ];
+
+      const skips: ItemTemplate[] = [
+        { label: 'item1', repoId: 'repo1', typeSchemaUri: 'http://type' },
+        { label: 'item4', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'folder2' }
+      ];
+
+      const templates = skips.concat(exists);
+
+      mockContentItems(templates);
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/export/folder1',
+        folderId: 'folder1'
+      };
+      await handler(argv);
+
+      await itemsExist('temp/export/', exists);
+      await itemsDontExist('temp/export/', skips);
+
+      await rimraf('temp/export/folder1/');
+    });
+
+    it('should export content from a multiple folders, with directory structure including both explicitly', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const exists: ItemTemplate[] = [
+        { label: 'item2', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'folder1' },
+        { label: 'item3', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'folder1/nested' },
+        { label: 'item5', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'folder3' },
+        { label: 'item6', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'folder3' }
+      ];
+
+      const skips: ItemTemplate[] = [
+        { label: 'item1', repoId: 'repo1', typeSchemaUri: 'http://type' },
+        { label: 'item4', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'folder2' }
+      ];
+
+      const templates = skips.concat(exists);
+
+      mockContentItems(templates);
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/export/multi/',
+        folderId: ['folder1', 'folder3']
+      };
+      await handler(argv);
+
+      await itemsExist('temp/export/multi/', exists);
+      await itemsDontExist('temp/export/multi/', skips);
+
+      await rimraf('temp/export/multi/');
+    });
+
+    it('should export content from a single repo, ignoring others.', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const exists: ItemTemplate[] = [
+        { label: 'item2', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'folder1' },
+        { label: 'item3', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'folder1/nested' }
+      ];
+
+      const skips: ItemTemplate[] = [
+        { label: 'item1', repoId: 'repo2', typeSchemaUri: 'http://type' },
+        { label: 'item4', repoId: 'repo2', typeSchemaUri: 'http://type', folderPath: 'folder2' },
+        { label: 'item5', repoId: 'repo3', typeSchemaUri: 'http://type' }
+      ];
+
+      const templates = skips.concat(exists);
+
+      mockContentItems(templates);
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/export/repo/',
+        repoId: 'repo1'
+      };
+      await handler(argv);
+
+      await itemsExist('temp/export/repo/', exists);
+      await itemsDontExist('temp/export/repo/', skips);
+
+      await rimraf('temp/export/repo/');
+    });
+
+    it('should export content from a multiple repos, ignoring others.', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const exists: ItemTemplate[] = [
+        { label: 'item2', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'folder1' },
+        { label: 'item3', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'folder1/nested' },
+        { label: 'item1', repoId: 'repo2', typeSchemaUri: 'http://type' },
+        { label: 'item4', repoId: 'repo2', typeSchemaUri: 'http://type', folderPath: 'folder2' }
+      ];
+
+      const skips: ItemTemplate[] = [{ label: 'item5', repoId: 'repo3', typeSchemaUri: 'http://type' }];
+
+      const templates = skips.concat(exists);
+
+      mockContentItems(templates);
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/export/repomulti/',
+        repoId: ['repo1', 'repo2']
+      };
+      await handler(argv);
+
+      await itemsExist('temp/export/repomulti/', exists, ['repo1', 'repo2']);
+      await itemsDontExist('temp/export/repomulti/', skips, ['repo1', 'repo2']);
+
+      await rimraf('temp/export/repomulti/');
+    });
+
+    it('should only export content with a matching type id when specified', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const exists: ItemTemplate[] = [
+        { label: 'item2', repoId: 'repo1', typeSchemaUri: 'http://typeMatch', folderPath: 'folder1' },
+        { label: 'item3', repoId: 'repo1', typeSchemaUri: 'http://typeMatch', folderPath: 'folder1/nested' }
+      ];
+
+      const skips: ItemTemplate[] = [
+        { label: 'item1', repoId: 'repo1', typeSchemaUri: 'http://typeMatch' },
+        { label: 'item4', repoId: 'repo1', typeSchemaUri: 'http://typeMatch', folderPath: 'folder2' },
+        { label: 'item5', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'folder1' }
+      ];
+
+      const templates = skips.concat(exists);
+
+      mockContentItems(templates);
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/export/typeSpecific/folder1',
+        folderId: 'folder1',
+        schemaId: '/typeMatch/'
+      };
+      await handler(argv);
+
+      await itemsExist('temp/export/typeSpecific/', exists);
+      await itemsDontExist('temp/export/typeSpecific/', skips);
+
+      await rimraf('temp/export/typeSpecific/');
+    });
+
+    it('should only export content with a matching name when specified', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const exists: ItemTemplate[] = [
+        { label: 'item-nameMatch2', repoId: 'repo1', typeSchemaUri: 'http://type3', folderPath: 'folder1' },
+        { label: 'item-nameMatch3', repoId: 'repo1', typeSchemaUri: 'http://type5', folderPath: 'folder1/nested' }
+      ];
+
+      const skips: ItemTemplate[] = [
+        { label: 'item1', repoId: 'repo1', typeSchemaUri: 'http://type2' },
+        { label: 'item-nameMatch1', repoId: 'repo1', typeSchemaUri: 'http://type2' },
+        { label: 'item4', repoId: 'repo1', typeSchemaUri: 'http://type4', folderPath: 'folder2' },
+        { label: 'item-nameMatch4', repoId: 'repo1', typeSchemaUri: 'http://type4', folderPath: 'folder2' },
+        { label: 'item5', repoId: 'repo1', typeSchemaUri: 'http://type1', folderPath: 'folder1' }
+      ];
+
+      const templates = skips.concat(exists);
+
+      mockContentItems(templates);
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/export/nameSpecific/folder1',
+        folderId: 'folder1',
+        name: '/nameMatch/'
+      };
+      await handler(argv);
+
+      await itemsExist('temp/export/nameSpecific/', exists);
+      await itemsDontExist('temp/export/nameSpecific/', skips);
+
+      await rimraf('temp/export/nameSpecific/');
+    });
+
+    it('should respect all filters when specified at the same time', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const exists: ItemTemplate[] = [
+        // repo correct, label and type correct
+        { label: 'item-nameMatch2', repoId: 'repo1', typeSchemaUri: 'http://typeMatch3', folderPath: 'folder1' },
+        { label: 'item-nameMatch3', repoId: 'repo1', typeSchemaUri: 'http://typeMatch5', folderPath: 'folder1/nested' },
+
+        { label: 'item-nameMatch7', repoId: 'repo2', typeSchemaUri: 'http://typeMatch7', folderPath: 'folder4' },
+        { label: 'item-nameMatch8', repoId: 'repo2', typeSchemaUri: 'http://typeMatch6', folderPath: 'folder4/nested' }
+      ];
+
+      const skips: ItemTemplate[] = [
+        // repo correct, type filtered out
+        { label: 'item-nameMatch5', repoId: 'repo2', typeSchemaUri: 'http://type3', folderPath: 'folder3' },
+
+        // repo correct, name filtered out
+        { label: 'item-name7', repoId: 'repo2', typeSchemaUri: 'http://typeMatch3', folderPath: 'folder3' },
+        { label: 'item-name8', repoId: 'repo2', typeSchemaUri: 'http://typeMatch5', folderPath: 'folder3/nested' },
+
+        // folder correct, type filtered out
+        { label: 'item-nameMatch6', repoId: 'repo1', typeSchemaUri: 'http://type3', folderPath: 'folder1' },
+
+        // folder correct, name filtered out
+        { label: 'item-name7', repoId: 'repo1', typeSchemaUri: 'http://typeMatch3', folderPath: 'folder1' },
+        { label: 'item-name8', repoId: 'repo1', typeSchemaUri: 'http://typeMatch5', folderPath: 'folder1/nested' },
+
+        // type and name correct/incorrect, repo and folder incorrect
+        { label: 'item1', repoId: 'repo1', typeSchemaUri: 'http://type2' },
+        { label: 'item-nameMatch1', repoId: 'repo1', typeSchemaUri: 'http://typeMatch2' },
+        { label: 'item4', repoId: 'repo1', typeSchemaUri: 'http://type4', folderPath: 'folder2' },
+        { label: 'item-nameMatch4', repoId: 'repo1', typeSchemaUri: 'http://typeMatch4', folderPath: 'folder2' },
+
+        // folder correct, both filtered out
+        { label: 'item5', repoId: 'repo1', typeSchemaUri: 'http://type1', folderPath: 'folder1' }
+      ];
+
+      const templates = skips.concat(exists);
+
+      mockContentItems(templates);
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/export/allFilter/',
+        repoId: 'repo2',
+        folderId: 'folder1', // folder1 in addition to repo2
+        name: '/nameMatch/',
+        schemaId: '/typeMatch/' // only content that with name containing nameMatch and type containing typeMatch
+      };
+      await handler(argv);
+
+      await itemsExist('temp/export/allFilter/', exists, ['repo2']);
+      await itemsDontExist('temp/export/allFilter/', skips, ['repo2']);
+
+      await rimraf('temp/export/allFilter/');
+    });
+  });
+});

--- a/src/commands/content-item/export.spec.ts
+++ b/src/commands/content-item/export.spec.ts
@@ -1,7 +1,9 @@
 import { builder, command, handler, LOG_FILENAME } from './export';
+import { dependsOn } from './__mocks__/dependant-content-helper';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
 import Yargs from 'yargs/yargs';
 import { ItemTemplate, getItemInfo, getItemName, MockContent } from '../../common/dc-management-sdk-js/mock-content';
+import { getDefaultLogPath } from '../../common/log-helpers';
 import { exists } from 'fs';
 import { promisify } from 'util';
 import readline from 'readline';
@@ -10,6 +12,7 @@ import rmdir from 'rimraf';
 
 jest.mock('readline');
 jest.mock('../../services/dynamic-content-client-factory');
+jest.mock('../../common/log-helpers');
 
 function rimraf(dir: string): Promise<Error> {
   return new Promise((resolve): void => {
@@ -24,6 +27,12 @@ describe('content-item export command', () => {
 
   it('should command should defined', function() {
     expect(command).toEqual('export <dir>');
+  });
+
+  it('should use getDefaultLogPath for LOG_FILENAME with process.platform as default', function() {
+    LOG_FILENAME();
+
+    expect(getDefaultLogPath).toHaveBeenCalledWith('item', 'export', process.platform);
   });
 
   describe('builder tests', function() {
@@ -199,7 +208,7 @@ describe('content-item export command', () => {
       await rimraf('temp/export/multi/');
     });
 
-    it('should export content from a single repo, ignoring others.', async () => {
+    it('should export content from a single repo, ignoring others', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (readline as any).setResponses(['y']);
 
@@ -232,7 +241,7 @@ describe('content-item export command', () => {
       await rimraf('temp/export/repo/');
     });
 
-    it('should export content from a multiple repos, ignoring others.', async () => {
+    it('should export content from a multiple repos, ignoring others', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (readline as any).setResponses(['y']);
 
@@ -392,18 +401,6 @@ describe('content-item export command', () => {
       await rimraf('temp/export/allFilter/');
     });
 
-    function dependsOn(itemIds: string[]): any {
-      return {
-        links: itemIds.map(id => ({
-          _meta: {
-            schema: 'http://bigcontent.io/cms/schema/v1/core#/definitions/content-link'
-          },
-          contentType: 'https://dev-solutions.s3.amazonaws.com/DynamicContentTypes/Accelerators/blog.json',
-          id: id
-        }))
-      };
-    }
-
     it('should export content outwith the filter if it is depended on', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (readline as any).setResponses(['y']);
@@ -414,7 +411,7 @@ describe('content-item export command', () => {
           repoId: 'repo1',
           typeSchemaUri: 'http://typeD',
           folderPath: 'folder1',
-          body: dependsOn(['item5', 'item7'])
+          body: dependsOn(['item5', 'item7', 'itemMissing'])
         },
         { label: 'item3', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'folder1/nested' },
 
@@ -435,7 +432,8 @@ describe('content-item export command', () => {
           typeSchemaUri: 'http://type',
           folderPath: 'folder2',
           body: dependsOn(['item5']),
-          dependancy: 'folder1'
+          dependancy: 'folder1',
+          status: 'ARCHIVED'
         },
         {
           id: 'item7',
@@ -468,6 +466,274 @@ describe('content-item export command', () => {
       await itemsDontExist('temp/export/', skips);
 
       await rimraf('temp/export/folder1/');
+    });
+
+    it('should export archived content if it is depended on, from multiple repos', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const exists: ItemTemplate[] = [
+        {
+          id: 'item2',
+          label: 'item2',
+          repoId: 'repo1',
+          typeSchemaUri: 'http://typeD',
+          body: dependsOn(['item5', 'item7', 'itemMissing'])
+        },
+
+        {
+          id: 'item8',
+          label: 'item8',
+          repoId: 'repo2',
+          typeSchemaUri: 'http://typeD',
+          body: dependsOn(['item9'])
+        },
+
+        // These are archived, but exported as dependancies.
+        {
+          id: 'item5',
+          label: 'item5',
+          repoId: 'repo1',
+          typeSchemaUri: 'http://typeD',
+          body: dependsOn(['item6']),
+          dependancy: 'repo1',
+          status: 'ARCHIVED'
+        },
+        {
+          id: 'item6',
+          label: 'item6',
+          repoId: 'repo1',
+          typeSchemaUri: 'http://type',
+          body: dependsOn(['item5']),
+          dependancy: 'repo1',
+          status: 'ARCHIVED'
+        },
+        {
+          id: 'item7',
+          label: 'item7',
+          repoId: 'repo1',
+          typeSchemaUri: 'http://type',
+          dependancy: 'repo1',
+          status: 'ARCHIVED'
+        },
+
+        {
+          id: 'item9',
+          label: 'item9',
+          repoId: 'repo2',
+          typeSchemaUri: 'http://type',
+          dependancy: 'repo2',
+          status: 'ARCHIVED'
+        }
+      ];
+
+      // Archived, but not as dependancies
+      const skips: ItemTemplate[] = [
+        { label: 'item1', repoId: 'repo1', typeSchemaUri: 'http://type', status: 'ARCHIVED' },
+        { label: 'item4', repoId: 'repo2', typeSchemaUri: 'http://type', folderPath: 'folder2', status: 'ARCHIVED' }
+      ];
+
+      const templates = skips.concat(exists);
+
+      new MockContent(dynamicContentClientFactory as jest.Mock).importItemTemplates(templates);
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/export/repoDeps'
+      };
+      await handler(argv);
+
+      await itemsExist('temp/export/repoDeps/', exists, ['repo1', 'repo2']);
+      await itemsDontExist('temp/export/repoDeps/', skips, ['repo1', 'repo2']);
+
+      await rimraf('temp/export/repoDeps/');
+    });
+
+    it('should warn when schema validation fails, but not if it succeeds', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const exists: ItemTemplate[] = [
+        { label: 'item2', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'folder1' },
+        {
+          label: 'item3',
+          repoId: 'repo1',
+          typeSchemaUri: 'http://type',
+          folderPath: 'folder1/nested',
+          body: { valid: true }
+        }
+      ];
+
+      const templates = exists;
+
+      const content = new MockContent(dynamicContentClientFactory as jest.Mock);
+      content.registerContentType('http://type', 'type', 'repo1', {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        $id: 'http://superbasic.com',
+
+        title: 'Title',
+        description: 'Description',
+
+        allOf: [
+          {
+            $ref: 'http://bigcontent.io/cms/schema/v1/core#/definitions/content'
+          }
+        ],
+
+        required: ['valid'],
+        type: 'object',
+        properties: {
+          valid: {
+            title: 'Valid',
+            description: 'Content is only valid if it has this property.',
+            type: 'boolean'
+          }
+        },
+        propertyOrder: []
+      });
+      content.importItemTemplates(templates);
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/export/validation/',
+        repoId: 'repo1'
+      };
+      await handler(argv);
+
+      await itemsExist('temp/export/validation/', exists);
+
+      await rimraf('temp/export/validation/');
+    });
+
+    it("should skip repositories if items can't be listed from them", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const exists: ItemTemplate[] = [
+        { label: 'item2', repoId: 'repo1', typeSchemaUri: 'http://type' },
+        { label: 'item3', repoId: 'repo1', typeSchemaUri: 'http://type' }
+      ];
+
+      const skips: ItemTemplate[] = [{ label: 'item1', repoId: 'repo2', typeSchemaUri: 'http://type' }];
+
+      const templates = skips.concat(exists);
+
+      const content = new MockContent(dynamicContentClientFactory as jest.Mock);
+      content.importItemTemplates(templates);
+      content.failRepoActions = 'list';
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/export/failRepo/',
+        repoId: 'repo1'
+      };
+      await handler(argv);
+      await itemsDontExist('temp/export/failRepo/', templates);
+
+      await rimraf('temp/export/failRepo/');
+    });
+
+    it('should skip content items if they are fetched folder, but the content items endpoints fail', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const exists: ItemTemplate[] = [
+        { label: 'item2', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'folder1' },
+        { label: 'item3', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'folder2' }
+      ];
+
+      const skips: ItemTemplate[] = [{ label: 'item1', repoId: 'repo2', typeSchemaUri: 'http://type' }];
+
+      const templates = skips.concat(exists);
+
+      const content = new MockContent(dynamicContentClientFactory as jest.Mock);
+      content.importItemTemplates(templates);
+      content.failRepoActions = 'list';
+      content.failFolderActions = 'items';
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/export/failFolder/',
+        folderId: ['folder1', 'folder2']
+      };
+      await handler(argv);
+
+      await itemsDontExist('temp/export/failFolder/', templates);
+
+      await rimraf('temp/export/failFolder/');
+    });
+
+    it('should place content items that error when getting the directory name in the base directory', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses([]);
+
+      const exists: ItemTemplate[] = [
+        { label: 'item2', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'folder1/nested/nested2' },
+
+        // This item does not need to search for a folder parent, as it is known as a base directory path.
+        { label: 'item3', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'folder2' }
+      ];
+
+      const skips: ItemTemplate[] = [{ label: 'item1', repoId: 'repo2', typeSchemaUri: 'http://type' }];
+
+      const templates = skips.concat(exists);
+
+      const content = new MockContent(dynamicContentClientFactory as jest.Mock);
+      content.importItemTemplates(templates);
+      content.failFolderActions = 'parent';
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/export/failFolder/',
+        repoId: 'repo1'
+      };
+      await handler(argv);
+
+      exists[0].folderPath = 'nested2'; // nested2 could not be tracked back to the base, so it was placed directly there.
+
+      await itemsExist('temp/export/failFolder/', exists);
+      await itemsDontExist('temp/export/failFolder/', skips);
+
+      await rimraf('temp/export/failFolder/');
+    });
+
+    it('should skip subfolders if the request for them fails', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses([]);
+
+      const exists: ItemTemplate[] = [
+        { label: 'item3', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'folder1' }
+      ];
+
+      const skips: ItemTemplate[] = [
+        // This item is in the subfolder, but it cannot be discovered
+        { label: 'item2', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'folder1/nested' },
+        { label: 'item1', repoId: 'repo2', typeSchemaUri: 'http://type' }
+      ];
+
+      const templates = skips.concat(exists);
+
+      const content = new MockContent(dynamicContentClientFactory as jest.Mock);
+      content.importItemTemplates(templates);
+      content.failFolderActions = 'list';
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/export/failSubfolder/folder1',
+        folderId: 'folder1'
+      };
+      await handler(argv);
+
+      await itemsExist('temp/export/failSubfolder/', exists);
+      await itemsDontExist('temp/export/failSubfolder/', skips);
+
+      await rimraf('temp/export/failSubfolder/');
     });
   });
 });

--- a/src/commands/content-item/export.ts
+++ b/src/commands/content-item/export.ts
@@ -1,0 +1,248 @@
+import { Arguments, Argv } from 'yargs';
+import { ConfigurationParameters } from '../configure';
+import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
+import { dirname, join, sep } from 'path';
+import { equalsOrRegex } from '../../common/filter/filter';
+import {
+  ExportResult,
+  nothingExportedExit,
+  promptToOverwriteExports,
+  uniqueFilename,
+  writeJsonToFile
+} from '../../services/export.service';
+
+import { mkdir, writeFile, exists, lstat } from 'fs';
+import { promisify } from 'util';
+import { ExportItemBuilderOptions } from '../../interfaces/export-item-builder-options.interface';
+import paginator from '../../common/dc-management-sdk-js/paginator';
+import { ContentItem, Folder, DynamicContent, Hub } from 'dc-management-sdk-js';
+
+export const command = 'export <dir>';
+
+export const desc = 'Export Content Types';
+
+export const builder = (yargs: Argv): void => {
+  yargs
+    .positional('dir', {
+      describe: 'Output directory for the exported Content Type definitions',
+      type: 'string'
+    })
+    .option('repoId', {
+      type: 'string',
+      describe:
+        'Export content from within a given repository. Directory structure will start at the specified repository.',
+      requiresArg: true
+    })
+    .option('folderId', {
+      type: 'string',
+      describe:
+        'Export content from within a given folder. Directory structure will start at the specified folder. Overrides repoId.',
+      requiresArg: true
+    })
+    .option('schemaId', {
+      type: 'string',
+      describe:
+        'Export content with a given or matching Schema ID. A regex can be provided, surrounded with forward slashes. Can be used in combination with other filters.',
+      requiresArg: true
+    })
+    .option('name', {
+      type: 'string',
+      describe:
+        'Export content with a given or matching Name. A regex can be provided, surrounded with forward slashes. Can be used in combination with other filters.',
+      requiresArg: true
+    });
+};
+
+export const writeItemBody = async (filename: string, body?: string): Promise<void> => {
+  if (!body) {
+    return;
+  }
+
+  const dir = dirname(filename);
+  if (await promisify(exists)(dir)) {
+    const dirStat = await promisify(lstat)(dir);
+    if (!dirStat || !dirStat.isDirectory()) {
+      throw new Error(`Unable to write schema to "${filename}" as "${dir}" is not a directory.`);
+    }
+  } else {
+    try {
+      await promisify(mkdir)(dir);
+    } catch {
+      throw new Error(`Unable to create directory: "${dir}".`);
+    }
+  }
+
+  try {
+    await promisify(writeFile)(filename, body);
+  } catch {
+    throw new Error(`Unable to write file: "${filename}".`);
+  }
+};
+
+const folderToPathMap: Map<string, string> = new Map();
+
+const getOrAddFolderPath = async (
+  client: DynamicContent,
+  folderOrId: Folder | string | undefined,
+  baseDir?: string
+): Promise<string> => {
+  if (folderOrId == null) return '';
+  const id = typeof folderOrId === 'string' ? folderOrId : (folderOrId.id as string);
+
+  const mapResult = folderToPathMap.get(id);
+  if (mapResult !== undefined) {
+    return mapResult;
+  }
+
+  // Build the path for this folder.
+  const folder = typeof folderOrId === 'string' ? await client.folders.get(folderOrId) : folderOrId;
+
+  let path: string;
+  try {
+    const parent = await folder.related.folders.parent();
+
+    path = `${await getOrAddFolderPath(client, parent)}/${folder.name}`;
+  } catch {
+    path = `${folder.name}`;
+  }
+
+  if (baseDir != null) {
+    path = join(baseDir, path);
+  }
+
+  folderToPathMap.set(id, path);
+  return path;
+};
+
+const ensureDirectoryExists = async (dir: string): Promise<void> => {
+  if (await promisify(exists)(dir)) {
+    const dirStat = await promisify(lstat)(dir);
+    if (!dirStat || !dirStat.isDirectory()) {
+      throw new Error(`"${dir}" already exists and is not a directory.`);
+    }
+  } else {
+    // Ensure parent directory exists.
+    const parentPath = dir.split(sep);
+    parentPath.pop();
+    const parent = parentPath.join(sep);
+    if (parent !== undefined) {
+      await ensureDirectoryExists(parent);
+    }
+
+    try {
+      await promisify(mkdir)(dir);
+    } catch {
+      throw new Error(`Unable to create directory: "${dir}".`);
+    }
+  }
+};
+
+export const filterContentItemsBySchemaId = (
+  listToFilter: ContentItem[],
+  listToMatch: string[] = []
+): ContentItem[] => {
+  if (listToMatch.length === 0) {
+    return listToFilter;
+  }
+
+  const unmatchedIdList: string[] = listToMatch.filter(id => !listToFilter.some(item => item.body._meta.schema === id));
+  if (unmatchedIdList.length > 0) {
+    throw new Error(
+      `Content matching the following schema ID(s) could not be found: [${unmatchedIdList
+        .map(u => `'${u}'`)
+        .join(', ')}].\nNothing was exported, exiting.`
+    );
+  }
+
+  return listToFilter.filter(item => listToMatch.some(id => item.body._meta.schema === id));
+};
+
+const getContentItems = async (
+  client: DynamicContent,
+  hub: Hub,
+  repoId?: string | string[],
+  folderId?: string | string[]
+): Promise<{ path: Promise<string>; item: ContentItem }[]> => {
+  const items: { path: Promise<string>; item: ContentItem }[] = [];
+
+  if (folderId != null) {
+    const folderIds = typeof folderId === 'string' ? [folderId] : folderId;
+    const folders = await Promise.all(folderIds.map(id => client.folders.get(id)));
+    for (let i = 0; i < folders.length; i++) {
+      const folder = folders[i];
+      folderToPathMap.set(folder.id as string, folders.length > 1 ? `${folder.name}/` : '');
+      const newItems = await paginator(folder.related.contentItems.list, { status: 'ACTIVE' });
+      Array.prototype.push.apply(
+        items,
+        newItems.map(item => ({ item, path: getOrAddFolderPath(client, item.folderId) }))
+      );
+
+      const subfolders = await paginator(folder.related.folders.list);
+      Array.prototype.push.apply(folders, subfolders);
+    }
+  } else {
+    const repoIds = typeof repoId === 'string' ? [repoId] : repoId || [];
+    const repositories = await (repoId != null
+      ? Promise.all(repoIds.map(id => client.contentRepositories.get(id)))
+      : paginator(hub.related.contentRepositories.list));
+    for (let i = 0; i < repositories.length; i++) {
+      const repository = repositories[i];
+      const baseDir = `${repository.label}/`;
+      const newItems = await paginator(repository.related.contentItems.list, { status: 'ACTIVE' });
+      Array.prototype.push.apply(
+        items,
+        newItems.map(item => ({ item, path: getOrAddFolderPath(client, item.folderId, baseDir) }))
+      );
+    }
+  }
+  return items;
+};
+
+// Output Plan:
+//
+// {repo}/{folderTree}/{label}.json
+//
+// repo is only present if all/more than one repository is specified, and a specific folder is not specified.
+// folder is only present if a specific folder is not specified.
+//
+// schema ID must be included in the json. (used to link relevant content type)
+//
+
+export const handler = async (argv: Arguments<ExportItemBuilderOptions & ConfigurationParameters>): Promise<void> => {
+  const { dir, repoId, folderId, schemaId, name } = argv;
+
+  const client = dynamicContentClientFactory(argv);
+  const hub = await client.hubs.get(argv.hubId);
+  let items = await getContentItems(client, hub, repoId, folderId);
+
+  // Filter using the schemaId and name, if present.
+  if (schemaId != null) {
+    const schemaIds: string[] = Array.isArray(schemaId) ? schemaId : [schemaId];
+    items = items.filter(
+      ({ item }: { item: ContentItem }) => schemaIds.findIndex(id => equalsOrRegex(item.body._meta.schemaId, id)) != -1
+    );
+  }
+  if (name != null) {
+    const names: string[] = Array.isArray(name) ? name : [name];
+    items = items.filter(
+      ({ item }: { item: ContentItem }) => names.findIndex(name => equalsOrRegex(item.label as string, name)) != -1
+    );
+  }
+
+  for (let i = 0; i < items.length; i++) {
+    const { item, path } = items[i];
+
+    let resolvedPath: string;
+    try {
+      resolvedPath = await path;
+    } catch {
+      console.log(`Could not determine folder for ${item.label}.`);
+      continue;
+    }
+    const directory = join(dir, resolvedPath);
+    resolvedPath = join(directory, `${item.label}.json`);
+    await ensureDirectoryExists(directory);
+
+    writeJsonToFile(resolvedPath, item);
+  }
+};

--- a/src/commands/content-item/export.ts
+++ b/src/commands/content-item/export.ts
@@ -49,12 +49,6 @@ export const builder = (yargs: Argv): void => {
     });
 };
 
-// multi export concerns:
-// Track dependancies.
-//  - notify and save dependancies which are not within the specified folders/repos
-//  - save dependancies with archived status (only if depended on). should be recreated then archived.
-//  - save info for exported content. (absolute content paths)
-
 export const writeItemBody = async (filename: string, body?: string): Promise<void> => {
   if (!body) {
     return;
@@ -237,16 +231,6 @@ const getContentItems = async (
   }
   return items;
 };
-
-// Output Plan:
-//
-// {repo}/{folderTree}/{label}.json
-//
-// repo is only present if all/more than one repository is specified, and a specific folder is not specified.
-// folder is only present if a specific folder is not specified.
-//
-// schema ID must be included in the json. (used to link relevant content type)
-//
 
 export const handler = async (argv: Arguments<ExportItemBuilderOptions & ConfigurationParameters>): Promise<void> => {
   const { dir, repoId, folderId, schemaId, name } = argv;

--- a/src/commands/content-item/export.ts
+++ b/src/commands/content-item/export.ts
@@ -3,11 +3,12 @@ import { ConfigurationParameters } from '../configure';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
 import { dirname, join, sep } from 'path';
 import { equalsOrRegex } from '../../common/filter/filter';
+import sanitize from 'sanitize-filename';
 import {
   ExportResult,
   nothingExportedExit,
   promptToOverwriteExports,
-  uniqueFilename,
+  uniqueFilenamePath,
   writeJsonToFile
 } from '../../services/export.service';
 
@@ -24,32 +25,29 @@ export const desc = 'Export Content Types';
 export const builder = (yargs: Argv): void => {
   yargs
     .positional('dir', {
-      describe: 'Output directory for the exported Content Type definitions',
-      type: 'string'
+      describe: 'Output directory for the exported Content Items',
+      type: 'string',
+      requiresArg: true
     })
     .option('repoId', {
       type: 'string',
       describe:
-        'Export content from within a given repository. Directory structure will start at the specified repository.',
-      requiresArg: true
+        'Export content from within a given repository. Directory structure will start at the specified repository. Will automatically export all contained folders.'
     })
     .option('folderId', {
       type: 'string',
       describe:
-        'Export content from within a given folder. Directory structure will start at the specified folder. Overrides repoId.',
-      requiresArg: true
+        'Export content from within a given folder. Directory structure will start at the specified folder. Can be used in addition to repoId.'
     })
     .option('schemaId', {
       type: 'string',
       describe:
-        'Export content with a given or matching Schema ID. A regex can be provided, surrounded with forward slashes. Can be used in combination with other filters.',
-      requiresArg: true
+        'Export content with a given or matching Schema ID. A regex can be provided, surrounded with forward slashes. Can be used in combination with other filters.'
     })
     .option('name', {
       type: 'string',
       describe:
-        'Export content with a given or matching Name. A regex can be provided, surrounded with forward slashes. Can be used in combination with other filters.',
-      requiresArg: true
+        'Export content with a given or matching Name. A regex can be provided, surrounded with forward slashes. Can be used in combination with other filters.'
     });
 };
 
@@ -79,9 +77,8 @@ export const writeItemBody = async (filename: string, body?: string): Promise<vo
   }
 };
 
-const folderToPathMap: Map<string, string> = new Map();
-
 const getOrAddFolderPath = async (
+  folderToPathMap: Map<string, string>,
   client: DynamicContent,
   folderOrId: Folder | string | undefined,
   baseDir?: string
@@ -97,13 +94,15 @@ const getOrAddFolderPath = async (
   // Build the path for this folder.
   const folder = typeof folderOrId === 'string' ? await client.folders.get(folderOrId) : folderOrId;
 
+  const name = sanitize(folder.name as string);
   let path: string;
   try {
     const parent = await folder.related.folders.parent();
 
-    path = `${await getOrAddFolderPath(client, parent)}/${folder.name}`;
+    path = `${join(await getOrAddFolderPath(folderToPathMap, client, parent), name)}`;
   } catch {
-    path = `${folder.name}`;
+    console.log(`Could not determine path for ${folder.name}. Placing in base directory.`);
+    path = `${name}`;
   }
 
   if (baseDir != null) {
@@ -125,14 +124,19 @@ const ensureDirectoryExists = async (dir: string): Promise<void> => {
     const parentPath = dir.split(sep);
     parentPath.pop();
     const parent = parentPath.join(sep);
-    if (parent !== undefined) {
+    if (parentPath.length > 0) {
       await ensureDirectoryExists(parent);
     }
 
-    try {
-      await promisify(mkdir)(dir);
-    } catch {
-      throw new Error(`Unable to create directory: "${dir}".`);
+    if (dir.length > 0) {
+      try {
+        await promisify(mkdir)(dir);
+      } catch (e) {
+        if (await promisify(exists)(dir)) {
+          return; // This directory could have been created after we checked if it existed.
+        }
+        throw new Error(`Unable to create directory: "${dir}".`);
+      }
     }
   }
 };
@@ -158,41 +162,88 @@ export const filterContentItemsBySchemaId = (
 };
 
 const getContentItems = async (
+  folderToPathMap: Map<string, string>,
   client: DynamicContent,
   hub: Hub,
   repoId?: string | string[],
   folderId?: string | string[]
-): Promise<{ path: Promise<string>; item: ContentItem }[]> => {
-  const items: { path: Promise<string>; item: ContentItem }[] = [];
+): Promise<{ path: string; item: ContentItem }[]> => {
+  const items: { path: string; item: ContentItem }[] = [];
 
-  if (folderId != null) {
-    const folderIds = typeof folderId === 'string' ? [folderId] : folderId;
-    const folders = await Promise.all(folderIds.map(id => client.folders.get(id)));
-    for (let i = 0; i < folders.length; i++) {
-      const folder = folders[i];
-      folderToPathMap.set(folder.id as string, folders.length > 1 ? `${folder.name}/` : '');
-      const newItems = await paginator(folder.related.contentItems.list, { status: 'ACTIVE' });
-      Array.prototype.push.apply(
-        items,
-        newItems.map(item => ({ item, path: getOrAddFolderPath(client, item.folderId) }))
-      );
+  const folderIds = typeof folderId === 'string' ? [folderId] : folderId || [];
 
+  const repoItems: ContentItem[] = [];
+
+  const repoIds = typeof repoId === 'string' ? [repoId] : repoId || [];
+
+  const repositories = await (repoId != null || folderId != null
+    ? Promise.all(repoIds.map(id => client.contentRepositories.get(id)))
+    : paginator(hub.related.contentRepositories.list));
+
+  let specifyBasePaths = repositories.length + folderIds.length > 1;
+
+  for (let i = 0; i < repositories.length; i++) {
+    const repository = repositories[i];
+    const baseDir = specifyBasePaths ? `${sanitize(repository.label as string)}/` : '';
+    await ensureDirectoryExists(baseDir);
+    const newFolders = await paginator(repository.related.folders.list);
+    newFolders.forEach(folder => {
+      if (folderIds.indexOf(folder.id as string) === -1) {
+        folderIds.push(folder.id as string);
+      }
+      folderToPathMap.set(folder.id as string, join(baseDir, `${sanitize(folder.name as string)}/`));
+    });
+
+    // Add content items in repo base folder. Cache the other items so we don't have to request them again.
+    let newItems: ContentItem[];
+    try {
+      const allItems = await paginator(repository.related.contentItems.list, { status: 'ACTIVE' });
+      Array.prototype.push.apply(repoItems, allItems);
+      newItems = allItems.filter(item => item.folderId == null);
+    } catch (e) {
+      console.error(`Error getting items from repository ${repository.name} (${repository.id}): ${e.toString()}`);
+      continue;
+    }
+
+    Array.prototype.push.apply(items, newItems.map(item => ({ item, path: baseDir })));
+  }
+
+  const folders = await Promise.all(folderIds.map(id => client.folders.get(id)));
+  const baseFolders = folders.length;
+  console.log(`Found ${folders.length} base folders.`);
+
+  specifyBasePaths = specifyBasePaths || folders.length > 1;
+
+  for (let i = 0; i < folders.length; i++) {
+    const folder = folders[i];
+    if (i < baseFolders) {
+      if (!folderToPathMap.has(folder.id as string)) {
+        folderToPathMap.set(folder.id as string, specifyBasePaths ? `${sanitize(folder.name as string)}/` : '');
+      }
+    }
+    const path = await getOrAddFolderPath(folderToPathMap, client, folder);
+    console.log(`Processing ${path}...`);
+
+    let newItems: ContentItem[];
+    // If we already have seen items in this folder, use those. Otherwise try get them explicitly.
+    // This may happen for folders in selected repositories if they are empty, but it will be a no-op (and is unavoidable).
+    newItems = repoItems.filter(item => item.folderId == folder.id);
+    if (newItems.length == 0) {
+      console.log(`Fetching additional folder: ${folder.name}`);
+      try {
+        newItems = (await paginator(folder.related.contentItems.list)).filter(item => item.status === 'ACTIVE');
+      } catch (e) {
+        console.error(`Error getting items from folder ${folder.name} (${folder.id}): ${e.toString()}`);
+        continue;
+      }
+    }
+    Array.prototype.push.apply(items, newItems.map(item => ({ item, path: path })));
+
+    try {
       const subfolders = await paginator(folder.related.folders.list);
       Array.prototype.push.apply(folders, subfolders);
-    }
-  } else {
-    const repoIds = typeof repoId === 'string' ? [repoId] : repoId || [];
-    const repositories = await (repoId != null
-      ? Promise.all(repoIds.map(id => client.contentRepositories.get(id)))
-      : paginator(hub.related.contentRepositories.list));
-    for (let i = 0; i < repositories.length; i++) {
-      const repository = repositories[i];
-      const baseDir = `${repository.label}/`;
-      const newItems = await paginator(repository.related.contentItems.list, { status: 'ACTIVE' });
-      Array.prototype.push.apply(
-        items,
-        newItems.map(item => ({ item, path: getOrAddFolderPath(client, item.folderId, baseDir) }))
-      );
+    } catch (e) {
+      console.error(`Error getting subfolders from folder ${folder.name} (${folder.id}): ${e.toString()}`);
     }
   }
   return items;
@@ -211,36 +262,39 @@ const getContentItems = async (
 export const handler = async (argv: Arguments<ExportItemBuilderOptions & ConfigurationParameters>): Promise<void> => {
   const { dir, repoId, folderId, schemaId, name } = argv;
 
+  const folderToPathMap: Map<string, string> = new Map();
   const client = dynamicContentClientFactory(argv);
   const hub = await client.hubs.get(argv.hubId);
-  let items = await getContentItems(client, hub, repoId, folderId);
+  console.log('Retrieving content items, please wait.');
+  let items = await getContentItems(folderToPathMap, client, hub, repoId, folderId);
 
   // Filter using the schemaId and name, if present.
   if (schemaId != null) {
     const schemaIds: string[] = Array.isArray(schemaId) ? schemaId : [schemaId];
     items = items.filter(
-      ({ item }: { item: ContentItem }) => schemaIds.findIndex(id => equalsOrRegex(item.body._meta.schemaId, id)) != -1
+      ({ item }: { item: ContentItem }) => schemaIds.findIndex(id => equalsOrRegex(item.body._meta.schema, id)) !== -1
     );
   }
   if (name != null) {
     const names: string[] = Array.isArray(name) ? name : [name];
     items = items.filter(
-      ({ item }: { item: ContentItem }) => names.findIndex(name => equalsOrRegex(item.label as string, name)) != -1
+      ({ item }: { item: ContentItem }) => names.findIndex(name => equalsOrRegex(item.label as string, name)) !== -1
     );
   }
+
+  console.log('Saving content items.');
+  const filenames: string[] = [];
 
   for (let i = 0; i < items.length; i++) {
     const { item, path } = items[i];
 
     let resolvedPath: string;
-    try {
-      resolvedPath = await path;
-    } catch {
-      console.log(`Could not determine folder for ${item.label}.`);
-      continue;
-    }
+    resolvedPath = path;
+
     const directory = join(dir, resolvedPath);
-    resolvedPath = join(directory, `${item.label}.json`);
+    resolvedPath = uniqueFilenamePath(directory, `${sanitize(item.label as string)}`, 'json', filenames);
+    filenames.push(resolvedPath);
+    console.log(resolvedPath);
     await ensureDirectoryExists(directory);
 
     writeJsonToFile(resolvedPath, item);

--- a/src/commands/content-item/export.ts
+++ b/src/commands/content-item/export.ts
@@ -4,13 +4,7 @@ import dynamicContentClientFactory from '../../services/dynamic-content-client-f
 import { dirname, join, sep } from 'path';
 import { equalsOrRegex } from '../../common/filter/filter';
 import sanitize from 'sanitize-filename';
-import {
-  ExportResult,
-  nothingExportedExit,
-  promptToOverwriteExports,
-  uniqueFilenamePath,
-  writeJsonToFile
-} from '../../services/export.service';
+import { uniqueFilenamePath, writeJsonToFile } from '../../services/export.service';
 
 import { mkdir, writeFile, exists, lstat } from 'fs';
 import { promisify } from 'util';
@@ -20,7 +14,7 @@ import { ContentItem, Folder, DynamicContent, Hub } from 'dc-management-sdk-js';
 
 export const command = 'export <dir>';
 
-export const desc = 'Export Content Types';
+export const desc = 'Export Content Items';
 
 export const builder = (yargs: Argv): void => {
   yargs

--- a/src/commands/content-item/export.ts
+++ b/src/commands/content-item/export.ts
@@ -229,12 +229,11 @@ export const handler = async (argv: Arguments<ExportItemBuilderOptions & Configu
     tree.filterAny(item => {
       const missingDeps = item.dependancies.filter(dep => !tree.byId.has(dep.dependancy.id as string));
       missingDeps.forEach(dep => {
-        if (dep.dependancy.id != null) {
-          if (!missingIDs.has(dep.dependancy.id)) {
-            newMissingIDs.add(dep.dependancy.id);
-          }
-          missingIDs.add(dep.dependancy.id);
+        const id = dep.dependancy.id as string;
+        if (!missingIDs.has(id)) {
+          newMissingIDs.add(id);
         }
+        missingIDs.add(id);
       });
       return missingDeps.length > 0;
     });

--- a/src/commands/content-item/export.ts
+++ b/src/commands/content-item/export.ts
@@ -60,32 +60,6 @@ export const builder = (yargs: Argv): void => {
     });
 };
 
-export const writeItemBody = async (filename: string, body?: string): Promise<void> => {
-  if (!body) {
-    return;
-  }
-
-  const dir = dirname(filename);
-  if (await promisify(exists)(dir)) {
-    const dirStat = await promisify(lstat)(dir);
-    if (!dirStat || !dirStat.isDirectory()) {
-      throw new Error(`Unable to write schema to "${filename}" as "${dir}" is not a directory.`);
-    }
-  } else {
-    try {
-      await promisify(mkdir)(dir);
-    } catch {
-      throw new Error(`Unable to create directory: "${dir}".`);
-    }
-  }
-
-  try {
-    await promisify(writeFile)(filename, body);
-  } catch {
-    throw new Error(`Unable to write file: "${filename}".`);
-  }
-};
-
 const getOrAddFolderPath = async (
   folderToPathMap: Map<string, string>,
   client: DynamicContent,
@@ -121,26 +95,6 @@ const getOrAddFolderPath = async (
 
   folderToPathMap.set(id, path);
   return path;
-};
-
-export const filterContentItemsBySchemaId = (
-  listToFilter: ContentItem[],
-  listToMatch: string[] = []
-): ContentItem[] => {
-  if (listToMatch.length === 0) {
-    return listToFilter;
-  }
-
-  const unmatchedIdList: string[] = listToMatch.filter(id => !listToFilter.some(item => item.body._meta.schema === id));
-  if (unmatchedIdList.length > 0) {
-    throw new Error(
-      `Content matching the following schema ID(s) could not be found: [${unmatchedIdList
-        .map(u => `'${u}'`)
-        .join(', ')}].\nNothing was exported, exiting.`
-    );
-  }
-
-  return listToFilter.filter(item => listToMatch.some(id => item.body._meta.schema === id));
 };
 
 const getContentItems = async (

--- a/src/commands/content-item/export.ts
+++ b/src/commands/content-item/export.ts
@@ -252,7 +252,7 @@ export const handler = async (argv: Arguments<ExportItemBuilderOptions & Configu
 
   const folderToPathMap: Map<string, string> = new Map();
   const client = dynamicContentClientFactory(argv);
-  const log = new FileLog(logFile);
+  const log = typeof logFile === 'string' || logFile == null ? new FileLog(logFile) : logFile;
   const hub = await client.hubs.get(argv.hubId);
 
   log.appendLine('Retrieving content items, please wait.');

--- a/src/commands/content-item/export.ts
+++ b/src/commands/content-item/export.ts
@@ -327,10 +327,12 @@ export const handler = async (argv: Arguments<ExportItemBuilderOptions & Configu
     const { item, path } = items[i];
 
     try {
-      if (!(await validator.validate(item.body))) {
+      const errors = await validator.validate(item.body);
+      if (errors.length > 0) {
         log.appendLine(
           `WARNING: ${item.label} does not validate under the available schema. It may not import correctly.`
         );
+        log.appendLine(JSON.stringify(errors, null, 2));
       }
     } catch (e) {
       log.appendLine(`WARNING: Could not validate ${item.label} as there is a problem with the schema: ${e}`);

--- a/src/commands/content-item/export.ts
+++ b/src/commands/content-item/export.ts
@@ -17,6 +17,11 @@ import { ContentMapping } from '../../common/content-item/content-mapping';
 import { getDefaultLogPath } from '../../common/log-helpers';
 import { AmplienceSchemaValidator, defaultSchemaLookup } from '../../common/content-item/amplience-schema-validator';
 
+interface PublishedContentItem {
+  lastPublishedVersion?: number;
+  lastPublishedDate?: string;
+}
+
 export const command = 'export <dir>';
 
 export const desc = 'Export Content Items';
@@ -197,7 +202,7 @@ const getContentItems = async (
     for (let i = 0; i < items.length; i++) {
       const item = items[i];
 
-      const publishedVersion: number | undefined = (item.item as any).lastPublishedVersion;
+      const publishedVersion: number | undefined = (item.item as PublishedContentItem).lastPublishedVersion;
       if (publishedVersion != null && publishedVersion != item.item.version) {
         const newVersion = await item.item.related.contentItemVersion(publishedVersion);
         item.item = newVersion;

--- a/src/commands/content-item/export.ts
+++ b/src/commands/content-item/export.ts
@@ -1,4 +1,4 @@
-import { Arguments, Argv, argv } from 'yargs';
+import { Arguments, Argv } from 'yargs';
 import { ConfigurationParameters } from '../configure';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
 import { FileLog } from '../../common/file-log';
@@ -9,15 +9,7 @@ import { uniqueFilenamePath, writeJsonToFile } from '../../services/export.servi
 
 import { ExportItemBuilderOptions } from '../../interfaces/export-item-builder-options.interface';
 import paginator from '../../common/dc-management-sdk-js/paginator';
-import {
-  ContentItem,
-  Folder,
-  DynamicContent,
-  Hub,
-  ContentRepository,
-  ContentTypeSchema,
-  CachedSchema
-} from 'dc-management-sdk-js';
+import { ContentItem, Folder, DynamicContent, Hub, ContentRepository } from 'dc-management-sdk-js';
 
 import { ensureDirectoryExists } from '../../common/import/directory-utils';
 import { ContentDependancyTree, RepositoryContentItem } from '../../common/content-item/content-dependancy-tree';
@@ -330,9 +322,7 @@ export const handler = async (argv: Arguments<ExportItemBuilderOptions & Configu
         log.appendLine(JSON.stringify(errors, null, 2));
       }
     } catch (e) {
-      log.appendLine(
-        `WARNING: Could not validate ${item.label} as there is a problem with the schema: ${e} \n ${e.stack}`
-      );
+      log.appendLine(`WARNING: Could not validate ${item.label} as there is a problem with the schema: ${e}`);
     }
 
     let resolvedPath: string;

--- a/src/commands/content-item/import-revert.spec.ts
+++ b/src/commands/content-item/import-revert.spec.ts
@@ -1,0 +1,416 @@
+import { revert } from './import-revert';
+import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
+import { writeFile } from 'fs';
+import { dirname } from 'path';
+import { promisify } from 'util';
+import readline from 'readline';
+
+import rmdir from 'rimraf';
+import { ensureDirectoryExists } from '../../common/import/directory-utils';
+import { MockContent, ItemTemplate } from '../../common/dc-management-sdk-js/mock-content';
+import { Status } from 'dc-management-sdk-js';
+
+jest.mock('readline');
+jest.mock('../../services/dynamic-content-client-factory');
+
+function rimraf(dir: string): Promise<Error> {
+  return new Promise((resolve): void => {
+    rmdir(dir, resolve);
+  });
+}
+
+describe('revert tests', function() {
+  const yargArgs = {
+    $0: 'test',
+    _: ['test'],
+    json: true
+  };
+  const config = {
+    clientId: 'client-id',
+    clientSecret: 'client-id',
+    hubId: 'hub-id'
+  };
+
+  beforeAll(async () => {
+    await rimraf('temp/revert/');
+  });
+
+  afterAll(async () => {
+    await rimraf('temp/revert/');
+  });
+
+  async function createLog(logFileName: string, log: string): Promise<void> {
+    const dir = dirname(logFileName);
+    await ensureDirectoryExists(dir);
+    await promisify(writeFile)(logFileName, log);
+  }
+
+  // Reverting a clean import (no updated content) should archive all imported content.
+  // Reverting an import on top of existing content should revert to an older version of the content, and archive content that was created.
+  // Attempting to revert an import of content that has since changed should warn the user.
+  // User responding no to the content changed warning should abort the process.
+  // Missing items when reverting (or already in the desired state) should be silently skipped.
+  // Reverting an empty log should not do anything.
+
+  // == FUNCTIONALITY TESTS ==
+  test('Reverting a clean import (no updated content) should archive all imported content.', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (readline as any).setResponses([]);
+
+    await createLog('temp/revert/createOnly.txt', 'CREATE id1\nCREATE id2\nCREATE id3');
+
+    // Create content to import
+
+    const templates: ItemTemplate[] = [
+      { id: 'id1', label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type' },
+      { id: 'id2', label: 'item2', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest' },
+      { id: 'id3', label: 'item3', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' }
+    ];
+
+    const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+    mockContent.createMockRepository('repo');
+    mockContent.registerContentType('http://type', 'type', 'repo');
+    mockContent.importItemTemplates(templates);
+
+    const argv = {
+      ...yargArgs,
+      ...config,
+      revertLog: 'temp/revert/createOnly.txt',
+      dir: '.'
+    };
+    await revert(argv);
+
+    // check items were archived appropriately
+    expect(mockContent.metrics.itemsArchived).toEqual(3);
+
+    await rimraf('temp/revert/createOnly.txt');
+  });
+
+  test('Reverting an import on top of existing content should revert to an older version of the content, and archive content that was created.', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (readline as any).setResponses([]);
+
+    await createLog('temp/revert/createImport.txt', 'UPDATE id1 1 2\nUPDATE id2 3 4\nCREATE id3');
+
+    // Create content to import
+
+    const templates: ItemTemplate[] = [
+      { id: 'id1', label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type', version: 2 },
+      { id: 'id2', label: 'item2', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest', version: 4 },
+      { id: 'id3', label: 'item3', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' }
+    ];
+
+    const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+    mockContent.createMockRepository('repo');
+    mockContent.registerContentType('http://type', 'type', 'repo');
+    mockContent.importItemTemplates(templates);
+
+    const argv = {
+      ...yargArgs,
+      ...config,
+      revertLog: 'temp/revert/createImport.txt',
+      dir: '.'
+    };
+    await revert(argv);
+
+    // check items were archived appropriately
+    expect(mockContent.metrics.itemsUpdated).toEqual(2);
+    // check items were archived appropriately
+    expect(mockContent.metrics.itemsArchived).toEqual(1);
+
+    await rimraf('temp/revert/createImport.txt');
+  });
+
+  test('Attempting to revert an import of content that has since changed should warn the user and continue on prompt.', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (readline as any).setResponses(['y']);
+
+    await createLog(
+      'temp/revert/createWarn.txt',
+      'UPDATE id1 1 2\nUPDATE id2 3 4\nCREATE id3\nUPDATE id4 3 4\nCREATE id5'
+    );
+
+    // Create content to import
+
+    const templates: ItemTemplate[] = [
+      { id: 'id1', label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type', version: 2 },
+
+      // This content item has a higher version than the revert log. It should warn the user that there has been a change.
+      { id: 'id2', label: 'item2', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest', version: 5 },
+
+      { id: 'id3', label: 'item3', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' },
+
+      // This content item has a higher version and is archived. This will act the same as unarchived, but warn the user.
+      {
+        id: 'id4',
+        label: 'item4',
+        repoId: 'repo',
+        typeSchemaUri: 'http://type',
+        folderPath: 'folderTest',
+        version: 5,
+        status: Status.DELETED
+      },
+
+      // This content item is archived, and it was created by the copy. Since it's already archived, nothing should happen.
+      {
+        id: 'id5',
+        label: 'item3',
+        repoId: 'repo',
+        typeSchemaUri: 'http://type',
+        folderPath: 'folderTest/nested',
+        version: 2,
+        status: Status.DELETED
+      }
+    ];
+
+    const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+    mockContent.createMockRepository('repo');
+    mockContent.registerContentType('http://type', 'type', 'repo');
+    mockContent.importItemTemplates(templates);
+
+    const argv = {
+      ...yargArgs,
+      ...config,
+      revertLog: 'temp/revert/createWarn.txt',
+      dir: '.'
+    };
+    await revert(argv);
+
+    // check items were archived appropriately
+    expect(mockContent.metrics.itemsUpdated).toEqual(3);
+    // check items were archived appropriately
+    expect(mockContent.metrics.itemsArchived).toEqual(1);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((readline as any).responsesLeft()).toEqual(0);
+
+    await rimraf('temp/revert/createWarn.txt');
+  });
+
+  test('User responding no to the content changed warning should abort the process.', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (readline as any).setResponses(['n']);
+
+    await createLog('temp/revert/revertAbort.txt', 'UPDATE id1 1 2\nUPDATE id2 3 4\nCREATE id3');
+
+    // Create content to import
+
+    const templates: ItemTemplate[] = [
+      { id: 'id1', label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type', version: 2 },
+
+      // This content item has a higher version than the revert log. It should warn the user that there has been a change.
+      { id: 'id2', label: 'item2', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest', version: 5 },
+
+      { id: 'id3', label: 'item3', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' }
+    ];
+
+    const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+    mockContent.createMockRepository('repo');
+    mockContent.registerContentType('http://type', 'type', 'repo');
+    mockContent.importItemTemplates(templates);
+
+    const argv = {
+      ...yargArgs,
+      ...config,
+      revertLog: 'temp/revert/revertAbort.txt',
+      dir: '.'
+    };
+    const result = await revert(argv);
+
+    expect(result).toBeFalsy();
+
+    // check items were archived appropriately
+    expect(mockContent.metrics.itemsUpdated).toEqual(0);
+    // check items were archived appropriately
+    expect(mockContent.metrics.itemsArchived).toEqual(0);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((readline as any).responsesLeft()).toEqual(0);
+
+    await rimraf('temp/revert/revertAbort.txt');
+  });
+
+  test('Missing/invalid/non-updated items when reverting (or already in the desired state) should be silently skipped.', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (readline as any).setResponses([]);
+
+    await createLog(
+      'temp/revert/revertSkip.txt',
+      'UPDATE id1 1 2\nUPDATE id2 3 4\nCREATE id3\nCREATE id4\nUPDATE id5 3 4\nCREATE id6\nUPDATE id7 23 24\nUPDATE id8 1 1\nUPDATE id9 0 1 invalid'
+    );
+
+    // Create content to import
+
+    const templates: ItemTemplate[] = [
+      { id: 'id1', label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type', version: 2 },
+      { id: 'id2', label: 'item2', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest', version: 4 },
+      { id: 'id3', label: 'item3', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' }
+    ];
+
+    const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+    mockContent.createMockRepository('repo');
+    mockContent.registerContentType('http://type', 'type', 'repo');
+    mockContent.importItemTemplates(templates);
+
+    const argv = {
+      ...yargArgs,
+      ...config,
+      revertLog: 'temp/revert/revertSkip.txt',
+      dir: '.'
+    };
+    const result = await revert(argv);
+
+    expect(result).toBeTruthy();
+
+    // check items were archived appropriately
+    expect(mockContent.metrics.itemsUpdated).toEqual(2);
+    // check items were archived appropriately
+    expect(mockContent.metrics.itemsArchived).toEqual(1);
+
+    await rimraf('temp/revert/revertSkip.txt');
+  });
+
+  test('Reverting an empty log should not do anything.', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (readline as any).setResponses([]);
+
+    await createLog('temp/revert/revertEmpty.txt', '// empty :)');
+
+    // Create content to import
+
+    const templates: ItemTemplate[] = [
+      { id: 'id1', label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type' },
+      { id: 'id2', label: 'item2', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest' },
+      { id: 'id3', label: 'item3', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' }
+    ];
+
+    const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+    mockContent.createMockRepository('repo');
+    mockContent.registerContentType('http://type', 'type', 'repo');
+    mockContent.importItemTemplates(templates);
+
+    const argv = {
+      ...yargArgs,
+      ...config,
+      revertLog: 'temp/revert/revertEmpty.txt',
+      dir: '.'
+    };
+    await revert(argv);
+
+    // make sure nothing happened
+    expect(mockContent.metrics.itemsArchived).toEqual(0);
+    expect(mockContent.metrics.itemsUpdated).toEqual(0);
+
+    await rimraf('temp/revert/revertEmpty.txt');
+  });
+
+  test('Failed requests should silently skip affected content.', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (readline as any).setResponses([]);
+
+    await createLog(
+      'temp/revert/revertSkip.txt',
+      'UPDATE id1 1 2\nUPDATE id2 3 4\nCREATE id3\nCREATE id4\nUPDATE id5 3 4\nCREATE id6\nUPDATE id7 23 24'
+    );
+
+    // Create content to import
+
+    const templates: ItemTemplate[] = [
+      { id: 'id1', label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type', version: 2 },
+      { id: 'id2', label: 'item2', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest', version: 4 },
+      { id: 'id3', label: 'item3', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' }
+    ];
+
+    const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+    mockContent.createMockRepository('repo');
+    mockContent.registerContentType('http://type', 'type', 'repo');
+    mockContent.importItemTemplates(templates);
+    mockContent.failItemActions = 'all';
+
+    const argv = {
+      ...yargArgs,
+      ...config,
+      revertLog: 'temp/revert/revertSkip.txt',
+      dir: '.'
+    };
+    const result = await revert(argv);
+
+    expect(result).toBeTruthy();
+
+    // check items were archived appropriately
+    expect(mockContent.metrics.itemsUpdated).toEqual(0);
+    // check items were archived appropriately
+    expect(mockContent.metrics.itemsArchived).toEqual(0);
+
+    await rimraf('temp/revert/revertSkip.txt');
+  });
+
+  test('When the version request does not fail but updating it to that version does, skip the item.', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (readline as any).setResponses([]);
+
+    await createLog('temp/revert/revertSkip2.txt', 'UPDATE id1 1 2');
+
+    // Create content to import
+
+    const templates: ItemTemplate[] = [
+      { id: 'id1', label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type', version: 2 }
+    ];
+
+    const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+    mockContent.createMockRepository('repo');
+    mockContent.registerContentType('http://type', 'type', 'repo');
+    mockContent.importItemTemplates(templates);
+    mockContent.failItemActions = 'not-version';
+
+    const argv = {
+      ...yargArgs,
+      ...config,
+      revertLog: 'temp/revert/revertSkip2.txt',
+      dir: '.'
+    };
+    const result = await revert(argv);
+
+    expect(result).toBeTruthy();
+
+    // check items were archived appropriately
+    expect(mockContent.metrics.itemsUpdated).toEqual(0);
+    // check items were archived appropriately
+    expect(mockContent.metrics.itemsArchived).toEqual(0);
+
+    await rimraf('temp/revert/revertSkip2.txt');
+  });
+
+  test('Missing log should exit early.', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (readline as any).setResponses([]);
+
+    // Create content to import
+
+    const templates: ItemTemplate[] = [
+      { id: 'id1', label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type', version: 2 },
+      { id: 'id2', label: 'item2', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest', version: 4 },
+      { id: 'id3', label: 'item3', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' }
+    ];
+
+    const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+    mockContent.createMockRepository('repo');
+    mockContent.registerContentType('http://type', 'type', 'repo');
+    mockContent.importItemTemplates(templates);
+
+    const argv = {
+      ...yargArgs,
+      ...config,
+      revertLog: 'temp/revert/revertMissing.txt',
+      dir: '.'
+    };
+    const result = await revert(argv);
+
+    expect(result).toBeFalsy();
+
+    // check items were archived appropriately
+    expect(mockContent.metrics.itemsUpdated).toEqual(0);
+    // check items were archived appropriately
+    expect(mockContent.metrics.itemsArchived).toEqual(0);
+  });
+});

--- a/src/commands/content-item/import-revert.spec.ts
+++ b/src/commands/content-item/import-revert.spec.ts
@@ -236,7 +236,7 @@ describe('revert tests', function() {
 
     await createLog(
       'temp/revert/revertSkip.txt',
-      'UPDATE id1 1 2\nUPDATE id2 3 4\nCREATE id3\nCREATE id4\nUPDATE id5 3 4\nCREATE id6\nUPDATE id7 23 24\nUPDATE id8 1 1\nUPDATE id9 0 1 invalid'
+      '// Title\n// Comment\nUPDATE id1 1 2\nUPDATE id2 3 4\nCREATE id3\nCREATE id4\nUPDATE id5 3 4\nCREATE id6\nUPDATE id7 23 24\nUPDATE id8 1 1\nUPDATE id9 0 1 invalid'
     );
 
     // Create content to import

--- a/src/commands/content-item/import-revert.ts
+++ b/src/commands/content-item/import-revert.ts
@@ -20,7 +20,6 @@ export const revert = async (argv: Arguments<ImportItemBuilderOptions & Configur
 
   const toArchive = log.getData('CREATE'); // Undo created content by archiving it.
   const toDowngrade = log.getData('UPDATE'); // Undo updated content by downgrading it.
-  // const folderToRemove = log.getData('FOLDER'); // Folders to remove. (TODO: needs changes to management sdk)
 
   const items: { item: ContentItem; oldVersion: number; newVersion: number }[] = [];
 
@@ -39,7 +38,7 @@ export const revert = async (argv: Arguments<ImportItemBuilderOptions & Configur
 
   for (let i = 0; i < toDowngrade.length; i++) {
     const split = toDowngrade[i].split(' ');
-    if (split.length != 3) {
+    if (split.length !== 3) {
       continue; // Must be in format (id, oldVersion, newVersion)
     }
     const id = split[0];

--- a/src/commands/content-item/import-revert.ts
+++ b/src/commands/content-item/import-revert.ts
@@ -1,0 +1,128 @@
+import { ImportItemBuilderOptions } from '../../interfaces/import-item-builder-options.interface';
+import { ConfigurationParameters } from '../configure';
+import { Arguments } from 'yargs';
+import { FileLog } from '../../common/file-log';
+import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
+import { ContentItem } from 'dc-management-sdk-js';
+import { asyncQuestion } from '../../common/archive/archive-helpers';
+
+export const revert = async (argv: Arguments<ImportItemBuilderOptions & ConfigurationParameters>): Promise<boolean> => {
+  const log = new FileLog();
+  try {
+    await log.loadFromFile(argv.revertLog as string);
+  } catch (e) {
+    console.log('Could not open the import log! Aborting.');
+    return false;
+  }
+
+  // We just need to access the destination repo to undo a import.
+  const client = dynamicContentClientFactory(argv);
+
+  const toArchive = log.getData('CREATE'); // Undo created content by archiving it.
+  const toDowngrade = log.getData('UPDATE'); // Undo updated content by downgrading it.
+  // const folderToRemove = log.getData('FOLDER'); // Folders to remove. (TODO: needs changes to management sdk)
+
+  const items: { item: ContentItem; oldVersion: number; newVersion: number }[] = [];
+
+  for (let i = 0; i < toArchive.length; i++) {
+    const id = toArchive[i];
+
+    try {
+      const item = await client.contentItems.get(id);
+      items.push({ item, oldVersion: 0, newVersion: 1 });
+    } catch {
+      console.log(`Could not find item with id ${id}, skipping.`);
+    }
+  }
+
+  let unchanged = 0;
+
+  for (let i = 0; i < toDowngrade.length; i++) {
+    const split = toDowngrade[i].split(' ');
+    if (split.length != 3) {
+      continue; // Must be in format (id, oldVersion, newVersion)
+    }
+    const id = split[0];
+    const oldVersion = Number(split[1]);
+    const newVersion = Number(split[2]);
+
+    if (oldVersion === newVersion) {
+      unchanged++;
+      continue;
+    }
+
+    try {
+      const item = await client.contentItems.get(id);
+      items.push({ item, oldVersion, newVersion });
+    } catch {
+      console.log(`Could not find item with id ${id}, skipping.`);
+    }
+  }
+
+  if (unchanged > 0) {
+    console.log(
+      `${unchanged} content items were imported, but were not updated so there is nothing to revert. Ignoring.`
+    );
+  }
+
+  const changed = items.filter(entry => entry.item.version !== entry.newVersion);
+
+  if (changed.length > 0) {
+    console.log(`${changed.length} content items have been changed since they were imported:`);
+
+    changed.forEach(entry => {
+      const hasBeenArchived = entry.item.status !== 'ACTIVE' ? ', has been archived)' : '';
+      const summary = `(modified ${(entry.item.version as number) -
+        entry.newVersion} times since import${hasBeenArchived})`;
+      console.log(`  ${entry.item.label} ${summary}`);
+    });
+
+    const answer = await asyncQuestion(
+      'Do you want to continue with the revert, losing any changes made since the import? (y/n)\n'
+    );
+
+    if (!answer) {
+      return false;
+    }
+  }
+
+  if (items.length > 0) {
+    for (let i = 0; i < items.length; i++) {
+      const entry = items[i];
+      const item = entry.item;
+
+      if (entry.oldVersion === 0) {
+        // Reverting should archive.
+        if (item.status === 'ACTIVE') {
+          console.log(`Archiving ${item.label}.`);
+          try {
+            await item.related.archive();
+          } catch (e) {
+            console.log(`Could not archive ${item.label}!\n${e.toString()}\nContinuing...`);
+          }
+        }
+      } else {
+        let oldItem: ContentItem;
+        try {
+          oldItem = await item.related.contentItemVersion(entry.oldVersion);
+        } catch (e) {
+          console.log(`Could not get old version for ${item.label}!\n${e.toString()}\nContinuing...`);
+          continue;
+        }
+
+        console.log(`Reverting ${item.label} to version ${entry.oldVersion}.`);
+
+        try {
+          await item.related.update(oldItem);
+        } catch (e) {
+          console.log(`Could not revert ${item.label}!\n${e.toString()}\nContinuing...`);
+        }
+      }
+    }
+  } else {
+    console.log('No actions found to revert.');
+  }
+
+  console.log('Done!');
+  return true;
+};

--- a/src/commands/content-item/import.spec.ts
+++ b/src/commands/content-item/import.spec.ts
@@ -1,0 +1,874 @@
+import { builder, command, handler } from './import';
+import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
+import { Folder, ContentType } from 'dc-management-sdk-js';
+import Yargs from 'yargs/yargs';
+import { writeFile } from 'fs';
+import { join, dirname, basename } from 'path';
+import { promisify } from 'util';
+import readline from 'readline';
+
+import rmdir from 'rimraf';
+import { ensureDirectoryExists } from '../../common/import/directory-utils';
+import { MockContent, ItemTemplate } from '../../common/dc-management-sdk-js/mock-content';
+
+jest.mock('readline');
+jest.mock('../../services/dynamic-content-client-factory');
+
+function rimraf(dir: string): Promise<Error> {
+  return new Promise((resolve): void => {
+    rmdir(dir, resolve);
+  });
+}
+
+describe('content-item import command', () => {
+  afterEach((): void => {
+    jest.restoreAllMocks();
+  });
+
+  it('should command should defined', function() {
+    expect(command).toEqual('import <dir>');
+  });
+
+  describe('builder tests', function() {
+    it('should configure yargs', function() {
+      const argv = Yargs(process.argv.slice(2));
+      const spyPositional = jest.spyOn(argv, 'positional').mockReturnThis();
+      const spyOption = jest.spyOn(argv, 'option').mockReturnThis();
+
+      builder(argv);
+
+      expect(spyPositional).toHaveBeenCalledWith('dir', {
+        describe:
+          'Directory containing content items to import. If this points to an export manifest, we will try and import the content with the same absolute path and repositories as the export.',
+        type: 'string',
+        requiresArg: true
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('baseRepo', {
+        type: 'string',
+        describe:
+          'Import matching the given repository to the import base directory, by ID. Folder structure will be followed and replicated from there.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('baseFolder', {
+        type: 'string',
+        describe:
+          'Import matching the given folder to the import base directory, by ID. Folder structure will be followed and replicated from there.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('mapFile', {
+        type: 'string',
+        describe:
+          'Mapping file to use when updating content that already exists. Updated with any new mappings that are generated. If not present, will be created.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('f', {
+        type: 'boolean',
+        boolean: true,
+        describe:
+          'Overwrite content, create and assign content types, and ignore content with missing types/references without asking.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('v', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'Only recreate folder structure - content is validated but not imported.'
+      });
+    });
+  });
+
+  describe('handler tests', function() {
+    const yargArgs = {
+      $0: 'test',
+      _: ['test'],
+      json: true
+    };
+    const config = {
+      clientId: 'client-id',
+      clientSecret: 'client-id',
+      hubId: 'hub-id'
+    };
+
+    beforeAll(async () => {
+      await rimraf('temp/import/');
+    });
+
+    afterAll(async () => {
+      await rimraf('temp/import/');
+    });
+
+    async function createContent(
+      baseFolder: string,
+      items: ItemTemplate[],
+      includeRepo: boolean,
+      repoFolderBase?: string
+    ): Promise<void> {
+      await ensureDirectoryExists(baseFolder);
+
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+
+        // Create the items for import.
+        const folderPath = item.folderPath || '';
+        let folder = folderPath;
+        if (repoFolderBase) {
+          folder = folder.substring(repoFolderBase.length);
+        }
+
+        let path: string;
+        if (includeRepo) {
+          path = join(baseFolder, item.repoId, folder, `${item.label}.json`);
+        } else {
+          path = join(baseFolder, folder, `${item.label}.json`);
+        }
+
+        await ensureDirectoryExists(dirname(path));
+
+        const folderId = folderPath == '' ? null : basename(folderPath as string);
+
+        const content = {
+          id: item.id,
+          label: item.label,
+          contentRepositoryId: item.repoId,
+          folderId: folderId,
+          body: {
+            _meta: {
+              schema: item.typeSchemaUri
+            },
+            ...(item.body || {})
+          }
+        };
+
+        const jsonString = JSON.stringify(content);
+
+        await promisify(writeFile)(path, jsonString);
+      }
+    }
+
+    // == FUNCTIONALITY TESTS ==
+    it('Importing into a baseRepo creates folder structure starting at the base repository', async () => {
+      // Create content to import
+
+      const templates: ItemTemplate[] = [
+        { label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type' },
+        { label: 'item2', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest' },
+        { label: 'item3', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest' },
+        { label: 'item4', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' }
+      ];
+
+      await createContent('temp/import/repo/', templates, false);
+
+      const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+      mockContent.createMockRepository('targetRepo');
+      mockContent.registerContentType('http://type', 'type', 'targetRepo');
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/import/repo/',
+        mapFile: 'temp/import/repo.json',
+        baseRepo: 'targetRepo'
+      };
+      await handler(argv);
+
+      // check items were created appropriately
+
+      const matches = await mockContent.filterMatch(templates, '', false);
+
+      expect(matches.length).toEqual(templates.length);
+
+      await rimraf('temp/import/repo/');
+    });
+
+    it('Importing into a baseFolder creates folder structure starting at the given folder (within the specified repository)', async () => {
+      // Create content to import.
+
+      const templates: ItemTemplate[] = [
+        { label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type' },
+        { label: 'item2', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest' },
+        { label: 'item3', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest' },
+        { label: 'item4', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' }
+      ];
+
+      await createContent('temp/import/folder/', templates, false);
+
+      const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+      mockContent.createMockRepository('targetRepo');
+      mockContent.createFolder(new Folder({ name: 'targetFolder', id: 'targetFolder', repoId: 'targetRepo' }));
+      mockContent.registerContentType('http://type', 'type', 'targetRepo');
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/import/folder/',
+        mapFile: 'temp/import/folder.json',
+        baseFolder: 'targetFolder'
+      };
+      await handler(argv);
+
+      // Check items were created appropriately.
+
+      const matches = await mockContent.filterMatch(templates, 'targetFolder', false);
+
+      expect(matches.length).toEqual(templates.length);
+
+      await rimraf('temp/import/folder/');
+    });
+
+    it('Folder structure recreation should work with existing, matching folders present without creating more.', async () => {
+      // Create content to import.
+
+      const templates: ItemTemplate[] = [
+        { label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type' },
+        { label: 'item2', repoId: 'repo', typeSchemaUri: 'http://type2', folderPath: 'folderTest' },
+        { label: 'item3', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest' },
+        { label: 'item4exists', repoId: 'repo', typeSchemaUri: 'http://type2', folderPath: 'folderTest/exists' },
+        { label: 'item5exists', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/exists/nested' },
+        { label: 'item6doesnt', repoId: 'repo', typeSchemaUri: 'http://type2', folderPath: 'folderTest/doesnt' },
+        { label: 'item7doesnt', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/doesnt/nested' }
+      ];
+
+      await createContent('temp/import/folder2/', templates, false);
+
+      const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+      mockContent.createMockRepository('targetRepo');
+
+      const baseFolder = mockContent.createFolder(
+        new Folder({ name: 'targetFolder', id: 'targetFolder', repoId: 'targetRepo' })
+      );
+      const folderTest = await baseFolder.related.folders.create(
+        new Folder({ name: 'folderTest', id: 'folderTest', repoId: 'targetRepo' })
+      );
+      const exists = await folderTest.related.folders.create(
+        new Folder({ name: 'exists', id: 'exists', repoId: 'targetRepo' })
+      );
+      await exists.related.folders.create(new Folder({ name: 'nested', id: 'nested', repoId: 'targetRepo' }));
+
+      mockContent.registerContentType('http://type', 'type', 'targetRepo');
+      mockContent.registerContentType('http://type2', 'type2', 'targetRepo');
+
+      mockContent.metrics.reset();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/import/folder2/',
+        mapFile: 'temp/import/folder2.json',
+        baseFolder: 'targetFolder'
+      };
+      await handler(argv);
+
+      // Only created the two folders "folderTest/doesnt" and "folderTest/doesnt/nested".
+      expect(mockContent.metrics.foldersCreated).toEqual(2);
+
+      // Check items were created appropriately.
+      const matches = await mockContent.filterMatch(templates, 'targetFolder', false);
+
+      expect(matches.length).toEqual(templates.length);
+
+      await rimraf('temp/import/folder2/');
+    });
+
+    // == INTERACTIVE PROMPT TESTS ==
+    it('Importing with no base should map all folders in the import root to existing repositories, then recreate folder structures within them.', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      // Create content to import.
+
+      const templates: ItemTemplate[] = [
+        { label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type' },
+        { label: 'item2', repoId: 'repo', typeSchemaUri: 'http://type2', folderPath: 'folderTest' },
+        { label: 'item3', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest' },
+        { label: 'item4', repoId: 'repo', typeSchemaUri: 'http://type2', folderPath: 'folderTest/nested' },
+
+        { label: 'item1', repoId: 'repo2', typeSchemaUri: 'http://type' },
+        { label: 'item2', repoId: 'repo2', typeSchemaUri: 'http://type2', folderPath: 'folderTest' },
+        { label: 'item3', repoId: 'repo2', typeSchemaUri: 'http://type', folderPath: 'folderTest' },
+        { label: 'item4', repoId: 'repo2', typeSchemaUri: 'http://type3', folderPath: 'folderTest/special' }
+      ];
+
+      await createContent('temp/import/all/', templates, true);
+
+      const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+      mockContent.createMockRepository('repo');
+      mockContent.createMockRepository('repo2');
+
+      mockContent.registerContentType('http://type', 'type', ['repo', 'repo2']);
+      mockContent.registerContentType('http://type2', 'type2', ['repo', 'repo2']);
+      mockContent.registerContentType('http://type3', 'type3', 'repo2');
+
+      mockContent.metrics.reset();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/import/all/',
+        mapFile: 'temp/import/all.json'
+      };
+      await handler(argv);
+
+      // Created a folder and a nested one in both repositories.
+      expect(mockContent.metrics.foldersCreated).toEqual(4);
+
+      // Check items were created appropriately.
+      const matches = await mockContent.filterMatch(templates, '', true);
+
+      expect(matches.length).toEqual(templates.length);
+
+      await rimraf('temp/import/all/');
+    });
+
+    it('Importing content with no base and a missing repository name will request that it be skipped (then skip it)', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      // Create content to import.
+
+      const skipped: ItemTemplate[] = [
+        // Repo 1 is missing, these should not be created.
+        { label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type' },
+        { label: 'item2', repoId: 'repo', typeSchemaUri: 'http://type2', folderPath: 'folderTest' },
+        { label: 'item3', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest' },
+        { label: 'item4', repoId: 'repo', typeSchemaUri: 'http://type2', folderPath: 'folderTest/nested' }
+      ];
+
+      const added: ItemTemplate[] = [
+        { label: 'item5', repoId: 'repo2', typeSchemaUri: 'http://type' },
+        { label: 'item6', repoId: 'repo2', typeSchemaUri: 'http://type2', folderPath: 'folderTest' },
+        { label: 'item7', repoId: 'repo2', typeSchemaUri: 'http://type', folderPath: 'folderTest' },
+        { label: 'item8', repoId: 'repo2', typeSchemaUri: 'http://type3', folderPath: 'folderTest/special' }
+      ];
+
+      await createContent('temp/import/repoMissing/', skipped.concat(added), true);
+
+      const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+      mockContent.createMockRepository('repo2');
+
+      mockContent.registerContentType('http://type', 'type', ['repo', 'repo2']);
+      mockContent.registerContentType('http://type2', 'type2', ['repo', 'repo2']);
+      mockContent.registerContentType('http://type3', 'type3', 'repo2');
+
+      mockContent.metrics.reset();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/import/repoMissing/',
+        mapFile: 'temp/import/repoMissing.json'
+      };
+      await handler(argv);
+
+      // Created a base folder and a nested one. One repository was skipped.
+      expect(mockContent.metrics.foldersCreated).toEqual(2);
+
+      // Check items were created appropriately.
+      const matches = await mockContent.filterMatch(added, '', true);
+
+      expect(matches.length).toEqual(added.length); // Only created the items that weren't skipped.
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((readline as any).responsesLeft()).toEqual(0); // All responses consumed.
+
+      await rimraf('temp/import/repoMissing/');
+    });
+
+    it('Importing content with a missing content type (but not schema) will request that the content type be created (then create it)', async () => {
+      // Asks if we want to create the types, then asks if we want to assign them.
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y', 'y']);
+
+      // Create content to import
+
+      const templates: ItemTemplate[] = [
+        { label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type' },
+        { label: 'item2', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest' },
+        { label: 'item3', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest' },
+        { label: 'item4', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' }
+      ];
+
+      await createContent('temp/import/missingType/', templates, false);
+
+      const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+      mockContent.createMockRepository('targetRepo');
+      mockContent.registerContentType('http://type', 'n/a', 'targetRepo', undefined, true);
+
+      expect(mockContent.typeById.get('type')).toBeUndefined();
+
+      mockContent.metrics.reset();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/import/missingType/',
+        mapFile: 'temp/import/missingType.json',
+        baseRepo: 'targetRepo'
+      };
+      await handler(argv);
+
+      // Check items were created appropriately.
+
+      const matches = await mockContent.filterMatch(templates, '', false);
+
+      // Type should be created.
+      expect(mockContent.metrics.typesCreated).toEqual(1);
+      expect((mockContent.typeById.values().next().value as ContentType).contentTypeUri).toEqual('http://type');
+
+      expect(matches.length).toEqual(templates.length);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((readline as any).responsesLeft()).toEqual(0); // All responses consumed.
+
+      await rimraf('temp/import/missingType/');
+    });
+
+    it('Importing content with a missing content type schema will ask if the affected content should be skipped (then create unaffected content)', async () => {
+      // Asks if we want to skip the missing type schema.
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      // Create content to import
+
+      const skipped: ItemTemplate[] = [
+        // Repo 1 is missing, these should not be created.
+        { label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type' },
+        { label: 'item2', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest' },
+        { label: 'item3', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest' },
+        { label: 'item4', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' }
+      ];
+
+      const added: ItemTemplate[] = [
+        { label: 'item5', repoId: 'repo', typeSchemaUri: 'http://type2' },
+        { label: 'item6', repoId: 'repo', typeSchemaUri: 'http://type2', folderPath: 'folderTest' },
+        { label: 'item7', repoId: 'repo', typeSchemaUri: 'http://type2', folderPath: 'folderTest' },
+        { label: 'item8', repoId: 'repo', typeSchemaUri: 'http://type2', folderPath: 'folderTest/special' }
+      ];
+
+      await createContent('temp/import/missingSchema/', skipped.concat(added), false);
+
+      const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+      mockContent.createMockRepository('targetRepo');
+      mockContent.registerContentType('http://type2', 'type2', 'targetRepo');
+
+      expect(
+        Array.from(mockContent.typeSchemaById.values()).find(schema => schema.id === 'http://type')
+      ).toBeUndefined();
+      expect(mockContent.typeById.get('type')).toBeUndefined();
+
+      mockContent.metrics.reset();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/import/missingSchema/',
+        mapFile: 'temp/import/missingSchema.json',
+        baseRepo: 'targetRepo'
+      };
+      await handler(argv);
+
+      // Check items were created appropriately.
+
+      const matches = await mockContent.filterMatch(added, '', false);
+
+      expect(matches.length).toEqual(added.length);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((readline as any).responsesLeft()).toEqual(0); // All responses consumed.
+
+      await rimraf('temp/import/missingSchema/');
+    });
+
+    function genContentTypeWithReference(
+      typeName: string,
+      refTypeName: string,
+      ids: string[],
+      isLink: boolean
+    ): { type: object; body: object } {
+      const type = {
+        $schema: 'http://bigcontent.io/cms/schema/v1/schema#',
+        id: typeName,
+
+        title: 'Example content type',
+        description: 'With a ref/link',
+
+        allOf: [
+          {
+            $ref: 'http://bigcontent.io/cms/schema/v1/core#/definitions/content'
+          }
+        ],
+
+        propertyOrder: ['referenceList'],
+
+        type: 'object',
+        properties: {
+          referenceList: {
+            type: 'array',
+            items: {
+              allOf: [
+                {
+                  $ref: `http://bigcontent.io/cms/schema/v1/core#/definitions/content-${isLink ? 'link' : 'reference'}`
+                },
+                {
+                  properties: {
+                    contentType: {
+                      title: 'Content Types',
+                      enum: [refTypeName]
+                    }
+                  }
+                }
+              ]
+            },
+            title: 'Content Type',
+            description: ''
+          }
+        }
+      };
+
+      const body = {
+        referenceList: [
+          ids.map(id => ({
+            _meta: {
+              schema: `http://bigcontent.io/cms/schema/v1/core#/definitions/content-${isLink ? 'link' : 'reference'}`
+            },
+            contentType: refTypeName,
+            id: id
+          }))
+        ]
+      };
+
+      return { type, body };
+    }
+
+    it('Importing content with cross reference to a content item that exists only in the mapping should work without question', async () => {
+      // Everything is in place - should not ask user any questions.
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses([]);
+
+      // Create content to import
+
+      const oldTemplates: ItemTemplate[] = [
+        { id: 'new1', label: 'item1', repoId: 'repo', typeSchemaUri: 'http://refType' },
+        { id: 'new2', label: 'item2', repoId: 'repo', typeSchemaUri: 'http://refType', folderPath: 'folderTest' }
+      ];
+
+      const item3 = genContentTypeWithReference('http://typeThatReferences', 'http://refType', ['ref1', 'ref2'], true);
+      const item4 = genContentTypeWithReference('http://typeThatLinks', 'http://refType', ['ref2'], true);
+
+      const templates: ItemTemplate[] = [
+        {
+          id: 'new3',
+          label: 'item3',
+          repoId: 'repo',
+          typeSchemaUri: 'http://typeThatReferences',
+          folderPath: 'folderTest',
+          body: item3.body
+        },
+        {
+          id: 'new4',
+          label: 'item4',
+          repoId: 'repo',
+          typeSchemaUri: 'http://typeThatLinks',
+          folderPath: 'folderTest/nested',
+          body: item4.body
+        },
+        { id: 'new5', label: 'item5', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' }
+      ];
+
+      await createContent('temp/import/ref/', templates, false);
+
+      // Add an existing mapping for the two items in "oldTemplates".
+      const existingMapping = { contentItems: [['ref1', 'new1'], ['ref2', 'new2']] };
+      await ensureDirectoryExists('temp/import/ref/');
+      await rimraf('temp/import/ref.json');
+      await promisify(writeFile)('temp/import/ref.json', JSON.stringify(existingMapping));
+
+      const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+      mockContent.createMockRepository('repo');
+      mockContent.registerContentType('http://type', 'type', 'repo');
+      mockContent.registerContentType('http://typeThatReferences', 'typeTRef', 'repo', item3.type);
+      mockContent.registerContentType('http://typeThatLinks', 'typeTLink', 'repo', item4.type);
+      mockContent.registerContentType('http://refType', 'refType', 'repo');
+      mockContent.importItemTemplates(oldTemplates);
+
+      mockContent.metrics.reset();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/import/ref/',
+        mapFile: 'temp/import/ref.json',
+        baseRepo: 'repo'
+      };
+      await handler(argv);
+
+      // Check items exist.
+
+      const matches = await mockContent.filterMatch(templates.concat(oldTemplates), '', false);
+
+      expect(matches.length).toEqual(5);
+
+      // Make sure that only two were created
+
+      expect(mockContent.metrics.itemsCreated).toEqual(3);
+      expect(mockContent.metrics.itemsUpdated).toEqual(0);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((readline as any).responsesLeft()).toEqual(0); // All responses consumed.
+
+      await rimraf('temp/import/ref/');
+    });
+
+    it('Importing content with missing cross references should ask if the user wants to continue (and skip all dependant items)', async () => {
+      // Everything is in place - should not ask user any questions.
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      // Create content to import
+
+      const item3 = genContentTypeWithReference('http://typeThatReferences', 'http://refType', ['ref1', 'ref2'], true);
+      const item4 = genContentTypeWithReference('http://typeThatLinks', 'http://refType', ['ref2'], true);
+
+      const templates: ItemTemplate[] = [
+        { id: 'new5', label: 'item5', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' }
+      ];
+
+      const skips: ItemTemplate[] = [
+        {
+          id: 'new3',
+          label: 'item3',
+          repoId: 'repo',
+          typeSchemaUri: 'http://typeThatReferences',
+          folderPath: 'folderTest',
+          body: item3.body
+        },
+        {
+          id: 'new4',
+          label: 'item4',
+          repoId: 'repo',
+          typeSchemaUri: 'http://typeThatLinks',
+          folderPath: 'folderTest/nested',
+          body: item4.body
+        }
+      ];
+
+      await createContent('temp/import/refMissing/', templates.concat(skips), false);
+
+      // Add an existing mapping for the two items in "oldTemplates".
+      await ensureDirectoryExists('temp/import/refMissing/');
+      await rimraf('temp/import/refMissing.json');
+
+      const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+      mockContent.createMockRepository('repo');
+      mockContent.registerContentType('http://type', 'type', 'repo');
+      mockContent.registerContentType('http://typeThatReferences', 'typeTRef', 'repo', item3.type);
+      mockContent.registerContentType('http://typeThatLinks', 'typeTLink', 'repo', item4.type);
+      mockContent.registerContentType('http://refType', 'refType', 'repo');
+
+      mockContent.metrics.reset();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/import/refMissing/',
+        mapFile: 'temp/import/refMissing.json',
+        baseRepo: 'repo'
+      };
+      await handler(argv);
+
+      // Check items exist.
+
+      const matches = await mockContent.filterMatch(templates, '', false);
+
+      expect(matches.length).toEqual(1);
+
+      // Make sure that only two were created
+
+      expect(mockContent.metrics.itemsCreated).toEqual(1);
+      expect(mockContent.metrics.itemsUpdated).toEqual(0);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((readline as any).responsesLeft()).toEqual(0); // All responses consumed.
+
+      await rimraf('temp/import/refMissing/');
+    });
+
+    it('Importing content with an existing mapping should ask if the user wants to overwrite existing content items (then overwrite it)', async () => {
+      // Asks if we want to overwrite existing rather than skip.
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      // Create content to import
+
+      const oldTemplates: ItemTemplate[] = [
+        { id: 'old1', label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type' },
+        { id: 'old2', label: 'item2', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest' }
+      ];
+
+      const newTemplates = oldTemplates.map(old => ({ ...old, id: 'new' + (old.id as string)[3] }));
+
+      const templates: ItemTemplate[] = [
+        { id: 'old3', label: 'item3', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest' },
+        { id: 'old4', label: 'item4', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' }
+      ];
+
+      oldTemplates.forEach(template => (template.label += 'updated')); // Should update existing content with this new label.
+
+      await createContent('temp/import/mapping/', oldTemplates.concat(templates), false);
+
+      // Add an existing mapping for the two items in "oldTemplates".
+      const existingMapping = { contentItems: [['old1', 'new1'], ['old2', 'new2']] };
+      await ensureDirectoryExists('temp/import/mapping/');
+      await rimraf('temp/import/mapping.json');
+      await promisify(writeFile)('temp/import/mapping.json', JSON.stringify(existingMapping));
+
+      const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+      mockContent.createMockRepository('repo');
+      mockContent.registerContentType('http://type', 'type', 'repo');
+      mockContent.importItemTemplates(newTemplates);
+
+      mockContent.metrics.reset();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/import/mapping/',
+        mapFile: 'temp/import/mapping.json',
+        baseRepo: 'repo'
+      };
+      await handler(argv);
+
+      // Check items exist. They should have been updated too.
+
+      newTemplates.forEach(template => (template.label += 'updated')); // Should update existing content with this new label.
+
+      const matches = await mockContent.filterMatch(templates.concat(newTemplates), '', false);
+
+      expect(matches.length).toEqual(4);
+
+      // Make sure that only two were created
+
+      expect(mockContent.metrics.itemsCreated).toEqual(2);
+      expect(mockContent.metrics.itemsUpdated).toEqual(2);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((readline as any).responsesLeft()).toEqual(0); // All responses consumed.
+
+      await rimraf('temp/import/mapping/');
+    });
+
+    it('Importing with the `force` flag should not ever await a response, and should skip and automate changes where necessary', async () => {
+      // Everything ever should go wrong... but by forcing through it we will not be asked for anything.
+
+      // - Overwrites based on existing mapping
+      // - Automatically skips content with missing schema
+      // - Automatically creates missing content types
+      // - Automatically assigns content types
+      // - Skips content from repositories that don't exist
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses([]);
+
+      // Create content to import
+
+      const oldTemplates: ItemTemplate[] = [
+        { id: 'old1', label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type' },
+        { id: 'old2', label: 'item2', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest' }
+      ];
+
+      const newTemplates = oldTemplates.map(old => ({ ...old, id: 'new' + (old.id as string)[3] }));
+
+      const templates: ItemTemplate[] = [
+        { id: 'old3', label: 'item3', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest' },
+        { id: 'old4', label: 'item4', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' },
+
+        // Schema without type
+        {
+          id: 'type6',
+          label: 'item6',
+          repoId: 'repo',
+          typeSchemaUri: 'http://typeCreate',
+          folderPath: 'folderTest/nested'
+        },
+
+        // Schema+type that needs assignment
+        {
+          id: 'assign7',
+          label: 'item7',
+          repoId: 'repo',
+          typeSchemaUri: 'http://typeAssign',
+          folderPath: 'folderTest/nested'
+        }
+      ];
+
+      const skips: ItemTemplate[] = [
+        // Missing schema (to be skipped)
+        {
+          id: 'skip5',
+          label: 'item5',
+          repoId: 'repo',
+          typeSchemaUri: 'http://typeMissing',
+          folderPath: 'folderTest/nested'
+        },
+
+        // Missing repo (to be skipped)
+        { id: 'skip8', label: 'item8', repoId: 'repoMissing', typeSchemaUri: 'http://type', folderPath: '' }
+      ];
+
+      oldTemplates.forEach(template => (template.label += 'updated')); // Should update existing content with this new label.
+
+      await createContent('temp/import/force/', skips.concat(oldTemplates.concat(templates)), true);
+
+      // Add an existing mapping for the two items in "oldTemplates".
+      const existingMapping = { contentItems: [['old1', 'new1'], ['old2', 'new2']] };
+      await ensureDirectoryExists('temp/import/force/');
+      await rimraf('temp/import/force.json');
+      await promisify(writeFile)('temp/import/force.json', JSON.stringify(existingMapping));
+
+      const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+      mockContent.createMockRepository('repo');
+      mockContent.registerContentType('http://type', 'type', 'repo');
+      mockContent.importItemTemplates(newTemplates);
+
+      // Type must be created (and assigned)
+      mockContent.registerContentType('http://typeCreate', 'typeCreate', [], undefined, true);
+
+      // Type must be assigned
+      mockContent.registerContentType('http://typeAssign', 'typeAssign', [], undefined, false);
+
+      mockContent.metrics.reset();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        force: true,
+        dir: 'temp/import/force/',
+        mapFile: 'temp/import/force.json'
+      };
+      await handler(argv);
+
+      // Check items exist. They should have been updated too.
+
+      newTemplates.forEach(template => (template.label += 'updated')); // Should update existing content with this new label.
+
+      const matches = await mockContent.filterMatch(templates.concat(newTemplates), '', true);
+
+      expect(matches.length).toEqual(6);
+
+      // Make sure that only two were created
+
+      expect(mockContent.metrics.itemsCreated).toEqual(4);
+      expect(mockContent.metrics.itemsUpdated).toEqual(2);
+      expect(mockContent.metrics.typesCreated).toEqual(1);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((readline as any).responsesLeft()).toEqual(0); // All responses consumed.
+
+      await rimraf('temp/import/force/');
+    });
+  });
+});

--- a/src/commands/content-item/import.spec.ts
+++ b/src/commands/content-item/import.spec.ts
@@ -675,7 +675,8 @@ describe('content-item import command', () => {
         ...config,
         dir: 'temp/import/refMissing/',
         mapFile: 'temp/import/refMissing.json',
-        baseRepo: 'repo'
+        baseRepo: 'repo',
+        skipIncomplete: true
       };
       await handler(argv);
 

--- a/src/commands/content-item/import.spec.ts
+++ b/src/commands/content-item/import.spec.ts
@@ -1,4 +1,4 @@
-import { builder, command, handler } from './import';
+import { builder, command, handler, LOG_FILENAME } from './import';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
 import { Folder, ContentType } from 'dc-management-sdk-js';
 import Yargs from 'yargs/yargs';
@@ -73,6 +73,18 @@ describe('content-item import command', () => {
         type: 'boolean',
         boolean: true,
         describe: 'Only recreate folder structure - content is validated but not imported.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('skipIncomplete', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'Skip any content items that has one or more missing dependancy.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('logFile', {
+        type: 'string',
+        default: LOG_FILENAME,
+        describe: 'Path to a log file to write to.'
       });
     });
   });
@@ -847,6 +859,8 @@ describe('content-item import command', () => {
         ...yargArgs,
         ...config,
         force: true,
+        skipIncomplete: true, // Make it easier to detect that "yes" was said to the dependancy question
+
         dir: 'temp/import/force/',
         mapFile: 'temp/import/force.json'
       };

--- a/src/commands/content-item/import.spec.ts
+++ b/src/commands/content-item/import.spec.ts
@@ -1,4 +1,8 @@
-import { builder, command, handler, LOG_FILENAME } from './import';
+import { builder, command, handler, LOG_FILENAME, getDefaultMappingPath } from './import';
+import { dependsOn, dependantType } from './__mocks__/dependant-content-helper';
+import * as reverter from './import-revert';
+import * as publish from '../../common/import/publish-queue';
+import { getDefaultLogPath } from '../../common/log-helpers';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
 import { Folder, ContentType } from 'dc-management-sdk-js';
 import Yargs from 'yargs/yargs';
@@ -12,7 +16,10 @@ import { ensureDirectoryExists } from '../../common/import/directory-utils';
 import { MockContent, ItemTemplate } from '../../common/dc-management-sdk-js/mock-content';
 
 jest.mock('readline');
+jest.mock('./import-revert');
 jest.mock('../../services/dynamic-content-client-factory');
+jest.mock('../../common/import/publish-queue');
+jest.mock('../../common/log-helpers');
 
 function rimraf(dir: string): Promise<Error> {
   return new Promise((resolve): void => {
@@ -27,6 +34,16 @@ describe('content-item import command', () => {
 
   it('should command should defined', function() {
     expect(command).toEqual('import <dir>');
+  });
+
+  it('should use getDefaultLogPath for LOG_FILENAME with process.platform as default', function() {
+    LOG_FILENAME();
+
+    expect(getDefaultLogPath).toHaveBeenCalledWith('item', 'import', process.platform);
+  });
+
+  it('should generate a default mapping path containing the given name', function() {
+    expect(getDefaultMappingPath('hub-1').indexOf('hub-1')).not.toEqual(-1);
   });
 
   describe('builder tests', function() {
@@ -81,6 +98,19 @@ describe('content-item import command', () => {
         describe: 'Skip any content items that has one or more missing dependancy.'
       });
 
+      expect(spyOption).toHaveBeenCalledWith('publish', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'Publish any content items that have an existing publish status in their JSON.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('republish', {
+        type: 'boolean',
+        boolean: true,
+        describe:
+          'Republish content items regardless of whether the import changed them or not. (--publish not required)'
+      });
+
       expect(spyOption).toHaveBeenCalledWith('logFile', {
         type: 'string',
         default: LOG_FILENAME,
@@ -101,10 +131,15 @@ describe('content-item import command', () => {
       hubId: 'hub-id'
     };
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       jest.mock('readline');
       jest.mock('../../services/dynamic-content-client-factory');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const calls = (publish as any).publishCalls;
+      calls.splice(0, calls.length);
+    });
 
+    beforeAll(async () => {
       await rimraf('temp/import/');
     });
 
@@ -146,6 +181,9 @@ describe('content-item import command', () => {
           label: item.label,
           contentRepositoryId: item.repoId,
           folderId: folderId,
+          locale: item.locale,
+          lastPublishedVersion: item.lastPublishedVersion,
+
           body: {
             _meta: {
               schema: item.typeSchemaUri
@@ -158,6 +196,9 @@ describe('content-item import command', () => {
 
         await promisify(writeFile)(path, jsonString);
       }
+
+      // Create a dummy file, which should not be imported in any tests.
+      await promisify(writeFile)(join(baseFolder, 'dummy'), 'don\t import me');
     }
 
     // == FUNCTIONALITY TESTS ==
@@ -167,7 +208,7 @@ describe('content-item import command', () => {
       const templates: ItemTemplate[] = [
         { label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type' },
         { label: 'item2', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest' },
-        { label: 'item3', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest' },
+        { label: 'item3', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest', locale: 'en-us' },
         { label: 'item4', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' }
       ];
 
@@ -191,6 +232,7 @@ describe('content-item import command', () => {
       const matches = await mockContent.filterMatch(templates, '', false);
 
       expect(matches.length).toEqual(templates.length);
+      expect(mockContent.metrics.itemsLocaleSet).toEqual(1);
 
       await rimraf('temp/import/repo/');
     });
@@ -954,6 +996,9 @@ describe('content-item import command', () => {
 
       await ensureDirectoryExists('temp/import/netError/');
 
+      const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+      mockContent.failHubGet = true;
+
       // First run: can't get hub.
       const argv0 = {
         ...yargArgs,
@@ -964,9 +1009,8 @@ describe('content-item import command', () => {
       expect(await handler(argv0)).toBeFalsy();
 
       // Other runs: everything but hub fails.
-
-      const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
-      mockContent.failHubList = true;
+      mockContent.failHubGet = false;
+      mockContent.failRepoList = true;
 
       const argv1 = {
         ...yargArgs,
@@ -995,6 +1039,249 @@ describe('content-item import command', () => {
       expect(await handler(argv3)).toBeFalsy();
 
       await rimraf('temp/import/netError/');
+    });
+
+    it('should call import-revert if passed a revertLog', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses([]);
+
+      // First run: can't get hub.
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/import/unused/',
+        revertLog: 'log.txt'
+      };
+
+      expect(await handler(argv)).toBeTruthy();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((reverter as any).calls[0]).toEqual(argv);
+    });
+
+    it('should publish items when --publish is provided, and the items specify a last published version', async () => {
+      // Create content to import
+      // 3 out of 4 should publish. item2 publishes item3, so only 2 requests are made.
+
+      const templates: ItemTemplate[] = [
+        { label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type', lastPublishedVersion: 1 },
+        {
+          label: 'item2',
+          repoId: 'repo',
+          typeSchemaUri: 'http://type',
+          folderPath: 'folderTest',
+          lastPublishedVersion: 1,
+          body: dependsOn(['id3'])
+        },
+        {
+          id: 'id3',
+          label: 'item3',
+          repoId: 'repo',
+          typeSchemaUri: 'http://type',
+          folderPath: 'folderTest',
+          lastPublishedVersion: 1 // This item is implicitly published by item 2, so it should NOT be published separately.
+        },
+        { label: 'item4', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' }
+      ];
+
+      await createContent('temp/import/publish/', templates, false);
+
+      const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+      mockContent.createMockRepository('targetRepo');
+      mockContent.registerContentType('http://type', 'type', 'targetRepo');
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/import/publish/',
+        mapFile: 'temp/import/publish.json',
+        baseRepo: 'targetRepo',
+        publish: true
+      };
+      await handler(argv);
+
+      const matches = await mockContent.filterMatch(templates, '', false);
+
+      expect(matches.length).toEqual(templates.length);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((publish as any).publishCalls.length).toEqual(2);
+
+      await rimraf('temp/import/publish/');
+    });
+
+    const circularDependancies: ItemTemplate[] = [
+      { id: 'id1', label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type', body: dependsOn(['id2']) },
+      {
+        id: 'id2',
+        label: 'item2',
+        repoId: 'repo',
+        typeSchemaUri: 'http://type',
+        folderPath: 'folderTest',
+        body: dependsOn(['id1', 'id3']),
+        lastPublishedVersion: 1 // Test publishing a circular dependancy.
+      },
+      {
+        id: 'id3',
+        label: 'item3',
+        repoId: 'repo',
+        typeSchemaUri: 'http://type',
+        folderPath: 'folderTest',
+        body: dependsOn(['id2'])
+      },
+
+      // No dependancy.
+      { id: 'id4', label: 'item4', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' }
+    ];
+
+    it('should import circular dependancies by first creating, then updating them with appropriate ids', async () => {
+      // Create content to import
+
+      const templates = circularDependancies;
+
+      await createContent('temp/import/circular/', templates, false);
+
+      const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+      mockContent.createMockRepository('targetRepo');
+      mockContent.registerContentType('http://type', 'type', 'targetRepo');
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/import/circular/',
+        mapFile: 'temp/import/circular.json',
+        baseRepo: 'targetRepo',
+        publish: true
+      };
+      await handler(argv);
+
+      // check items were created appropriately
+
+      expect(mockContent.metrics.itemsCreated).toEqual(4);
+      expect(mockContent.metrics.itemsUpdated).toEqual(3);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((publish as any).publishCalls.length).toEqual(1); // One of the circular dependancies will be published.
+
+      const matches = await mockContent.filterMatch(templates, '', false);
+
+      expect(matches.length).toEqual(templates.length);
+
+      await rimraf('temp/import/circular/');
+    });
+
+    it('should not import any content if passed --validate', async () => {
+      const templates: ItemTemplate[] = [{ label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type' }];
+
+      await createContent('temp/import/validate/', templates, false);
+
+      const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+      mockContent.createMockRepository('targetRepo');
+      mockContent.registerContentType('http://type', 'type', 'targetRepo');
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/import/validate/',
+        mapFile: 'temp/import/validate.json',
+        baseRepo: 'targetRepo',
+        validate: true
+      };
+      await handler(argv);
+
+      // No items should have been created.
+      expect(mockContent.metrics.itemsCreated).toEqual(0);
+      expect(mockContent.metrics.itemsUpdated).toEqual(0);
+
+      await rimraf('temp/import/validate/');
+    });
+
+    it('should ask for imported dependancies to be nullified if they are missing, and then skipped if invalid', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const templates: ItemTemplate[] = [
+        { label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type', body: dependsOn(['idNotExist']) }
+      ];
+
+      await createContent('temp/import/depNull/', templates, false);
+
+      const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+      mockContent.createMockRepository('targetRepo');
+      mockContent.registerContentType('http://type', 'type', 'targetRepo', dependantType(1));
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/import/depNull/',
+        mapFile: 'temp/import/depNull.json',
+        baseRepo: 'targetRepo'
+      };
+      await handler(argv);
+
+      expect(mockContent.metrics.itemsCreated).toEqual(0);
+      expect(mockContent.metrics.itemsUpdated).toEqual(0);
+
+      await rimraf('temp/import/depNull/');
+    });
+
+    it('should abort when failing to create content', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses([]);
+
+      const templates: ItemTemplate[] = [{ label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type' }];
+
+      await createContent('temp/import/abort1/', templates, false);
+
+      const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+      mockContent.failRepoActions = 'create';
+      mockContent.createMockRepository('targetRepo');
+      mockContent.registerContentType('http://type', 'type', 'targetRepo');
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/import/abort1/',
+        mapFile: 'temp/import/abort1.json',
+        baseRepo: 'targetRepo',
+        publish: true
+      };
+      expect(await handler(argv)).toBeFalsy();
+
+      // check items were not created
+
+      expect(mockContent.metrics.itemsCreated).toEqual(0);
+
+      await rimraf('temp/import/abort1/');
+    });
+
+    it('should abort when failing to create content with a circular dependancy', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses([]);
+
+      const templates = circularDependancies.slice(0, 3);
+
+      await createContent('temp/import/abort2/', templates, false);
+
+      const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+      mockContent.failRepoActions = 'create';
+      mockContent.createMockRepository('targetRepo');
+      mockContent.registerContentType('http://type', 'type', 'targetRepo');
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/import/abort2/',
+        mapFile: 'temp/import/abort2.json',
+        baseRepo: 'targetRepo',
+        publish: true
+      };
+      expect(await handler(argv)).toBeFalsy();
+
+      // check items were not created
+
+      expect(mockContent.metrics.itemsCreated).toEqual(0);
+
+      await rimraf('temp/import/abort2/');
     });
   });
 });

--- a/src/commands/content-item/import.ts
+++ b/src/commands/content-item/import.ts
@@ -462,6 +462,8 @@ const prepareContentForImport = async (
       return null;
     }
 
+    invalidContentItems.forEach(item => console.log(`  ${item.owner.content.label}`));
+
     const ignore =
       force ||
       (await asyncQuestion(

--- a/src/commands/content-item/import.ts
+++ b/src/commands/content-item/import.ts
@@ -1,0 +1,735 @@
+import { Arguments, Argv } from 'yargs';
+import { ConfigurationParameters } from '../configure';
+import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
+import { dirname, basename, join, relative, resolve, extname } from 'path';
+
+import { lstat, readdir, readFile } from 'fs';
+import { promisify } from 'util';
+import { ImportItemBuilderOptions } from '../../interfaces/import-item-builder-options.interface';
+import paginator from '../../common/dc-management-sdk-js/paginator';
+import {
+  ContentItem,
+  Folder,
+  DynamicContent,
+  Hub,
+  ContentRepository,
+  ContentType,
+  ContentTypeSchema
+} from 'dc-management-sdk-js';
+import { ContentMapping } from '../../common/content-item/content-mapping';
+import { ContentDependancyTree, RepositoryContentItem } from '../../common/content-item/content-dependancy-tree';
+
+import { asyncQuestion } from '../../common/archive/archive-helpers';
+import { repeat } from 'lodash';
+
+export function getDefaultMappingPath(name: string, platform: string = process.platform): string {
+  return join(
+    process.env[platform == 'win32' ? 'USERPROFILE' : 'HOME'] || __dirname,
+    '.amplience',
+    `imports/`,
+    `${name}.json`
+  );
+}
+
+export const command = 'import <dir>';
+
+export const desc = 'Import content items';
+
+export const builder = (yargs: Argv): void => {
+  yargs
+    .positional('dir', {
+      describe:
+        'Directory containing content items to import. If this points to an export manifest, we will try and import the content with the same absolute path and repositories as the export.',
+      type: 'string',
+      requiresArg: true
+    })
+
+    .option('baseRepo', {
+      type: 'string',
+      describe:
+        'Import matching the given repository to the import base directory, by ID. Folder structure will be followed and replicated from there.'
+    })
+
+    .option('baseFolder', {
+      type: 'string',
+      describe:
+        'Import matching the given folder to the import base directory, by ID. Folder structure will be followed and replicated from there.'
+    })
+
+    .option('mapFile', {
+      type: 'string',
+      describe:
+        'Mapping file to use when updating content that already exists. Updated with any new mappings that are generated. If not present, will be created.'
+    })
+
+    .alias('f', 'force')
+    .option('f', {
+      type: 'boolean',
+      boolean: true,
+      describe:
+        'Overwrite content, create and assign content types, and ignore content with missing types/references without asking.'
+    })
+
+    .alias('v', 'validate')
+    .option('v', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'Only recreate folder structure - content is validated but not imported.'
+    });
+};
+
+interface ImportContext {
+  client: DynamicContent;
+  hub: Hub;
+  repo: ContentRepository;
+  baseDir: string;
+  pathToFolderMap: Map<string, Promise<Folder | null>>;
+  folderToSubfolderMap: Map<string, Promise<Folder[]>>;
+  mapping: ContentMapping;
+  rootFolders: Folder[];
+}
+
+const getSubfolders = (context: ImportContext, folder: Folder): Promise<Folder[]> => {
+  if (context.folderToSubfolderMap.has(folder.id as string)) {
+    return context.folderToSubfolderMap.get(folder.id as string) as Promise<Folder[]>;
+  }
+
+  const subfolders = paginator(folder.related.folders.list);
+
+  context.folderToSubfolderMap.set(folder.id as string, subfolders);
+  return subfolders;
+};
+
+// eslint-disable-next-line prefer-const
+let getOrCreateFolderCached: (context: ImportContext, path: string) => Promise<Folder>;
+const getOrCreateFolder = async (context: ImportContext, rel: string): Promise<Folder> => {
+  try {
+    // Get the parent folder.
+    const parentPath = dirname(rel);
+
+    const parent = await getOrCreateFolderCached(context, resolve(context.baseDir, parentPath));
+
+    const folderInfo = {
+      name: basename(rel)
+    };
+
+    const container = parent == null ? context.rootFolders : await getSubfolders(context, parent);
+
+    let result = container.find(target => target.name === folderInfo.name);
+
+    const containerName = parent == null ? context.repo.label : parent.name;
+
+    if (result == null) {
+      if (parent == null) {
+        result = await context.repo.related.folders.create(new Folder(folderInfo));
+      } else {
+        result = await parent.related.folders.create(new Folder(folderInfo));
+      }
+
+      console.log(`Created folder in ${containerName}: '${rel}'.`);
+    } else {
+      console.log(`Found existing subfolder in ${containerName}: '${rel}'.`);
+    }
+
+    return result;
+  } catch (e) {
+    console.log(`Couldn't get or create folder ${rel}! ${e.toString()}`);
+    throw e;
+  }
+};
+
+getOrCreateFolderCached = async (context: ImportContext, path: string): Promise<Folder> => {
+  let rel = relative(context.baseDir, path);
+  if (rel === '') {
+    rel = '.';
+  }
+
+  if (context.pathToFolderMap.has(rel)) {
+    return await (context.pathToFolderMap.get(rel) as Promise<Folder>);
+  }
+
+  const resultPromise = getOrCreateFolder(context, rel);
+  context.pathToFolderMap.set(rel, resultPromise);
+
+  const result = await resultPromise;
+  return result;
+};
+
+const traverseRecursive = async (path: string, action: (path: string) => Promise<void>): Promise<void> => {
+  const dir = await promisify(readdir)(path);
+
+  await Promise.all(
+    dir.map(async (contained: string) => {
+      contained = join(path, contained);
+      const stat = await promisify(lstat)(contained);
+      return await (stat.isDirectory() ? traverseRecursive(contained, action) : action(contained));
+    })
+  );
+};
+
+const createOrUpdateContent = async (
+  client: DynamicContent,
+  repo: ContentRepository,
+  existing: string | ContentItem | null,
+  item: ContentItem
+): Promise<{ newItem: ContentItem; updated: boolean }> => {
+  let oldItem: ContentItem | null = null;
+  if (typeof existing === 'string') {
+    oldItem = await client.contentItems.get(existing);
+  } else {
+    oldItem = existing;
+  }
+
+  if (oldItem == null) {
+    return { newItem: await repo.related.contentItems.create(item), updated: false };
+  } else {
+    item.version = oldItem.version;
+    return { newItem: await oldItem.related.update(item), updated: true };
+  }
+};
+
+const trySaveMapping = async (mapFile: string | undefined, mapping: ContentMapping): Promise<void> => {
+  if (mapFile != null) {
+    try {
+      await mapping.save(mapFile);
+    } catch (e) {
+      console.log(`Failed to save the mapping. ${e.toString()}`);
+    }
+  }
+};
+
+const prepareContentForImport = async (
+  client: DynamicContent,
+  hub: Hub,
+  repos: { basePath: string; repo: ContentRepository }[],
+  folder: Folder | null,
+  mapping: ContentMapping,
+  force: boolean
+): Promise<ContentDependancyTree | null> => {
+  // traverse folder structure and find content items
+  // replicate relative path string in target repo/folder (create if does not exist)
+  // if there is an existing mapping (old id to new id), update the existing content (check all before beginning and ask user)
+  // otherwise create new
+
+  const contexts = new Map<ContentRepository, ImportContext>();
+  repos.forEach(repo => {
+    const pathToFolderMap: Map<string, Promise<Folder | null>> = new Map();
+
+    if (folder != null) {
+      pathToFolderMap.set('.', Promise.resolve(folder));
+    } else {
+      pathToFolderMap.set('.', Promise.resolve(null));
+    }
+
+    contexts.set(repo.repo, {
+      client,
+      hub,
+      repo: repo.repo,
+      pathToFolderMap,
+      baseDir: resolve(repo.basePath),
+      folderToSubfolderMap: new Map(),
+      mapping,
+      rootFolders: []
+    });
+  });
+
+  // Step 1: Prepare content for import. We traverse the input directory recursively and try to set up the directory structure on the repo.
+  //         This will result in list of content to put in target folders.
+
+  let contentItems: RepositoryContentItem[] = [];
+  const schemaNames = new Set<string>();
+
+  for (let i = 0; i < repos.length; i++) {
+    const repo = repos[i].repo;
+    const context = contexts.get(repo) as ImportContext;
+
+    try {
+      const folders = await paginator(repo.related.folders.list);
+
+      for (let j = 0; j < folders.length; j++) {
+        const folder = folders[j];
+
+        let parent: Folder | null = null;
+
+        try {
+          parent = await folder.related.folders.parent();
+        } catch {
+          // When there is no parent, this will throw.
+        }
+        if (parent == null) {
+          context.rootFolders.push(folder);
+        }
+      }
+    } catch (e) {
+      console.log(`Could not get base folders for repository ${repo.label}: ${e.toString()}`);
+      return null;
+    }
+
+    console.log(`Scanning structure and content in '${repos[i].basePath}' for repository '${repo.label}'...`);
+
+    await traverseRecursive(resolve(repos[i].basePath), async path => {
+      // Is this valid content? Must have extension .json to be considered, for a start.
+      if (extname(path) !== '.json') {
+        return;
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let contentJSON: any;
+      try {
+        const contentText = await promisify(readFile)(path, { encoding: 'utf8' });
+        contentJSON = JSON.parse(contentText);
+      } catch (e) {
+        console.log(`Couldn't read content item at '${path}': ${e.toString()}`);
+        return;
+      }
+
+      // Get the folder id via the mapping.
+      const folder = await getOrCreateFolderCached(context, dirname(path));
+
+      // Only filter relevant information - for example status and previous content repo are not useful.
+      const filteredContent = {
+        id: contentJSON.id,
+        label: contentJSON.label,
+        body: contentJSON.body,
+        deliveryId: contentJSON.deliveryId == contentJSON.Id ? undefined : contentJSON.deliveryId,
+        folderId: folder == null ? null : folder.id
+      };
+
+      schemaNames.add(contentJSON.body._meta.schema);
+
+      contentItems.push({ repo: repo, content: new ContentItem(filteredContent) });
+    });
+  }
+
+  console.log('Done. Validating content...');
+
+  const alreadyExists = contentItems.filter(item => mapping.getContentItem(item.content.id) != null);
+  if (alreadyExists.length > 0) {
+    const updateExisting =
+      force ||
+      (await asyncQuestion(
+        `${alreadyExists.length} of the items being imported already exist in the mapping. Would you like to update these content items instead of skipping them? (y/n) `
+      ));
+
+    if (!updateExisting) {
+      contentItems = contentItems.filter(item => mapping.getContentItem(item.content.id) == null);
+    }
+  }
+
+  // Step 2: Content Type Mapping.
+  // Find content types with matching schemas. If schemas are missing, we cannot continue.
+
+  let types: ContentType[];
+  let schemas: ContentTypeSchema[];
+  try {
+    types = await paginator(hub.related.contentTypes.list);
+    schemas = await paginator(hub.related.contentTypeSchema.list);
+  } catch (e) {
+    console.error(`Could not load content types: ${e.toString()}`);
+    return null;
+  }
+
+  const typesBySchema = new Map<string, ContentType>(types.map(type => [type.contentTypeUri as string, type]));
+
+  const missingTypes = Array.from(schemaNames).filter(name => {
+    return !typesBySchema.has(name);
+  });
+
+  if (missingTypes.length > 0) {
+    // Alert the user of missing content types.
+    // Can we create content types in the missing cases? (schema exists, not recommended)
+
+    const existing = schemas.filter(schema => missingTypes.indexOf(schema.schemaId as string) !== -1);
+
+    console.log('Required content types are missing from the target hub.');
+    if (existing.length > 0) {
+      console.log('The following required content types schemas exist, but do not exist as content types:');
+      existing.forEach(schema => {
+        console.log(`  ${schema.schemaId}`);
+      });
+      const create =
+        force ||
+        (await asyncQuestion(
+          'Content types can be automatically created for these schemas, but it is not recommended as they will have a default name and lack any configuration. Are you sure you wish to continue? (y/n) '
+        ));
+      if (!create) {
+        return null;
+      }
+
+      // Create the content types
+
+      for (let i = 0; i < existing.length; i++) {
+        const missing = existing[i];
+        let type = new ContentType({
+          contentTypeUri: missing.schemaId,
+          settings: { label: basename(missing.schemaId as string) } // basename on a URL is valid.
+        });
+        type = await hub.related.contentTypes.register(type);
+        types.push(type);
+        typesBySchema.set(missing.schemaId as string, type);
+      }
+    }
+  }
+
+  // Are the content types used by the content items assigned to their repository? If not, we can assign it ourselves.
+
+  const repom = new Map<ContentRepository, Set<ContentType>>();
+
+  contentItems.forEach(item => {
+    let repoSet = repom.get(item.repo);
+    if (repoSet == null) {
+      repoSet = new Set<ContentType>();
+      repom.set(item.repo, repoSet);
+    }
+
+    const type = typesBySchema.get(item.content.body._meta.schema);
+    if (type != null) {
+      repoSet.add(type);
+    }
+  });
+
+  const missingRepoAssignments: [ContentRepository, ContentType][] = [];
+  Array.from(repom).forEach(([repo, expectedTypes]) => {
+    // The repository must have each of the expected repo types.
+    const expectedTypesArray = Array.from(expectedTypes);
+
+    const missingTypes = expectedTypesArray.filter(
+      expectedType => (repo.contentTypes || []).find(type => type.hubContentTypeId == expectedType.id) == null
+    );
+    missingTypes.forEach(missingType => missingRepoAssignments.push([repo, missingType]));
+  });
+
+  if (missingRepoAssignments.length > 0) {
+    console.log('Some content items are using types incompatible with the target repository. Missing assignments:');
+    missingRepoAssignments.forEach(([repo, type]) => {
+      let label = '<no label>';
+      if (type.settings && type.settings.label) {
+        label = type.settings.label;
+      }
+      console.log(`  ${repo.label} - ${label} (${type.contentTypeUri})`);
+    });
+
+    const createAssignments =
+      force ||
+      (await asyncQuestion(
+        'These assignments will be created automatically. Are you sure you still wish to continue? (y/n) '
+      ));
+    if (!createAssignments) {
+      return null;
+    }
+
+    try {
+      await Promise.all(
+        missingRepoAssignments.map(([repo, type]) => repo.related.contentTypes.assign(type.id as string))
+      );
+    } catch (e) {
+      console.log(`Failed creating repo assignments. Error: ${e.toString()}`);
+      return null;
+    }
+  }
+
+  // Step 3: Track dependancies between content items and update them to match the new content ids.
+  //         To do this, we must insert content that is depended on before inserting the replacement.
+  //         Circular references cannot be resolved, so they should be handled by an insert with invalid id, then subsequent update.
+
+  const tree = new ContentDependancyTree(contentItems, mapping);
+
+  // Do all the content items that we depend on exist either in the mapping or in the items we're importing?
+  const missingIDs = new Set<string>();
+  const invalidContentItems = tree.filterAny(item => {
+    const missingDeps = item.dependancies.filter(
+      dep => !tree.byId.has(dep.dependancy.id as string) && mapping.getContentItem(dep.dependancy.id) == null
+    );
+    missingDeps.forEach(dep => {
+      if (dep.dependancy.id != null) {
+        missingIDs.add(dep.dependancy.id);
+      }
+    });
+    return missingDeps.length > 0;
+  });
+
+  if (invalidContentItems.length > 0) {
+    console.log('Required content items (targets of links/references) are missing from the import and mapping:');
+    missingIDs.forEach(id => console.log(`  ${id}`));
+    console.log(
+      `All items referencing these content items will be skipped. Note: if you have already imported these items before, make sure you are using a mapping file from that import.`
+    );
+
+    tree.removeContent(invalidContentItems);
+
+    if (tree.all.length === 0) {
+      console.log('No content remains after removing those with missing dependancies. Aborting.');
+      return null;
+    }
+
+    const ignore =
+      force ||
+      (await asyncQuestion(
+        `${invalidContentItems.length} out of ${contentItems.length} content items will be skipped. Are you sure you still wish to continue? (y/n) `
+      ));
+    if (!ignore) {
+      return null;
+    }
+  }
+
+  // Do all the content types that items use exist in the schema list?
+  const missingSchema = tree.requiredSchema.filter(
+    schemaId =>
+      schemas.findIndex(schema => schema.schemaId === schemaId) === -1 &&
+      types.findIndex(type => type.contentTypeUri === schemaId) === -1 // Can also exist with external schema.
+  );
+
+  if (missingSchema.length > 0) {
+    console.log('Required content type schema are missing from the target hub:');
+    missingSchema.forEach(schema => console.log(`  ${schema}`));
+    console.log(
+      'All content referencing this content type schema, and any content depending on those items will be skipped.'
+    );
+
+    const affectedContentItems = tree.filterAny(item => {
+      return missingSchema.indexOf(item.owner.content.body._meta.schema) !== -1;
+    });
+
+    // Ignore content items that use the required content type schema.
+    const beforeRemove = tree.all.length;
+    tree.removeContent(affectedContentItems);
+
+    if (tree.all.length === 0) {
+      console.log('No content remains after removing those with missing content type schemas. Aborting.');
+      return null;
+    }
+
+    const ignore =
+      force ||
+      (await asyncQuestion(
+        `${affectedContentItems.length} out of ${beforeRemove} content items will be skipped. Are you sure you still wish to continue? (y/n) `
+      ));
+    if (!ignore) {
+      return null;
+    }
+  }
+
+  console.log(
+    `Found ${tree.levels.length} dependancy levels in ${tree.all.length} items, ${tree.circularLinks.length} referencing a circular dependancy.`
+  );
+  console.log(`Importing ${tree.all.length} content items...`);
+
+  return tree;
+};
+
+const importTree = async (
+  client: DynamicContent,
+  tree: ContentDependancyTree,
+  mapping: ContentMapping
+): Promise<boolean> => {
+  const abort = (error: Error): void => {
+    console.log(`Importing content item failed, aborting. Error: ${error.toString()}`);
+  };
+
+  for (let i = 0; i < tree.levels.length; i++) {
+    const level = tree.levels[i];
+
+    for (let j = 0; j < level.items.length; j++) {
+      const item = level.items[j];
+      const content = item.owner.content;
+
+      // Replace any dependancies with the existing mapping.
+      item.dependancies.forEach(dep => {
+        dep.dependancy.id = mapping.getContentItem(dep.dependancy.id) || dep.dependancy.id;
+      });
+
+      const originalId = content.id;
+      content.id = mapping.getContentItem(content.id as string);
+
+      let newItem: ContentItem;
+      let updated: boolean;
+      try {
+        const result = await createOrUpdateContent(
+          client,
+          item.owner.repo,
+          mapping.getContentItem(originalId as string) || null,
+          content
+        );
+        newItem = result.newItem;
+        updated = result.updated;
+      } catch (e) {
+        console.log(`Failed creating ${content.label}.`);
+        abort(e);
+        return false;
+      }
+
+      console.log(`${updated ? 'Updated' : 'Created'} ${content.label}.`);
+      mapping.registerContentItem(originalId as string, newItem.id as string);
+    }
+  }
+
+  // Create circular dependancies with all the mappings we have, and update the mapping.
+  // Do a second pass that updates the existing assets to point to the new ones.
+  const newDependants: ContentItem[] = [];
+
+  for (let pass = 0; pass < 2; pass++) {
+    const mode = pass === 0 ? 'Creating' : 'Resolving';
+    console.log(`${mode} circular dependants.`);
+
+    for (let i = 0; i < tree.circularLinks.length; i++) {
+      const item = tree.circularLinks[i];
+      const content = item.owner.content;
+
+      item.dependancies.forEach(dep => {
+        dep.dependancy.id = mapping.getContentItem(dep.dependancy.id) || dep.dependancy.id;
+      });
+
+      const originalId = content.id;
+      content.id = mapping.getContentItem(content.id);
+
+      let newItem: ContentItem;
+      try {
+        const result = await createOrUpdateContent(
+          client,
+          item.owner.repo,
+          newDependants[i] || mapping.getContentItem(originalId as string),
+          content
+        );
+        newItem = result.newItem;
+      } catch (e) {
+        console.log(`Failed creating ${content.label}.`);
+        abort(e);
+        return false;
+      }
+
+      console.log(`Processed ${content.label}.`);
+
+      if (pass === 0) {
+        // New mappings are created in the first pass, they are only propagated in the second.
+        newDependants[i] = newItem;
+        mapping.registerContentItem(originalId as string, newItem.id as string);
+      }
+    }
+  }
+
+  console.log('Done!');
+  return true;
+};
+
+export const handler = async (argv: Arguments<ImportItemBuilderOptions & ConfigurationParameters>): Promise<void> => {
+  const { dir, baseRepo, baseFolder, validate } = argv;
+  const force = argv.force || false;
+  let { mapFile } = argv;
+
+  const client = dynamicContentClientFactory(argv);
+
+  let hub: Hub;
+  try {
+    hub = await client.hubs.get(argv.hubId);
+  } catch (e) {
+    console.error(`Couldn't get hub: ${e.toString()}`);
+    return;
+  }
+
+  let importTitle = 'unknownImport';
+  if (baseFolder != null) {
+    importTitle = `folder-${baseFolder}`;
+  } else if (baseRepo != null) {
+    importTitle = `repo-${baseRepo}`;
+  } else {
+    importTitle = `hub-${hub.id}`;
+  }
+
+  const mapping = new ContentMapping();
+  if (mapFile == null) {
+    mapFile = getDefaultMappingPath(importTitle);
+  }
+
+  if (mapping.load(mapFile)) {
+    console.log(`Existing mapping loaded from '${mapFile}', changes will be saved back to it.`);
+  } else {
+    console.log(`Creating new mapping file at '${mapFile}'.`);
+  }
+
+  let tree: ContentDependancyTree | null;
+  if (baseFolder != null) {
+    let repo: ContentRepository;
+    let folder: Folder;
+    try {
+      const bFolder = await client.folders.get(baseFolder);
+      repo = await bFolder.related.contentRepository();
+      folder = bFolder;
+    } catch (e) {
+      console.error(`Couldn't get base folder: ${e.toString()}`);
+      return;
+    }
+    tree = await prepareContentForImport(client, hub, [{ repo, basePath: dir }], folder, mapping, force);
+  } else if (baseRepo != null) {
+    let repo: ContentRepository;
+    try {
+      repo = await client.contentRepositories.get(baseRepo);
+    } catch (e) {
+      console.error(`Couldn't get base repository: ${e.toString()}`);
+      return;
+    }
+    tree = await prepareContentForImport(client, hub, [{ repo, basePath: dir }], null, mapping, force);
+  } else {
+    // Match repositories by label.
+    let repos: ContentRepository[];
+    try {
+      repos = await paginator(hub.related.contentRepositories.list);
+    } catch (e) {
+      console.log(`Couldn't get repositories: ${e.toString()}`);
+      return;
+    }
+
+    const baseDirContents = await promisify(readdir)(dir);
+    const importRepos: { basePath: string; repo: ContentRepository }[] = [];
+    const missingRepos: string[] = [];
+    for (let i = 0; i < baseDirContents.length; i++) {
+      const name = baseDirContents[i];
+      const path = join(dir, name);
+      const status = await promisify(lstat)(path);
+      if (status.isDirectory()) {
+        // does this folder map to a repository name?
+        const match = repos.find(repo => repo.label === name);
+        if (match) {
+          importRepos.push({ basePath: path, repo: match });
+        } else {
+          missingRepos.push(name);
+        }
+      }
+    }
+
+    if (missingRepos.length > 0) {
+      console.log(
+        "The following repositories must exist on the destination hub to import content into them, but don't:"
+      );
+      missingRepos.forEach(name => {
+        console.log(`  ${name}`);
+      });
+      if (importRepos.length > 0) {
+        const ignore =
+          force ||
+          (await asyncQuestion(
+            'These repositories will be skipped during the import, as they need to be added to the hub manually. Do you want to continue? (y/n) '
+          ));
+        if (!ignore) {
+          return;
+        }
+      }
+    }
+
+    if (importRepos.length == 0) {
+      console.log('Could not find any matching repositories to import into, aborting.');
+      return;
+    }
+
+    tree = await prepareContentForImport(client, hub, importRepos, null, mapping, force);
+  }
+
+  if (tree != null) {
+    if (!validate) {
+      await importTree(client, tree, mapping);
+    } else {
+      console.log('--validate was passed, so no content was imported.');
+    }
+  }
+
+  trySaveMapping(mapFile, mapping);
+};

--- a/src/commands/content-item/import.ts
+++ b/src/commands/content-item/import.ts
@@ -555,8 +555,7 @@ const prepareContentForImport = async (
       const mustSkip: ItemContentDependancies[] = [];
       await Promise.all(
         invalidContentItems.map(async item => {
-          tree.removeContentDependancies(
-            item.owner,
+          tree.removeContentDependanciesFromBody(
             item.owner.content.body,
             item.dependancies.map(dependancy => dependancy.dependancy)
           );

--- a/src/commands/content-item/import.ts
+++ b/src/commands/content-item/import.ts
@@ -26,7 +26,7 @@ import {
 } from '../../common/content-item/content-dependancy-tree';
 
 import { asyncQuestion } from '../../common/archive/archive-helpers';
-import { AmplienceSchemaValidator } from '../../common/content-item/amplience-schema-validator';
+import { AmplienceSchemaValidator, defaultSchemaLookup } from '../../common/content-item/amplience-schema-validator';
 import { getDefaultLogPath } from '../../common/log-helpers';
 import { PublishQueue } from '../../common/import/publish-queue';
 
@@ -550,7 +550,7 @@ const prepareContentForImport = async (
     if (skipIncomplete) {
       tree.removeContent(invalidContentItems);
     } else {
-      const validator = new AmplienceSchemaValidator(schemas);
+      const validator = new AmplienceSchemaValidator(defaultSchemaLookup(types, schemas));
 
       const mustSkip: ItemContentDependancies[] = [];
       await Promise.all(
@@ -767,7 +767,7 @@ const importTree = async (
 
     log.appendLine(`Waiting for all publishes to complete...`);
     await pubQueue.waitForAll();
-    
+
     log.appendLine(`Finished publishing, with ${pubQueue.failedJobs.length} failed publishes total.`);
     pubQueue.failedJobs.forEach(job => {
       log.appendLine(` - ${job.item.label}`);

--- a/src/commands/content-item/import.ts
+++ b/src/commands/content-item/import.ts
@@ -338,7 +338,6 @@ const prepareContentForImport = async (
         id: contentJSON.id,
         label: contentJSON.label,
         locale: contentJSON.locale,
-        workflow: contentJSON.workflow,
         body: contentJSON.body,
         deliveryId: contentJSON.deliveryId == contentJSON.Id ? undefined : contentJSON.deliveryId,
         folderId: folder == null ? null : folder.id,

--- a/src/commands/content-item/import.ts
+++ b/src/commands/content-item/import.ts
@@ -767,7 +767,11 @@ const importTree = async (
 
     log.appendLine(`Waiting for all publishes to complete...`);
     await pubQueue.waitForAll();
+    
     log.appendLine(`Finished publishing, with ${pubQueue.failedJobs.length} failed publishes total.`);
+    pubQueue.failedJobs.forEach(job => {
+      log.appendLine(` - ${job.item.label}`);
+    });
   }
 
   log.appendLine('Done!');

--- a/src/commands/content-type-schema/__mocks__/readline.ts
+++ b/src/commands/content-type-schema/__mocks__/readline.ts
@@ -3,6 +3,7 @@ let responseQueue: string[] = [];
 module.exports = {
   createInterface: jest.fn().mockReturnValue({
     question: jest.fn().mockImplementation((questionText, cb) => {
+      console.log(questionText);
       if (responseQueue.length == 0) {
         throw new Error('Too many responses given.');
       }

--- a/src/commands/content-type-schema/archive.ts
+++ b/src/commands/content-type-schema/archive.ts
@@ -5,8 +5,9 @@ import dynamicContentClientFactory from '../../services/dynamic-content-client-f
 import { ArchiveLog } from '../../common/archive/archive-log';
 import paginator from '../../common/dc-management-sdk-js/paginator';
 import { equalsOrRegex } from '../../common/filter/filter';
-import { getDefaultLogPath, confirmArchive } from '../../common/archive/archive-helpers';
+import { confirmArchive } from '../../common/archive/archive-helpers';
 import ArchiveOptions from '../../common/archive/archive-options';
+import { getDefaultLogPath } from '../../common/log-helpers';
 
 export const command = 'archive [id]';
 

--- a/src/commands/content-type-schema/unarchive.ts
+++ b/src/commands/content-type-schema/unarchive.ts
@@ -5,8 +5,9 @@ import dynamicContentClientFactory from '../../services/dynamic-content-client-f
 import { ArchiveLog } from '../../common/archive/archive-log';
 import { equalsOrRegex } from '../../common/filter/filter';
 import paginator from '../../common/dc-management-sdk-js/paginator';
-import { getDefaultLogPath, confirmArchive } from '../../common/archive/archive-helpers';
+import { confirmArchive } from '../../common/archive/archive-helpers';
 import UnarchiveOptions from '../../common/archive/unarchive-options';
+import { getDefaultLogPath } from '../../common/log-helpers';
 
 export const LOG_FILENAME = (platform: string = process.platform): string =>
   getDefaultLogPath('schema', 'unarchive', platform);

--- a/src/commands/content-type/archive.ts
+++ b/src/commands/content-type/archive.ts
@@ -6,8 +6,9 @@ import { ArchiveLog } from '../../common/archive/archive-log';
 import paginator from '../../common/dc-management-sdk-js/paginator';
 import { equalsOrRegex } from '../../common/filter/filter';
 
-import { getDefaultLogPath, confirmArchive } from '../../common/archive/archive-helpers';
+import { confirmArchive } from '../../common/archive/archive-helpers';
 import ArchiveOptions from '../../common/archive/archive-options';
+import { getDefaultLogPath } from '../../common/log-helpers';
 
 export const command = 'archive [id]';
 

--- a/src/commands/content-type/unarchive.ts
+++ b/src/commands/content-type/unarchive.ts
@@ -5,8 +5,9 @@ import dynamicContentClientFactory from '../../services/dynamic-content-client-f
 import { ArchiveLog } from '../../common/archive/archive-log';
 import { equalsOrRegex } from '../../common/filter/filter';
 import paginator from '../../common/dc-management-sdk-js/paginator';
-import { getDefaultLogPath, confirmArchive } from '../../common/archive/archive-helpers';
+import { confirmArchive } from '../../common/archive/archive-helpers';
 import UnarchiveOptions from '../../common/archive/unarchive-options';
+import { getDefaultLogPath } from '../../common/log-helpers';
 
 export const LOG_FILENAME = (platform: string = process.platform): string =>
   getDefaultLogPath('type', 'unarchive', platform);

--- a/src/common/archive/archive-helpers.ts
+++ b/src/common/archive/archive-helpers.ts
@@ -1,6 +1,7 @@
 import { join } from 'path';
 import readline, { ReadLine } from 'readline';
 
+<<<<<<< HEAD
 export function getDefaultLogPath(type: string, action: string, platform: string = process.platform): string {
   return join(
     process.env[platform == 'win32' ? 'USERPROFILE' : 'HOME'] || __dirname,
@@ -10,6 +11,8 @@ export function getDefaultLogPath(type: string, action: string, platform: string
   );
 }
 
+=======
+>>>>>>> feat(content-item): allow log file output, validation for setting fields null and warnings on export
 function asyncQuestionInternal(rl: ReadLine, question: string): Promise<string> {
   return new Promise((resolve): void => {
     rl.question(question, resolve);

--- a/src/common/archive/archive-helpers.ts
+++ b/src/common/archive/archive-helpers.ts
@@ -10,7 +10,7 @@ export function getDefaultLogPath(type: string, action: string, platform: string
   );
 }
 
-function asyncQuestion(rl: ReadLine, question: string): Promise<string> {
+function asyncQuestionInternal(rl: ReadLine, question: string): Promise<string> {
   return new Promise((resolve): void => {
     rl.question(question, resolve);
   });
@@ -34,7 +34,20 @@ export async function confirmArchive(
     ? 'Warning: Some content specified on the log is missing. Are you sure you want to continue? (y/n)\n'
     : `Are you sure you want to ${action} these ${type}? (y/n)\n`;
 
-  const answer: string = await asyncQuestion(rl, question);
+  const answer: string = await asyncQuestionInternal(rl, question);
+  rl.close();
+  return answer.length > 0 && answer[0].toLowerCase() == 'y';
+}
+
+export async function asyncQuestion(question: string): Promise<boolean> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: false
+  });
+
+  const answer = await asyncQuestionInternal(rl, question);
+
   rl.close();
   return answer.length > 0 && answer[0].toLowerCase() === 'y';
 }

--- a/src/common/archive/archive-helpers.ts
+++ b/src/common/archive/archive-helpers.ts
@@ -1,18 +1,5 @@
-import { join } from 'path';
 import readline, { ReadLine } from 'readline';
 
-<<<<<<< HEAD
-export function getDefaultLogPath(type: string, action: string, platform: string = process.platform): string {
-  return join(
-    process.env[platform == 'win32' ? 'USERPROFILE' : 'HOME'] || __dirname,
-    '.amplience',
-    'logs',
-    `${type}-${action}-<DATE>.log`
-  );
-}
-
-=======
->>>>>>> feat(content-item): allow log file output, validation for setting fields null and warnings on export
 function asyncQuestionInternal(rl: ReadLine, question: string): Promise<string> {
   return new Promise((resolve): void => {
     rl.question(question, resolve);

--- a/src/common/archive/archive-log.ts
+++ b/src/common/archive/archive-log.ts
@@ -21,7 +21,7 @@ export class ArchiveLog {
       if (line.startsWith('//')) {
         // The first comment is the title, all ones after it should be recorded as comment items.
         const message = line.substring(2).trimLeft();
-        if (this.items.length === 0) {
+        if (this.title == null) {
           this.title = message;
         } else {
           this.addComment(message);

--- a/src/common/content-item/amplience-schema-validator.ts
+++ b/src/common/content-item/amplience-schema-validator.ts
@@ -1,0 +1,68 @@
+import Ajv from 'ajv';
+import { ContentTypeSchema } from 'dc-management-sdk-js';
+import fetch from 'node-fetch';
+
+export class AmplienceSchemaValidator {
+  private ajv: Ajv.Ajv;
+  private cache: Map<string, PromiseLike<Ajv.ValidateFunction>>;
+
+  constructor(private schemas: ContentTypeSchema[]) {
+    const loadSchema = async (uri: string): Promise<object | boolean> => {
+      const internal = schemas.find(schema => schema.schemaId == uri);
+
+      if (internal !== undefined) {
+        return JSON.parse(internal.body as string);
+      }
+
+      try {
+        return await (await fetch(uri)).json();
+      } catch {
+        return false;
+      }
+    };
+
+    const ajv = new Ajv({ loadSchema, unknownFormats: ['symbol', 'color', 'markdown', 'text'], schemaId: 'auto' });
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const draft4 = require('ajv/lib/refs/json-schema-draft-04.json');
+
+    ajv.addMetaSchema(draft4);
+    ajv.addMetaSchema(draft4, 'http://bigcontent.io/cms/schema/v1/schema.json');
+
+    this.ajv = ajv;
+    this.cache = new Map();
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private getValidatorCached(body: any): PromiseLike<Ajv.ValidateFunction> {
+    const schemaId = body._meta.schema;
+
+    const cacheResult = this.cache.get(schemaId);
+    if (cacheResult != null) {
+      return cacheResult;
+    }
+
+    const schema = this.schemas.find(schema => schema.schemaId === schemaId);
+    if (schema != null) {
+      const validator = this.ajv.compileAsync(JSON.parse(schema.body as string));
+      this.cache.set(schemaId, validator);
+
+      return validator;
+    } else {
+      const validator = (async (): Promise<Ajv.ValidateFunction> => {
+        const schema = await (await fetch(schemaId)).json();
+
+        return await this.ajv.compileAsync(schema);
+      })();
+
+      this.cache.set(schemaId, validator);
+      return validator;
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public async validate(body: any): Promise<boolean> {
+    const validator = await this.getValidatorCached(body);
+    return validator(body);
+  }
+}

--- a/src/common/content-item/amplience-schema-validator.ts
+++ b/src/common/content-item/amplience-schema-validator.ts
@@ -1,28 +1,45 @@
 import Ajv, { ErrorObject } from 'ajv';
-import { ContentTypeSchema } from 'dc-management-sdk-js';
+import { ContentTypeSchema, ContentType, CachedSchema } from 'dc-management-sdk-js';
 import { Body } from './body';
 import fetch from 'node-fetch';
+
+export function defaultSchemaLookup(types: ContentType[], schemas: ContentTypeSchema[]) {
+  return async (uri: string): Promise<ContentTypeSchema | undefined> => {
+    const type = types.find(x => x.contentTypeUri === uri);
+    let schema: ContentTypeSchema | undefined;
+
+    if (type !== undefined) {
+      try {
+        const cached = (await type.related.contentTypeSchema.get()).cachedSchema as CachedSchema;
+
+        schema = new ContentTypeSchema({
+          body: JSON.stringify(cached),
+          schemaId: cached.id
+        });
+      } catch {
+        // Cached schema could not be retrieved, try fetch it from the schema list.
+      }
+    }
+
+    if (schema === undefined) {
+      schema = schemas.find(x => x.schemaId === uri);
+    }
+
+    return schema;
+  };
+}
 
 export class AmplienceSchemaValidator {
   private ajv: Ajv.Ajv;
   private cache: Map<string, PromiseLike<Ajv.ValidateFunction>>;
+  private schemas: ContentTypeSchema[] = [];
 
-  constructor(private schemas: ContentTypeSchema[]) {
-    const loadSchema = async (uri: string): Promise<object | boolean> => {
-      const internal = schemas.find(schema => schema.schemaId == uri);
-
-      if (internal !== undefined) {
-        return JSON.parse(internal.body as string);
-      }
-
-      try {
-        return await (await fetch(uri)).json();
-      } catch {
-        return false;
-      }
-    };
-
-    const ajv = new Ajv({ loadSchema, unknownFormats: ['symbol', 'color', 'markdown', 'text'], schemaId: 'auto' });
+  constructor(private schemaLookup: (uri: string) => Promise<ContentTypeSchema | undefined>) {
+    const ajv = new Ajv({
+      loadSchema: this.loadSchema.bind(this),
+      unknownFormats: ['symbol', 'color', 'markdown', 'text'],
+      schemaId: 'auto'
+    });
 
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const draft4 = require('ajv/lib/refs/json-schema-draft-04.json');
@@ -34,6 +51,31 @@ export class AmplienceSchemaValidator {
     this.cache = new Map();
   }
 
+  private loadSchema = async (uri: string): Promise<object | boolean> => {
+    let internal = this.schemas.find(schema => schema.schemaId == uri);
+
+    if (internal !== undefined) {
+      return JSON.parse(internal.body as string);
+    }
+
+    internal = await this.schemaLookup(uri);
+    let body: object;
+
+    if (internal === undefined) {
+      try {
+        body = await (await fetch(uri)).json();
+      } catch {
+        return false;
+      }
+    } else {
+      body = JSON.parse(internal.body as string);
+
+      this.schemas.push(internal);
+    }
+
+    return body;
+  };
+
   private getValidatorCached(body: Body): PromiseLike<Ajv.ValidateFunction> {
     const schemaId = body._meta.schema;
 
@@ -42,22 +84,18 @@ export class AmplienceSchemaValidator {
       return cacheResult;
     }
 
-    const schema = this.schemas.find(schema => schema.schemaId === schemaId);
-    if (schema != null) {
-      const validator = this.ajv.compileAsync(JSON.parse(schema.body as string));
-      this.cache.set(schemaId, validator);
+    const validator = (async (): Promise<Ajv.ValidateFunction> => {
+      const schema = await this.loadSchema(schemaId);
 
-      return validator;
-    } else {
-      const validator = (async (): Promise<Ajv.ValidateFunction> => {
-        const schema = await (await fetch(schemaId)).json();
-
+      if (schema) {
         return await this.ajv.compileAsync(schema);
-      })();
+      } else {
+        throw new Error('Could not find Content Type Schema!');
+      }
+    })();
 
-      this.cache.set(schemaId, validator);
-      return validator;
-    }
+    this.cache.set(schemaId, validator);
+    return validator;
   }
 
   public async validate(body: Body): Promise<ErrorObject[]> {

--- a/src/common/content-item/amplience-schema-validator.ts
+++ b/src/common/content-item/amplience-schema-validator.ts
@@ -63,8 +63,9 @@ export class AmplienceSchemaValidator {
 
     if (internal === undefined) {
       try {
-        body = await (await fetch(uri)).json();
-      } catch {
+        const result = await (await fetch(uri)).text();
+        body = JSON.parse(result.trim());
+      } catch (e) {
         return false;
       }
     } else {

--- a/src/common/content-item/amplience-schema-validator.ts
+++ b/src/common/content-item/amplience-schema-validator.ts
@@ -1,4 +1,4 @@
-import Ajv from 'ajv';
+import Ajv, { ErrorObject } from 'ajv';
 import { ContentTypeSchema } from 'dc-management-sdk-js';
 import fetch from 'node-fetch';
 
@@ -61,8 +61,9 @@ export class AmplienceSchemaValidator {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public async validate(body: any): Promise<boolean> {
+  public async validate(body: any): Promise<ErrorObject[]> {
     const validator = await this.getValidatorCached(body);
-    return validator(body);
+    const result = validator(body);
+    return result ? [] : validator.errors || [];
   }
 }

--- a/src/common/content-item/amplience-schema-validator.ts
+++ b/src/common/content-item/amplience-schema-validator.ts
@@ -1,5 +1,6 @@
 import Ajv, { ErrorObject } from 'ajv';
 import { ContentTypeSchema } from 'dc-management-sdk-js';
+import { Body } from './body';
 import fetch from 'node-fetch';
 
 export class AmplienceSchemaValidator {
@@ -33,8 +34,7 @@ export class AmplienceSchemaValidator {
     this.cache = new Map();
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private getValidatorCached(body: any): PromiseLike<Ajv.ValidateFunction> {
+  private getValidatorCached(body: Body): PromiseLike<Ajv.ValidateFunction> {
     const schemaId = body._meta.schema;
 
     const cacheResult = this.cache.get(schemaId);
@@ -60,8 +60,7 @@ export class AmplienceSchemaValidator {
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public async validate(body: any): Promise<ErrorObject[]> {
+  public async validate(body: Body): Promise<ErrorObject[]> {
     const validator = await this.getValidatorCached(body);
     const result = validator(body);
     return result ? [] : validator.errors || [];

--- a/src/common/content-item/body.ts
+++ b/src/common/content-item/body.ts
@@ -1,0 +1,16 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ObjectMap<T = Record<string, any>, K = any> = T & {
+  [key: string]: K;
+};
+
+export type Body<T = {}> = ObjectMap<
+  T & {
+    _meta: ContentMeta;
+  }
+>;
+
+interface ContentMeta {
+  name: string;
+  schema: string;
+  deliveryKey?: string;
+}

--- a/src/common/content-item/content-dependancy-tree.spec.ts
+++ b/src/common/content-item/content-dependancy-tree.spec.ts
@@ -1,0 +1,244 @@
+import { ContentDependancyTree, RepositoryContentItem, ItemContentDependancies } from './content-dependancy-tree';
+import { ContentMapping } from './content-mapping';
+import { ContentItem, Status, ContentRepository } from 'dc-management-sdk-js';
+import { ItemTemplate } from '../dc-management-sdk-js/mock-content';
+import { dependsOn } from '../../commands/content-item/__mocks__/dependant-content-helper';
+
+describe('content-dependancy-tree', () => {
+  describe('content dependancy tree tests', () => {
+    afterEach((): void => {
+      jest.resetAllMocks();
+    });
+
+    const itemFromTemplate = (template: ItemTemplate): ContentItem => {
+      const item = new ContentItem({
+        label: template.label,
+        status: template.status || Status.ACTIVE,
+        id: template.id || template.label,
+        folderId: null,
+        version: template.version,
+        lastPublishedVersion: template.lastPublishedVersion,
+        locale: template.locale,
+        body: {
+          ...template.body,
+          _meta: {
+            schema: template.typeSchemaUri
+          }
+        },
+
+        // Not meant to be here, but used later for sorting by repository
+        repoId: template.repoId
+      });
+
+      return item;
+    };
+
+    const createItems = (items: ItemTemplate[]): RepositoryContentItem[] => {
+      const repo = new ContentRepository();
+
+      return items.map(item => ({ repo: repo, content: itemFromTemplate(item) }));
+    };
+
+    const expectItemMatch = (items1: ItemContentDependancies[], items2: RepositoryContentItem[]): void => {
+      const matchedItems = items1.map(item => item.owner);
+      for (let i = 0; i < items2.length; i++) {
+        expect(matchedItems).toContain(items2[i]);
+      }
+    };
+
+    const defaultDependantItems = (): RepositoryContentItem[] => {
+      return createItems([
+        { label: 'id1', body: dependsOn([]), repoId: 'repo1', typeSchemaUri: 'http://type.com' },
+        { label: 'id2', body: dependsOn(['id1']), repoId: 'repo1', typeSchemaUri: 'http://type.com' },
+        { label: 'id3', body: dependsOn(['id2']), repoId: 'repo1', typeSchemaUri: 'http://type2.com' },
+        { label: 'id4', body: dependsOn(['id1']), repoId: 'repo1', typeSchemaUri: 'http://type2.com' },
+        {
+          label: 'id5',
+          body: dependsOn(['id1', 'id2'], [['exampleProp', 'id2']]),
+          repoId: 'repo1',
+          typeSchemaUri: 'http://type2.com'
+        }
+      ]);
+    };
+
+    const defaultCircularItems = (): RepositoryContentItem[] => {
+      return createItems([
+        { label: 'id1', body: dependsOn([]), repoId: 'repo1', typeSchemaUri: 'http://type.com' },
+        { label: 'id2', body: dependsOn([]), repoId: 'repo1', typeSchemaUri: 'http://type.com' },
+        { label: 'id3', body: dependsOn([]), repoId: 'repo1', typeSchemaUri: 'http://type2.com' },
+
+        { label: 'id4', body: dependsOn(['id5']), repoId: 'repo1', typeSchemaUri: 'http://type.com' },
+        { label: 'id5', body: dependsOn(['id4']), repoId: 'repo1', typeSchemaUri: 'http://type2.com' },
+        { label: 'id6', body: dependsOn(['id4']), repoId: 'repo1', typeSchemaUri: 'http://type2.com' }
+      ]);
+    };
+
+    it('should create an empty tree given no content items', () => {
+      const tree = new ContentDependancyTree([], new ContentMapping());
+
+      expect(tree.levels.length).toEqual(0);
+      expect(tree.circularLinks.length).toEqual(0);
+      expect(tree.all.length).toEqual(0);
+      expect(tree.byId.size).toEqual(0);
+      expect(tree.requiredSchema.length).toEqual(0);
+    });
+
+    it('should contain one level when no content dependancies are present', () => {
+      const items = createItems([
+        { label: 'id1', body: dependsOn([]), repoId: 'repo1', typeSchemaUri: 'http://type.com' },
+        { label: 'id2', body: dependsOn([]), repoId: 'repo1', typeSchemaUri: 'http://type.com' },
+        { label: 'id3', body: dependsOn([]), repoId: 'repo1', typeSchemaUri: 'http://type2.com' }
+      ]);
+
+      const tree = new ContentDependancyTree(items, new ContentMapping());
+
+      expect(tree.levels.length).toEqual(1);
+      expect(tree.circularLinks.length).toEqual(0);
+      expect(tree.all.length).toEqual(3);
+      expect(tree.byId.size).toEqual(3);
+      expect(tree.requiredSchema.length).toEqual(2);
+    });
+
+    it('should partition content items into levels when dependancies are present, first dependancies then dependants', () => {
+      const items = createItems([
+        { label: 'id1', body: dependsOn([]), repoId: 'repo1', typeSchemaUri: 'http://type.com' },
+        { label: 'id2', body: dependsOn(['id1']), repoId: 'repo1', typeSchemaUri: 'http://type.com' },
+        { label: 'id3', body: dependsOn(['id2']), repoId: 'repo1', typeSchemaUri: 'http://type2.com' },
+        { label: 'id4', body: dependsOn(['id1']), repoId: 'repo1', typeSchemaUri: 'http://type2.com' },
+        { label: 'id5', body: dependsOn(['id2', 'id1']), repoId: 'repo1', typeSchemaUri: 'http://type2.com' }
+      ]);
+
+      const tree = new ContentDependancyTree(items, new ContentMapping());
+
+      expect(tree.levels.length).toEqual(3);
+      expect(tree.circularLinks.length).toEqual(0);
+      expect(tree.all.length).toEqual(5);
+      expect(tree.byId.size).toEqual(5);
+      expect(tree.requiredSchema.length).toEqual(2);
+    });
+
+    it('should partition circular dependancies in their own array, and not in any levels.', () => {
+      const items = defaultCircularItems();
+
+      const tree = new ContentDependancyTree(items, new ContentMapping());
+
+      expect(tree.levels.length).toEqual(1);
+      expect(tree.circularLinks.length).toEqual(3);
+      expect(tree.all.length).toEqual(6);
+      expect(tree.byId.size).toEqual(6);
+      expect(tree.requiredSchema.length).toEqual(2);
+    });
+
+    it('should match cases in dependancies on filter any', () => {
+      const items = defaultDependantItems();
+
+      const tree = new ContentDependancyTree(items, new ContentMapping());
+
+      // id3 depends on id1 and id2, which will also be matched.
+      const id3Filter = tree.filterAny(item => item.owner.content.id === 'id3');
+      expect(id3Filter.length).toEqual(3);
+
+      expectItemMatch(id3Filter, items.slice(0, 3));
+
+      // id4 depends on id1 which will also be matched.
+      const id4Filter = tree.filterAny(item => item.owner.content.id === 'id4');
+      expect(id4Filter.length).toEqual(2);
+
+      expectItemMatch(id4Filter, [items[0], items[3]]);
+
+      expect(tree.all.length).toEqual(5);
+      expect(tree.byId.size).toEqual(5);
+    });
+
+    it('should remove content from relevant lists with removeContent', () => {
+      const items = defaultDependantItems();
+
+      const tree = new ContentDependancyTree(items, new ContentMapping());
+
+      // 5 items to begin with.
+      expect(tree.all.length).toEqual(5);
+      expect(tree.levels.reduce((acc, value) => acc + value.items.length, 0)).toEqual(5);
+      expect(tree.byId.size).toEqual(5);
+
+      tree.removeContent([tree.all[0], tree.all[2]]);
+
+      // 3 items after removal.
+
+      expectItemMatch(tree.all, [items[1], items[3], items[4]]);
+
+      expect(tree.all.length).toEqual(3);
+      expect(tree.levels.reduce((acc, value) => acc + value.items.length, 0)).toEqual(3);
+      expect(tree.byId.size).toEqual(3);
+    });
+
+    it('should traverse all dependants of an item with traverseDependants, with multiple levels', () => {
+      const items = defaultDependantItems();
+
+      const tree = new ContentDependancyTree(items, new ContentMapping());
+      const dependants: ItemContentDependancies[] = [];
+
+      // traverse dependants for id2, which is depended on by id3 and id5
+      tree.traverseDependants(tree.all[1], item => {
+        dependants.push(item);
+      });
+
+      expect(dependants.length).toEqual(3);
+      expectItemMatch(dependants, [items[1], items[2], items[4]]);
+
+      const dependants2: ItemContentDependancies[] = [];
+
+      // traverse dependants for id1, which is depended on by all content items
+      // (sometimes in multiple levels, though they are only traversed once)
+      tree.traverseDependants(tree.all[0], item => {
+        dependants2.push(item);
+      });
+
+      expect(dependants2.length).toEqual(5);
+      expectItemMatch(dependants2, items);
+    });
+
+    it('should traverse all dependants of an item with traverseDependants ONCE, with circular dependancies', () => {
+      const items = defaultCircularItems();
+
+      const tree = new ContentDependancyTree(items, new ContentMapping());
+
+      for (let i = 3; i < 6; i++) {
+        // For items 4,5 on the list, picking any one of them will traverse the other two as well.
+        // For item 6, there are no _dependants_, so it just returns itself
+        const dependants: ItemContentDependancies[] = [];
+
+        tree.traverseDependants(tree.all[i], item => {
+          dependants.push(item);
+        });
+
+        if (i == 5) {
+          expect(dependants.length).toEqual(1);
+          expectItemMatch(dependants, [items[5]]);
+        } else {
+          expect(dependants.length).toEqual(3);
+          expectItemMatch(dependants, items.slice(3));
+        }
+      }
+    });
+
+    it('should successfully remove content dependancies', () => {
+      const items = defaultDependantItems();
+
+      const tree = new ContentDependancyTree(items, new ContentMapping());
+
+      expect(tree.all[4].dependancies.length).toEqual(3);
+
+      // Remove dependancy for item id2 from id5
+      tree.removeContentDependanciesFromBody(
+        items[4].content.body,
+        tree.all[4].dependancies.filter(dep => dep.dependancy.id === 'id2').map(dep => dep.dependancy)
+      );
+
+      // When evaluating the tree with the new content body, the dependancy should be removed.
+      // The removal itself does not remove the dependancy from the first tree.
+      const tree2 = new ContentDependancyTree(items, new ContentMapping());
+
+      expect(tree2.all[4].dependancies.length).toEqual(1);
+    });
+  });
+});

--- a/src/common/content-item/content-dependancy-tree.ts
+++ b/src/common/content-item/content-dependancy-tree.ts
@@ -128,6 +128,62 @@ export class ContentDependancyTree {
     }
   }
 
+  public removeContentDependancies(
+    item: RepositoryContentItem,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    body: any,
+    remove: object[]
+  ): void {
+    if (Array.isArray(body)) {
+      for (let i = 0; i < body.length; i++) {
+        if (remove.indexOf(body[i]) !== -1) {
+          body.splice(i--, 1);
+        } else {
+          this.removeContentDependancies(item, body[i], remove);
+        }
+      }
+    } else {
+      const allPropertyNames = Object.getOwnPropertyNames(body);
+
+      allPropertyNames.forEach(propName => {
+        const prop = body[propName];
+        if (remove.indexOf(prop) !== -1) {
+          delete body[propName];
+        } else if (typeof prop === 'object') {
+          this.removeContentDependancies(item, prop, remove);
+        }
+      });
+    }
+  }
+
+  public simpleValidation(
+    item: RepositoryContentItem,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    body: any,
+    remove: object[]
+  ): void {
+    if (Array.isArray(body)) {
+      for (let i = 0; i < body.length; i++) {
+        if (remove.indexOf(body[i]) !== -1) {
+          body.splice(i--, 1);
+        } else {
+          this.removeContentDependancies(item, body[i], remove);
+        }
+      }
+    } else {
+      const allPropertyNames = Object.getOwnPropertyNames(body);
+
+      allPropertyNames.forEach(propName => {
+        const prop = body[propName];
+        if (remove.indexOf(prop) !== -1) {
+          delete body[propName];
+        } else if (typeof prop === 'object') {
+          this.removeContentDependancies(item, prop, remove);
+        }
+      });
+    }
+  }
+
   private identifyContentDependancies(items: RepositoryContentItem[]): ItemContentDependancies[] {
     return items.map(item => {
       const result: ContentDependancyInfo[] = [];

--- a/src/common/content-item/content-dependancy-tree.ts
+++ b/src/common/content-item/content-dependancy-tree.ts
@@ -1,0 +1,197 @@
+import { ContentItem, ContentRepository } from 'dc-management-sdk-js';
+import { ContentMapping } from './content-mapping';
+
+type DependancyContentTypeSchema =
+  | 'http://bigcontent.io/cms/schema/v1/core#/definitions/content-link'
+  | 'http://bigcontent.io/cms/schema/v1/core#/definitions/content-reference';
+
+export interface RepositoryContentItem {
+  repo: ContentRepository;
+  content: ContentItem;
+}
+
+export interface ContentDependancy {
+  _meta: { schema: DependancyContentTypeSchema };
+  contentType: string;
+  id: string | undefined;
+}
+
+export interface ContentDependancyInfo {
+  resolved?: ItemContentDependancies;
+  dependancy: ContentDependancy;
+  owner: RepositoryContentItem;
+}
+
+export interface ItemContentDependancies {
+  owner: RepositoryContentItem;
+  dependancies: ContentDependancyInfo[];
+  dependants: ItemContentDependancies[];
+}
+
+export interface ContentDependancyLayer {
+  items: ItemContentDependancies[];
+}
+
+export const referenceTypes = [
+  'http://bigcontent.io/cms/schema/v1/core#/definitions/content-link',
+  'http://bigcontent.io/cms/schema/v1/core#/definitions/content-reference'
+];
+
+export class ContentDependancyTree {
+  levels: ContentDependancyLayer[];
+  circularLinks: ItemContentDependancies[];
+  all: ItemContentDependancies[];
+  byId: Map<string, ItemContentDependancies>;
+  requiredSchema: string[];
+
+  constructor(items: RepositoryContentItem[], mapping: ContentMapping) {
+    // Identify all content dependancies.
+    let info = this.identifyContentDependancies(items);
+    const allInfo = info;
+    this.resolveContentDependancies(info);
+
+    const requiredSchema = new Set<string>();
+    info.forEach(item => {
+      requiredSchema.add(item.owner.content.body._meta.schema);
+    });
+
+    // For each stage, add all content that has no dependancies resolved in a previous stage
+    const resolved = new Set<string>();
+    mapping.contentItems.forEach((to, from) => {
+      resolved.add(from);
+    });
+
+    let unresolvedCount = info.length;
+
+    const stages: ContentDependancyLayer[] = [];
+    while (unresolvedCount > 0) {
+      const stage: ItemContentDependancies[] = [];
+      const lastUnresolvedCount = unresolvedCount;
+      info = info.filter(item => {
+        const unresolvedDependancies = item.dependancies.filter(dep => !resolved.has(dep.dependancy.id as string));
+
+        if (unresolvedDependancies.length === 0) {
+          resolved.add(item.owner.content.id as string);
+          stage.push(item);
+          return false;
+        }
+
+        return true;
+      });
+
+      unresolvedCount = info.length;
+      if (unresolvedCount === lastUnresolvedCount) {
+        break;
+      }
+
+      stages.push({ items: stage });
+    }
+
+    // Remaining items in the info array are connected to circular dependancies, so must be resolved via rewriting.
+
+    this.levels = stages;
+    this.circularLinks = info;
+    this.all = allInfo;
+    this.byId = new Map(allInfo.map(info => [info.owner.content.id as string, info]));
+    this.requiredSchema = Array.from(requiredSchema);
+  }
+
+  public searchObjectForContentDependancies(
+    item: RepositoryContentItem,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    body: any,
+    result: ContentDependancyInfo[]
+  ): void {
+    if (Array.isArray(body)) {
+      body.forEach(contained => {
+        this.searchObjectForContentDependancies(item, contained, result);
+      });
+    } else {
+      const allPropertyNames = Object.getOwnPropertyNames(body);
+      // Does this object match the pattern expected for a content item or reference?
+      if (
+        body._meta &&
+        referenceTypes.indexOf(body._meta.schema) !== -1 &&
+        typeof body.contentType === 'string' &&
+        typeof body.id === 'string'
+      ) {
+        result.push({ dependancy: body, owner: item });
+        return;
+      }
+
+      allPropertyNames.forEach(propName => {
+        const prop = body[propName];
+        if (typeof prop === 'object') {
+          this.searchObjectForContentDependancies(item, prop, result);
+        }
+      });
+    }
+  }
+
+  private identifyContentDependancies(items: RepositoryContentItem[]): ItemContentDependancies[] {
+    return items.map(item => {
+      const result: ContentDependancyInfo[] = [];
+      this.searchObjectForContentDependancies(item, item.content.body, result);
+      return { owner: item, dependancies: result, dependants: [] };
+    });
+  }
+
+  private resolveContentDependancies(items: ItemContentDependancies[]): void {
+    // Create cross references to make it easier to traverse dependancies.
+
+    const idMap = new Map(items.map(item => [item.owner.content.id as string, item]));
+    const visited = new Set<ItemContentDependancies>();
+
+    const resolve = (item: ItemContentDependancies): void => {
+      if (visited.has(item)) return;
+      visited.add(item);
+
+      item.dependancies.forEach(dep => {
+        const target = idMap.get(dep.dependancy.id as string);
+        dep.resolved = target;
+        if (target) {
+          target.dependants.push(item);
+          resolve(target);
+        }
+      });
+    };
+
+    items.forEach(item => resolve(item));
+  }
+
+  public traverseDependants(
+    item: ItemContentDependancies,
+    action: (item: ItemContentDependancies) => void,
+    traversed?: Set<ItemContentDependancies>
+  ): void {
+    const traversedSet = traversed || new Set<ItemContentDependancies>();
+    traversedSet.add(item);
+    action(item);
+    item.dependants.forEach(dependant => {
+      if (!traversedSet.has(dependant)) {
+        this.traverseDependants(dependant, action, traversedSet);
+      }
+    });
+  }
+
+  public filterAny(action: (item: ItemContentDependancies) => boolean): ItemContentDependancies[] {
+    return this.all.filter(item => {
+      let match = false;
+      this.traverseDependants(item, item => {
+        if (action(item)) {
+          match = true;
+        }
+      });
+      return match;
+    });
+  }
+
+  removeContent = (items: ItemContentDependancies[]): void => {
+    this.levels.forEach(level => {
+      level.items = level.items.filter(item => items.indexOf(item) === -1);
+    });
+
+    this.all = this.all.filter(item => items.indexOf(item) === -1);
+    this.circularLinks = this.circularLinks.filter(item => items.indexOf(item) === -1);
+  };
+}

--- a/src/common/content-item/content-dependancy-tree.ts
+++ b/src/common/content-item/content-dependancy-tree.ts
@@ -1,5 +1,6 @@
 import { ContentItem, ContentRepository } from 'dc-management-sdk-js';
 import { ContentMapping } from './content-mapping';
+import { Body } from './body';
 
 type DependancyContentTypeSchema =
   | 'http://bigcontent.io/cms/schema/v1/core#/definitions/content-link'
@@ -36,6 +37,8 @@ export const referenceTypes = [
   'http://bigcontent.io/cms/schema/v1/core#/definitions/content-link',
   'http://bigcontent.io/cms/schema/v1/core#/definitions/content-reference'
 ];
+
+type RecursiveSearchStep = Body | ContentDependancy | Array<Body>;
 
 export class ContentDependancyTree {
   levels: ContentDependancyLayer[];
@@ -98,8 +101,7 @@ export class ContentDependancyTree {
 
   public searchObjectForContentDependancies(
     item: RepositoryContentItem,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    body: any,
+    body: RecursiveSearchStep,
     result: ContentDependancyInfo[]
   ): void {
     if (Array.isArray(body)) {
@@ -115,12 +117,12 @@ export class ContentDependancyTree {
         typeof body.contentType === 'string' &&
         typeof body.id === 'string'
       ) {
-        result.push({ dependancy: body, owner: item });
+        result.push({ dependancy: body as ContentDependancy, owner: item });
         return;
       }
 
       allPropertyNames.forEach(propName => {
-        const prop = body[propName];
+        const prop = (body as Body)[propName];
         if (typeof prop === 'object') {
           this.searchObjectForContentDependancies(item, prop, result);
         }

--- a/src/common/content-item/content-dependancy-tree.ts
+++ b/src/common/content-item/content-dependancy-tree.ts
@@ -156,34 +156,6 @@ export class ContentDependancyTree {
     }
   }
 
-  public simpleValidation(
-    item: RepositoryContentItem,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    body: any,
-    remove: object[]
-  ): void {
-    if (Array.isArray(body)) {
-      for (let i = 0; i < body.length; i++) {
-        if (remove.indexOf(body[i]) !== -1) {
-          body.splice(i--, 1);
-        } else {
-          this.removeContentDependancies(item, body[i], remove);
-        }
-      }
-    } else {
-      const allPropertyNames = Object.getOwnPropertyNames(body);
-
-      allPropertyNames.forEach(propName => {
-        const prop = body[propName];
-        if (remove.indexOf(prop) !== -1) {
-          delete body[propName];
-        } else if (typeof prop === 'object') {
-          this.removeContentDependancies(item, prop, remove);
-        }
-      });
-    }
-  }
-
   private identifyContentDependancies(items: RepositoryContentItem[]): ItemContentDependancies[] {
     return items.map(item => {
       const result: ContentDependancyInfo[] = [];

--- a/src/common/content-item/content-mapping.ts
+++ b/src/common/content-item/content-mapping.ts
@@ -4,11 +4,9 @@ import { promisify } from 'util';
 
 export class ContentMapping {
   contentItems: Map<string, string>;
-  contentTypes: Map<string, string>;
 
   constructor() {
     this.contentItems = new Map<string, string>();
-    this.contentTypes = new Map<string, string>();
   }
 
   getContentItem(id: string | undefined): string | undefined {
@@ -21,18 +19,6 @@ export class ContentMapping {
 
   registerContentItem(fromId: string, toId: string): void {
     this.contentItems.set(fromId, toId);
-  }
-
-  getContentType(id: string | undefined): string | undefined {
-    if (id === undefined) {
-      return undefined;
-    }
-
-    return this.contentTypes.get(id);
-  }
-
-  registerContentType(fromId: string, toId: string): void {
-    this.contentTypes.set(fromId, toId);
   }
 
   async save(filename: string): Promise<void> {

--- a/src/common/content-item/content-mapping.ts
+++ b/src/common/content-item/content-mapping.ts
@@ -1,0 +1,67 @@
+import { readFile, writeFile, exists, mkdir } from 'fs';
+import { dirname } from 'path';
+import { promisify } from 'util';
+
+export class ContentMapping {
+  contentItems: Map<string, string>;
+  contentTypes: Map<string, string>;
+
+  constructor() {
+    this.contentItems = new Map<string, string>();
+    this.contentTypes = new Map<string, string>();
+  }
+
+  getContentItem(id: string | undefined): string | undefined {
+    if (id === undefined) {
+      return undefined;
+    }
+
+    return this.contentItems.get(id);
+  }
+
+  registerContentItem(fromId: string, toId: string): void {
+    this.contentItems.set(fromId, toId);
+  }
+
+  getContentType(id: string | undefined): string | undefined {
+    if (id === undefined) {
+      return undefined;
+    }
+
+    return this.contentTypes.get(id);
+  }
+
+  registerContentType(fromId: string, toId: string): void {
+    this.contentTypes.set(fromId, toId);
+  }
+
+  async save(filename: string): Promise<void> {
+    const obj: SerializedContentMapping = {
+      contentItems: Array.from(this.contentItems)
+    };
+
+    const text = JSON.stringify(obj);
+
+    const dir = dirname(filename);
+    if (!(await promisify(exists)(dir))) {
+      await promisify(mkdir)(dir);
+    }
+    await promisify(writeFile)(filename, text, { encoding: 'utf8' });
+  }
+
+  async load(filename: string): Promise<boolean> {
+    try {
+      const text = await promisify(readFile)(filename, { encoding: 'utf8' });
+      const obj = JSON.parse(text);
+
+      this.contentItems = new Map(obj.contentItems);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+}
+
+interface SerializedContentMapping {
+  contentItems: [string, string][];
+}

--- a/src/common/dc-management-sdk-js/mock-content.ts
+++ b/src/common/dc-management-sdk-js/mock-content.ts
@@ -1,0 +1,483 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { join, basename, dirname } from 'path';
+import {
+  Folder,
+  ContentItem,
+  ContentRepository,
+  Hub,
+  DynamicContent,
+  ContentType,
+  ContentTypeSchema,
+  ContentRepositoryContentType
+} from 'dc-management-sdk-js';
+import MockPage from './mock-page';
+
+export interface ItemTemplate {
+  label: string;
+  id?: string;
+  folderPath?: string;
+  repoId: string;
+  typeSchemaUri: string;
+
+  body?: any;
+}
+
+export interface ItemInfo {
+  repos: string[];
+  baseFolders: string[];
+}
+
+export interface MockRepository {
+  repo: ContentRepository;
+  items: ContentItem[];
+  folders: Folder[];
+}
+
+export class MockContentMetrics {
+  itemsCreated = 0;
+  itemsUpdated = 0;
+  foldersCreated = 0;
+  typesCreated = 0;
+  typeSchemasCreated = 0;
+
+  reset(): void {
+    this.itemsCreated = 0;
+    this.itemsUpdated = 0;
+    this.foldersCreated = 0;
+    this.typesCreated = 0;
+    this.typeSchemasCreated = 0;
+  }
+}
+
+export class MockContent {
+  items: ContentItem[] = [];
+  repos: MockRepository[] = [];
+  folders: Folder[] = [];
+
+  typeById: Map<string, ContentType> = new Map();
+  typeSchemaById: Map<string, ContentTypeSchema> = new Map();
+  repoById: Map<string, MockRepository> = new Map();
+  folderById: Map<string, Folder> = new Map();
+
+  subfoldersById: Map<string, Folder[]> = new Map();
+  typeAssignmentsByRepoId: Map<string, ContentType[]> = new Map();
+
+  metrics = new MockContentMetrics();
+
+  uniqueId = 0;
+
+  constructor(private contentService: jest.Mock<DynamicContent>) {
+    const mockHub = this.createMockHub();
+
+    const mockFolderGet = jest.fn(id => Promise.resolve(this.folderById.get(id) as Folder));
+    const mockRepoGet = jest.fn(id => Promise.resolve((this.repoById.get(id) as MockRepository).repo));
+
+    const mockHubGet = jest.fn().mockResolvedValue(mockHub);
+    const mockHubList = jest.fn().mockResolvedValue([mockHub]);
+
+    const mockTypeGet = jest.fn(id => Promise.resolve(this.typeById.get(id) as ContentType));
+
+    const mockTypeSchemaGet = jest.fn(id => Promise.resolve(this.typeSchemaById.get(id) as ContentTypeSchema));
+
+    const mockItemGet = jest.fn(id => Promise.resolve(this.items.find(item => item.id === id)));
+
+    contentService.mockReturnValue(({
+      hubs: {
+        get: mockHubGet,
+        list: mockHubList
+      },
+      folders: {
+        get: mockFolderGet
+      },
+      contentRepositories: {
+        get: mockRepoGet
+      },
+      contentTypes: {
+        get: mockTypeGet
+      },
+      contentTypeSchemas: {
+        get: mockTypeSchemaGet
+      },
+      contentItems: {
+        get: mockItemGet
+      }
+    } as any) as DynamicContent);
+  }
+
+  private createMockHub(): Hub {
+    const mockHub = new Hub();
+
+    const mockRepoList = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(new MockPage(ContentRepository, this.repos.map(repo => repo.repo))));
+    const mockTypesList = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(new MockPage(ContentType, Array.from(this.typeById.values()))));
+    const mockSchemaList = jest
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve(new MockPage(ContentTypeSchema, Array.from(this.typeSchemaById.values())))
+      );
+    const mockTypeRegister = jest.fn().mockImplementation((type: ContentType) => {
+      this.metrics.typesCreated++;
+      type = new ContentType(type);
+      type.id = 'UNIQUE-' + this.uniqueId++;
+      this.typeById.set(type.id as string, type);
+      return Promise.resolve(type);
+    });
+
+    mockHub.related.contentRepositories.list = mockRepoList;
+    mockHub.related.contentTypeSchema.list = mockSchemaList;
+    mockHub.related.contentTypes.list = mockTypesList;
+    mockHub.related.contentTypes.register = mockTypeRegister;
+
+    return mockHub;
+  }
+
+  private assignmentMeta(typeAssignments: ContentType[]): ContentRepositoryContentType[] {
+    return typeAssignments.map(assign => ({
+      hubContentTypeId: assign.id,
+      contentTypeUri: assign.contentTypeUri
+    }));
+  }
+
+  createMockRepository(repoId: string): void {
+    if (this.repoById.has(repoId)) return;
+
+    const repo = new ContentRepository({
+      id: repoId,
+      label: repoId
+    });
+
+    const mockRepo: MockRepository = {
+      repo,
+      folders: [],
+      items: this.items.filter(item => (item as any).repoId == repoId)
+    };
+
+    const mockItemList = jest.fn().mockImplementation(() => Promise.resolve(new MockPage(ContentItem, mockRepo.items)));
+    repo.related.contentItems.list = mockItemList;
+
+    const mockFolderList = jest
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve(
+          new MockPage(
+            Folder,
+            this.folders.filter(folder => (folder as any).repoId === repoId && folder.id == folder.name)
+          )
+        )
+      );
+    repo.related.folders.list = mockFolderList;
+
+    const mockItemCreate = jest.fn().mockImplementation((item: ContentItem) => {
+      item = new ContentItem(item);
+      item.id = 'UNIQUE-' + this.uniqueId++;
+      this.createItem(item, mockRepo);
+      return Promise.resolve(item);
+    });
+    repo.related.contentItems.create = mockItemCreate;
+
+    const mockTypeAssign = jest.fn().mockImplementation((contentTypeId: string) => {
+      const typeAssignments = this.typeAssignmentsByRepoId.get(repo.id as string) || [];
+      typeAssignments.push(this.typeById.get(contentTypeId) as ContentType);
+      this.typeAssignmentsByRepoId.set(repo.id as string, typeAssignments);
+      repo.contentTypes = this.assignmentMeta(typeAssignments);
+      return Promise.resolve(repo);
+    });
+    repo.related.contentTypes.assign = mockTypeAssign;
+
+    const mockFolderCreate = jest.fn().mockImplementation((folder: Folder) => {
+      folder = new Folder(folder);
+      (folder as any).repoId = repo.id;
+      this.createFolder(folder);
+      return Promise.resolve(folder);
+    });
+    repo.related.folders.create = mockFolderCreate;
+
+    this.repoById.set(repoId, mockRepo);
+    this.repos.push(mockRepo);
+  }
+
+  createItem(item: ContentItem, mockRepo: MockRepository | undefined): void {
+    this.metrics.itemsCreated++;
+
+    const mockItemRepo = jest.fn();
+    item.related.contentRepository = mockItemRepo;
+
+    const mockItemUpdate = jest.fn();
+    item.related.update = mockItemUpdate;
+
+    if (mockRepo != null) {
+      (item as any).repoId = mockRepo.repo.id;
+    }
+
+    mockItemRepo.mockImplementation(() =>
+      Promise.resolve((this.repoById.get((item as any).repoId) as MockRepository).repo)
+    );
+
+    mockItemUpdate.mockImplementation(newItem => {
+      this.metrics.itemsUpdated++;
+
+      item.label = newItem.label;
+      item.body = newItem.body;
+      item.status = newItem.status;
+      item.version = newItem.version;
+
+      return Promise.resolve(item);
+    });
+
+    this.items.push(item);
+
+    if (mockRepo) {
+      mockRepo.items.push(item);
+    }
+  }
+
+  registerContentType(
+    schemaName: string,
+    id: string,
+    repos: string | string[],
+    body?: object,
+    schemaOnly?: boolean
+  ): void {
+    if (!this.typeSchemaById.has(id)) {
+      const schema = new ContentTypeSchema({ id: id, schemaId: schemaName, body: body });
+      this.typeSchemaById.set(id, schema);
+    }
+
+    if (!schemaOnly) {
+      const type = new ContentType({ id: id, contentTypeUri: schemaName, settings: { label: basename(schemaName) } });
+      this.typeById.set(id, type);
+
+      const repoArray = typeof repos === 'string' ? [repos] : repos;
+      repoArray.forEach(repoName => {
+        const typeAssignments = this.typeAssignmentsByRepoId.get(repoName) || [];
+        typeAssignments.push(type);
+        const repo = this.repoById.get(repoName);
+        if (repo != null) {
+          repo.repo.contentTypes = this.assignmentMeta(typeAssignments);
+        }
+        this.typeAssignmentsByRepoId.set(repoName, typeAssignments);
+      });
+    }
+  }
+
+  importItemTemplates(templates: ItemTemplate[]): void {
+    const repoIds: string[] = this.repos.map(repo => repo.repo.id as string);
+    const newRepoIds: string[] = this.repos.map(repo => repo.repo.id as string);
+    const folderTemplates: { name: string; id: string; repoId: string }[] = [];
+
+    // Generate items.
+    templates.forEach(template => {
+      let folderName = '';
+      const folderId = template.folderPath;
+      if (folderId != null) {
+        const pathSplit = folderId.split('/');
+        folderName = pathSplit[pathSplit.length - 1];
+      }
+
+      const folderNullOrEmpty = folderId == null || folderId.length == 0;
+
+      const item = new ContentItem({
+        label: template.label,
+        status: 'ACTIVE',
+        id: template.id || '0',
+        folderId: folderNullOrEmpty ? null : folderId,
+        body: {
+          _meta: {
+            schema: template.typeSchemaUri
+          }
+        },
+
+        // Not meant to be here, but used later for sorting by repository
+        repoId: template.repoId
+      });
+
+      if (repoIds.indexOf(template.repoId) === -1) {
+        repoIds.push(template.repoId);
+        newRepoIds.push(template.repoId);
+      }
+
+      if (!folderNullOrEmpty && folderTemplates.findIndex(folder => folder.id == folderId) === -1) {
+        folderTemplates.push({ id: folderId || '', name: folderName, repoId: template.repoId });
+      }
+
+      this.createItem(item, this.repoById.get(template.repoId));
+    });
+
+    // Generate folders that contain the items.
+    folderTemplates.forEach(folderTemplate => {
+      if (this.folderById.has(folderTemplate.id)) {
+        return;
+      }
+
+      const id = folderTemplate.id;
+
+      const folder = new Folder({
+        id: id,
+        name: folderTemplate.name,
+        repoId: folderTemplate.repoId
+      });
+
+      const slashInd = id.lastIndexOf('/');
+      if (slashInd !== -1) {
+        const parentPath = id.substring(0, slashInd);
+        const parent = this.folders.find(folder => folder.id == parentPath);
+        if (parent != null) {
+          const subfolders = this.subfoldersById.get(parent.id as string) || [];
+          subfolders.push(folder);
+          this.subfoldersById.set(parent.id as string, subfolders);
+        }
+      }
+
+      this.createFolder(folder);
+    });
+
+    // Generate repositories.
+    newRepoIds.forEach(repoId => {
+      this.createMockRepository(repoId);
+    });
+  }
+
+  private async getFolderPath(folder: Folder | undefined): Promise<string> {
+    if (folder == null) {
+      return '';
+    }
+
+    let parent: Folder | undefined = undefined;
+    try {
+      parent = await folder.related.folders.parent();
+    } catch {}
+
+    if (parent == null) {
+      return (folder.name as string) + '/';
+    } else {
+      return (await this.getFolderPath(parent)) + (folder.name as string) + '/';
+    }
+  }
+
+  private async getPath(item: ContentItem): Promise<string> {
+    return (await this.getFolderPath(this.folderById.get(item.folderId as string))) + item.label + '.json';
+  }
+
+  async filterMatch(templates: ItemTemplate[], baseDir: string, multiRepo: boolean): Promise<ItemTemplate[]> {
+    const results: ItemTemplate[] = [];
+
+    for (let i = 0; i < templates.length; i++) {
+      const template = templates[i];
+      for (let j = 0; j < this.items.length; j++) {
+        const item = this.items[j];
+
+        if (item.label === template.label) {
+          if (multiRepo) {
+            const repo = await item.related.contentRepository();
+            if (repo.id != template.repoId) {
+              continue;
+            }
+          }
+          const path = await this.getPath(item);
+          if (join(baseDir, template.folderPath || '') == dirname(path)) {
+            results.push(template);
+          }
+          break;
+        }
+      }
+    }
+
+    return results;
+  }
+
+  createFolder(folder: Folder): Folder {
+    this.metrics.foldersCreated++;
+
+    const id = folder.id as string;
+
+    const mockFolderList = jest.fn();
+    folder.related.contentItems.list = mockFolderList;
+    const mockFolderSubfolder = jest.fn();
+    folder.related.folders.list = mockFolderSubfolder;
+    const mockFolderParent = jest.fn();
+    folder.related.folders.parent = mockFolderParent;
+    const mockFolderCreate = jest.fn();
+    folder.related.folders.create = mockFolderCreate;
+    const mockFolderRepo = jest.fn();
+    folder.related.contentRepository = mockFolderRepo;
+
+    mockFolderList.mockImplementation(() =>
+      Promise.resolve(new MockPage(ContentItem, this.items.filter(item => item.folderId === id)))
+    );
+
+    mockFolderSubfolder.mockImplementation(() => {
+      const subfolders: Folder[] = this.subfoldersById.get(id) || [];
+      return Promise.resolve(new MockPage(Folder, subfolders));
+    });
+
+    mockFolderParent.mockImplementation(() => {
+      let result: Folder | undefined;
+      this.subfoldersById.forEach((value, key) => {
+        if (value.indexOf(folder) !== -1) {
+          result = this.folderById.get(key);
+        }
+      });
+      if (result == null) {
+        throw new Error('No parent - calling this throws an exception.');
+      }
+      return Promise.resolve(result);
+    });
+
+    mockFolderCreate.mockImplementation((newFolder: Folder) => {
+      const subfolders = this.subfoldersById.get(id) || [];
+      newFolder.id = 'UNIQUE-' + this.uniqueId++;
+
+      subfolders.push(newFolder);
+      (newFolder as any).repoId = (folder as any).repoId;
+      this.createFolder(newFolder);
+      this.subfoldersById.set(id, subfolders);
+      return Promise.resolve(newFolder);
+    });
+
+    mockFolderRepo.mockImplementation(() =>
+      Promise.resolve((this.repoById.get((folder as any).repoId) as MockRepository).repo)
+    );
+
+    this.folderById.set(id, folder);
+    this.folders.push(folder);
+
+    return folder;
+  }
+}
+
+export function getItemInfo(items: ItemTemplate[]): ItemInfo {
+  const repos: string[] = [];
+  const baseFolders: string[] = [];
+
+  items.forEach(item => {
+    if (repos.indexOf(item.repoId) === -1) {
+      repos.push(item.repoId);
+    }
+
+    if (item.folderPath != null) {
+      const folderFirstSlash = item.folderPath.indexOf('/');
+      const baseFolder = folderFirstSlash === -1 ? item.folderPath : item.folderPath.substring(0, folderFirstSlash);
+
+      if (baseFolder.length > 0 && baseFolders.indexOf(baseFolder) === -1) {
+        baseFolders.push(baseFolder);
+      }
+    }
+  });
+
+  return { repos, baseFolders };
+}
+
+export function getItemName(baseDir: string, item: ItemTemplate, info: ItemInfo, validRepos?: string[]): string {
+  if (validRepos) {
+    let basePath = item.folderPath || '';
+    if (info.repos.length > 1 && validRepos.indexOf(item.repoId) !== -1) {
+      basePath = `${item.repoId}/${basePath}`;
+    }
+    return join(baseDir + basePath, item.label + '.json');
+  } else {
+    return join(baseDir + (item.folderPath || ''), item.label + '.json');
+  }
+}

--- a/src/common/dc-management-sdk-js/mock-content.ts
+++ b/src/common/dc-management-sdk-js/mock-content.ts
@@ -23,6 +23,7 @@ export interface ItemTemplate {
   status?: string;
 
   body?: any;
+  dependancy?: string;
 }
 
 export interface ItemInfo {
@@ -354,6 +355,7 @@ export class MockContent {
         folderId: folderNullOrEmpty ? null : folderId,
         version: template.version,
         body: {
+          ...template.body,
           _meta: {
             schema: template.typeSchemaUri
           }
@@ -540,6 +542,10 @@ export function getItemInfo(items: ItemTemplate[]): ItemInfo {
 }
 
 export function getItemName(baseDir: string, item: ItemTemplate, info: ItemInfo, validRepos?: string[]): string {
+  if (item.dependancy) {
+    return join(baseDir, item.dependancy, '_dependancies', item.label + '.json');
+  }
+
   if (validRepos) {
     let basePath = item.folderPath || '';
     if (info.repos.length > 1 && validRepos.indexOf(item.repoId) !== -1) {

--- a/src/common/file-log.spec.ts
+++ b/src/common/file-log.spec.ts
@@ -1,0 +1,44 @@
+import { FileLog } from './file-log';
+import { readFile, exists, unlink } from 'fs';
+import { promisify } from 'util';
+import { ensureDirectoryExists } from './import/directory-utils';
+
+describe('file-log', () => {
+  describe('file-log tests', () => {
+    it('should create a log file when filename is specified, and closed', async () => {
+      const log = new FileLog('file.log');
+      log.appendLine('Test Message');
+      const writeSpy = jest.spyOn(log, 'writeToFile').mockImplementation(() => Promise.resolve(true));
+      await log.close();
+
+      expect(writeSpy).toBeCalled();
+    });
+
+    it('should not create a log file when filename is null, and closed', async () => {
+      const log = new FileLog();
+      log.appendLine('Test Message');
+      const writeSpy = jest.spyOn(log, 'writeToFile').mockImplementation(() => Promise.resolve(true));
+      await log.close();
+
+      expect(writeSpy).not.toBeCalled();
+    });
+
+    it('should embed the date in the filename', async () => {
+      jest.spyOn(Date, 'now').mockImplementation(() => 1234);
+      await ensureDirectoryExists('temp/');
+
+      const log = new FileLog('temp/FileWithDate-<DATE>.log');
+      log.appendLine('Test Message');
+      await log.close();
+
+      expect(await promisify(exists)('temp/FileWithDate-1234.log')).toBeTruthy();
+      expect(await promisify(readFile)('temp/FileWithDate-1234.log', { encoding: 'utf-8' })).toMatchInlineSnapshot(`
+        "// temp/FileWithDate-1234.log
+        // Test Message
+        "
+      `);
+
+      await promisify(unlink)('temp/FileWithDate-1234.log');
+    });
+  });
+});

--- a/src/common/file-log.ts
+++ b/src/common/file-log.ts
@@ -1,0 +1,34 @@
+import { writeFile } from 'fs';
+import { promisify } from 'util';
+
+export class FileLog {
+  private contents: string;
+
+  constructor(private filename?: string) {
+    if (this.filename != null) {
+      const timestamp = Date.now().toString();
+      this.filename = this.filename.replace('<DATE>', timestamp);
+    }
+  }
+
+  public appendLine(text?: string): void {
+    console.log(text);
+
+    if (text !== null) {
+      this.contents += text;
+    }
+
+    this.contents += '\n';
+  }
+
+  public async close(): Promise<void> {
+    if (this.filename != null) {
+      try {
+        await promisify(writeFile)(this.filename, this.contents);
+        console.log(`Log written to "${this.filename}".`);
+      } catch {
+        console.log(`Could not write log.`);
+      }
+    }
+  }
+}

--- a/src/common/file-log.ts
+++ b/src/common/file-log.ts
@@ -1,10 +1,9 @@
-import { writeFile } from 'fs';
-import { promisify } from 'util';
+import { ArchiveLog } from './archive/archive-log';
 
-export class FileLog {
-  private contents: string;
-
+export class FileLog extends ArchiveLog {
   constructor(private filename?: string) {
+    super((filename || '').replace('<DATE>', Date.now().toString()));
+
     if (this.filename != null) {
       const timestamp = Date.now().toString();
       this.filename = this.filename.replace('<DATE>', timestamp);
@@ -14,17 +13,13 @@ export class FileLog {
   public appendLine(text?: string): void {
     console.log(text);
 
-    if (text !== null) {
-      this.contents += text;
-    }
-
-    this.contents += '\n';
+    this.addComment(text as string);
   }
 
   public async close(): Promise<void> {
     if (this.filename != null) {
       try {
-        await promisify(writeFile)(this.filename, this.contents);
+        await this.writeToFile(this.filename);
         console.log(`Log written to "${this.filename}".`);
       } catch {
         console.log(`Could not write log.`);

--- a/src/common/file-log.ts
+++ b/src/common/file-log.ts
@@ -18,12 +18,7 @@ export class FileLog extends ArchiveLog {
 
   public async close(): Promise<void> {
     if (this.filename != null) {
-      try {
-        await this.writeToFile(this.filename);
-        console.log(`Log written to "${this.filename}".`);
-      } catch {
-        console.log(`Could not write log.`);
-      }
+      await this.writeToFile(this.filename);
     }
   }
 }

--- a/src/common/filter/filter.spec.ts
+++ b/src/common/filter/filter.spec.ts
@@ -1,0 +1,43 @@
+import { equalsOrRegex } from './filter';
+
+describe('filter', () => {
+  describe('filter tests', () => {
+    it('should search with a regex if the string starts and ends with /', () => {
+      expect(equalsOrRegex('test filter match', '/filter/')).toBeTruthy();
+      expect(equalsOrRegex('test filter match', '/f.*r/')).toBeTruthy();
+
+      expect(equalsOrRegex('not match', '/filter/')).toBeFalsy();
+      expect(equalsOrRegex('test filter match', '/f.*z/')).toBeFalsy();
+    });
+
+    it('should check equality when not surrounded by /', () => {
+      expect(equalsOrRegex('filter', 'filter')).toBeTruthy();
+      expect(equalsOrRegex('/filter', '/filter')).toBeTruthy();
+      expect(equalsOrRegex('filter/', 'filter/')).toBeTruthy();
+
+      expect(equalsOrRegex('test filter match', 'filter')).toBeFalsy();
+      expect(equalsOrRegex('filter', '/filter')).toBeFalsy();
+      expect(equalsOrRegex('filter', 'filter/')).toBeFalsy();
+    });
+
+    it('should check equality when string is too short to contain a regex', () => {
+      expect(equalsOrRegex('', '')).toBeTruthy();
+      expect(equalsOrRegex('', 'filter')).toBeFalsy();
+      expect(equalsOrRegex('text', '')).toBeFalsy();
+
+      expect(equalsOrRegex('/', '/')).toBeTruthy();
+      expect(equalsOrRegex('hell/o', '/')).toBeFalsy();
+      expect(equalsOrRegex('', '/')).toBeFalsy();
+    });
+
+    it('should throw when a regex cannot be parsed', () => {
+      let throws = false;
+      try {
+        equalsOrRegex('', '/filter\\/');
+      } catch {
+        throws = true;
+      }
+      expect(throws).toEqual(true);
+    });
+  });
+});

--- a/src/common/import/__mocks__/publish-queue.ts
+++ b/src/common/import/__mocks__/publish-queue.ts
@@ -1,0 +1,30 @@
+import { ContentItem } from 'dc-management-sdk-js';
+import { JobRequest } from '../publish-queue';
+
+export const publishCalls: ContentItem[] = [];
+
+export class PublishQueue {
+  maxWaiting = 3;
+  attemptDelay = 1000;
+  failedJobs: JobRequest[] = [];
+
+  waitInProgress = false;
+
+  constructor() {
+    /* empty */
+  }
+
+  async publish(item: ContentItem): Promise<void> {
+    // TODO: testing ability to throw
+
+    publishCalls.push(item);
+
+    return;
+  }
+
+  async waitForAll(): Promise<void> {
+    // TODO: testing ability to throw (in wait for publish)
+
+    return;
+  }
+}

--- a/src/common/import/directory-utils.ts
+++ b/src/common/import/directory-utils.ts
@@ -1,0 +1,31 @@
+import { promisify } from 'util';
+import { mkdir, exists, lstat } from 'fs';
+import { sep } from 'path';
+
+export async function ensureDirectoryExists(dir: string): Promise<void> {
+  if (await promisify(exists)(dir)) {
+    const dirStat = await promisify(lstat)(dir);
+    if (!dirStat || !dirStat.isDirectory()) {
+      throw new Error(`"${dir}" already exists and is not a directory.`);
+    }
+  } else {
+    // Ensure parent directory exists.
+    const parentPath = dir.split(sep);
+    parentPath.pop();
+    const parent = parentPath.join(sep);
+    if (parentPath.length > 0) {
+      await ensureDirectoryExists(parent);
+    }
+
+    if (dir.length > 0) {
+      try {
+        await promisify(mkdir)(dir);
+      } catch (e) {
+        if (await promisify(exists)(dir)) {
+          return; // This directory could have been created after we checked if it existed.
+        }
+        throw new Error(`Unable to create directory: "${dir}".`);
+      }
+    }
+  }
+}

--- a/src/common/import/publish-queue.spec.ts
+++ b/src/common/import/publish-queue.spec.ts
@@ -1,0 +1,395 @@
+import fetch from 'node-fetch';
+import { OAuth2Client, ContentItem, AccessToken } from 'dc-management-sdk-js';
+import { PublishingJob, PublishQueue } from './publish-queue';
+
+jest.mock('node-fetch');
+jest.mock('dc-management-sdk-js/build/main/lib/oauth2/services/OAuth2Client');
+
+interface PublishTemplate {
+  href: string;
+  status: number;
+  statusText: string;
+  headers?: Map<string, string>;
+
+  jsonProvider: (template: PublishTemplate) => PublishingJob;
+}
+
+const defaultTemplate: PublishTemplate = {
+  href: '',
+  status: 404,
+  statusText: 'NOT_FOUND',
+
+  jsonProvider: () => {
+    throw new Error('Not valid JSON');
+  }
+};
+
+describe('publish-queue', () => {
+  describe('publishing tests', () => {
+    let totalPolls = 0;
+    let totalRequests = 0;
+    let authRequests = 0;
+
+    beforeEach((): void => {
+      totalRequests = 0;
+      totalPolls = 0;
+      authRequests = 0;
+    });
+
+    afterEach((): void => {
+      jest.resetAllMocks();
+    });
+
+    // should request a publish using the REST api, with authentication given by the creation arguments
+    // should wait for publish completion when hitting the concurrent limit and attempting to publish more
+    // should never wait for publish completion between publishes when less than the concurrent limit
+    // should wait for all publishes to complete when calling waitForAll
+    // should complete immediately when calling waitForAll with no publishes in progress
+
+    // should throw an error when publish link is not present
+    // should throw an error when publish fails to start (request is not OK)
+    // should throw an error when publish POST response headers do not include a Location for the job status
+
+    // should ignore an attempt waiting for job status if fetching it does not succeed, and request again later as usual
+    // should delay when a job reports as not completed and it is being waited on
+    // should throw an error when waiting for a publish job exceeds the maxAttempts number
+    // should report failed publishes in the failedJobs list
+
+    function sharedMock(templates: PublishTemplate[]): void {
+      (OAuth2Client.prototype.getToken as jest.Mock).mockImplementation(() => {
+        authRequests++;
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        const result: AccessToken = { access_token: 'token-example', expires_in: 99999, refresh_token: 'refresh' };
+        return Promise.resolve(result);
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ((fetch as any) as jest.Mock).mockImplementation((href, options) => {
+        const template: PublishTemplate = templates.find(template => template.href == href) || defaultTemplate;
+
+        if (options.headers['Authorization'] != 'bearer token-example') {
+          throw new Error('Not authorized!');
+        }
+
+        totalRequests++;
+
+        return Promise.resolve({
+          status: template.status,
+          statusText: template.statusText,
+          headers: template.headers,
+          json: jest.fn().mockImplementation(() => Promise.resolve(template.jsonProvider(template))),
+          text: jest.fn().mockResolvedValue('Error Text')
+        });
+      });
+    }
+
+    function getPublishableItem(id: string): ContentItem {
+      return new ContentItem({
+        id: id,
+        _links: {
+          publish: {
+            href: '//publish-' + id
+          }
+        }
+      });
+    }
+
+    function publishStartTemplate(href: string, location: string): PublishTemplate {
+      return {
+        href: href,
+        status: 204,
+        statusText: 'No Content',
+        headers: new Map([['Location', location]]),
+
+        jsonProvider: (): PublishingJob => {
+          throw new Error('No body');
+        }
+      };
+    }
+
+    function progressStepsTemplate(href: string, polls: number, fail?: boolean | number): PublishTemplate {
+      let callNumber = 0;
+
+      return {
+        href: href,
+        status: 200,
+        statusText: 'OK',
+
+        jsonProvider: (): PublishingJob => {
+          const result: PublishingJob = {
+            id: href,
+            scheduledDate: '',
+            createdDate: '',
+            createdBy: '',
+            state: 'PREPARING',
+            _links: { self: { href } }
+          };
+
+          totalPolls++;
+
+          if (typeof fail === 'number' && fail == callNumber) {
+            callNumber++;
+            throw new Error('Data does not parse.');
+          } else {
+            if (callNumber == 0 && polls > 1) {
+              result.state = 'PREPARING';
+            } else if (callNumber < polls - 1) {
+              result.state = 'PUBLISHING';
+            } else {
+              result.state = fail === true ? 'FAILED' : 'COMPLETED';
+            }
+          }
+
+          callNumber++;
+
+          return result;
+        }
+      };
+    }
+
+    function multiMock(count: number, polls: number): ContentItem[] {
+      const items: ContentItem[] = [];
+      const templates: PublishTemplate[] = [];
+
+      for (let i = 0; i < count; i++) {
+        templates.push(publishStartTemplate(`//publish-id${i}`, `//publishJob-id${i}`));
+        templates.push(progressStepsTemplate(`//publishJob-id${i}`, polls));
+
+        items.push(getPublishableItem(`id${i}`));
+      }
+
+      sharedMock(templates);
+
+      return items;
+    }
+
+    function makeQueue(maxWaiting: number): PublishQueue {
+      const queue = new PublishQueue({ clientId: 'id', clientSecret: 'secret', hubId: 'hub' });
+      queue.attemptDelay = 0;
+      queue.maxWaiting = maxWaiting;
+
+      return queue;
+    }
+
+    it('should request a publish using the REST api, with authentication given by the creation arguments', async () => {
+      const item1 = getPublishableItem('id1');
+      sharedMock([
+        publishStartTemplate('//publish-id1', '//publishJob-id1'),
+        progressStepsTemplate('//publishJob-id1', 3)
+      ]);
+
+      const queue = makeQueue(10);
+
+      await queue.publish(item1);
+
+      await queue.waitForAll();
+
+      expect(authRequests).toBeGreaterThan(0);
+      expect(totalRequests).toEqual(4);
+      expect(totalPolls).toEqual(3);
+    });
+
+    it('should wait for publish completion when hitting the concurrent limit and attempting to publish more', async () => {
+      const items = multiMock(10, 1); // 10 items, return success on the first poll (instant publish)
+
+      const queue = makeQueue(5); // After 5 concurrent requests, start waiting.
+
+      for (let i = 0; i < items.length; i++) {
+        await queue.publish(items[i]);
+
+        // Starts polling when i == 5, and each time we continue one job has completed.
+        expect(totalPolls).toEqual(Math.max(0, i - 4));
+      }
+
+      await queue.waitForAll();
+
+      expect(totalPolls).toEqual(10);
+    });
+
+    it('should never wait for publish completion between publishes when less than the concurrent limit', async () => {
+      const items = multiMock(10, 1); // 10 items, return success on the first poll (instant publish)
+
+      const queue = makeQueue(15); // After 15 concurrent requests, start waiting.
+
+      for (let i = 0; i < items.length; i++) {
+        await queue.publish(items[i]);
+      }
+
+      expect(totalPolls).toEqual(0);
+
+      await queue.waitForAll();
+
+      expect(totalPolls).toEqual(10);
+    });
+
+    it('should complete immediately when calling waitForAll with no publishes in progress', async () => {
+      const queue = makeQueue(15); // After 15 concurrent requests, start waiting.
+
+      await queue.waitForAll();
+
+      expect(totalPolls).toEqual(0);
+    });
+
+    it('should throw an error when publish link is not present', async () => {
+      const item1 = getPublishableItem('id1');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (item1 as any)._links = {};
+      sharedMock([
+        publishStartTemplate('//publish-id1', '//publishJob-id1'),
+        progressStepsTemplate('//publishJob-id1', 3)
+      ]);
+
+      const queue = makeQueue(15);
+
+      let threw = false;
+      try {
+        await queue.publish(item1);
+      } catch (e) {
+        threw = true;
+      }
+
+      expect(threw).toBeTruthy();
+
+      await queue.waitForAll();
+
+      expect(totalPolls).toEqual(0);
+    });
+
+    it('should throw an error when publish POST response headers do not include a Location for the job status', async () => {
+      const item1 = getPublishableItem('id1');
+      sharedMock([
+        {
+          href: '//publish-id1',
+          status: 204,
+          statusText: 'No Content',
+          headers: new Map(),
+
+          jsonProvider: (): PublishingJob => {
+            throw new Error('No body');
+          }
+        },
+        progressStepsTemplate('//publishJob-id1', 3)
+      ]);
+
+      const queue = makeQueue(15);
+
+      let threw = false;
+      try {
+        await queue.publish(item1);
+      } catch (e) {
+        threw = true;
+      }
+
+      expect(threw).toBeTruthy();
+
+      await queue.waitForAll();
+
+      expect(totalPolls).toEqual(0);
+    });
+
+    it('should throw an error when publish fails to start (request is not OK)', async () => {
+      const item1 = getPublishableItem('id1');
+      sharedMock([
+        {
+          href: '//publish-id1',
+          status: 500,
+          statusText: 'Internal Server Error',
+
+          jsonProvider: (): PublishingJob => {
+            throw new Error('No body');
+          }
+        },
+        progressStepsTemplate('//publishJob-id1', 3)
+      ]);
+
+      const queue = makeQueue(15);
+
+      let threw = false;
+      try {
+        await queue.publish(item1);
+      } catch (e) {
+        threw = true;
+      }
+
+      expect(threw).toBeTruthy();
+
+      await queue.waitForAll();
+
+      expect(totalPolls).toEqual(0);
+    });
+
+    // should ignore an attempt waiting for job status if fetching it does not succeed, and request again later as usual
+    // should delay when a job reports as not completed and it is being waited on
+    // should throw an error when waiting for a publish job exceeds the maxAttempts number
+    // should report failed publishes in the failedJobs list
+
+    it('should ignore an attempt waiting for job status if fetching it does not succeed, and request again later as usual', async () => {
+      const item1 = getPublishableItem('id1');
+
+      sharedMock([
+        publishStartTemplate('//publish-id1', '//publishJob-id1'),
+        progressStepsTemplate('//publishJob-id1', 3, 1)
+      ]);
+
+      const queue = makeQueue(15);
+
+      await queue.publish(item1);
+
+      await queue.waitForAll();
+
+      expect(queue.failedJobs.length).toEqual(0);
+      expect(totalPolls).toEqual(3);
+      expect(totalRequests).toEqual(4);
+    });
+
+    it('should report failed publishes in the failedJobs list', async () => {
+      const item1 = getPublishableItem('id1');
+      const item2 = getPublishableItem('id2'); // fails
+      const item3 = getPublishableItem('id3'); // fails
+
+      sharedMock([
+        publishStartTemplate('//publish-id1', '//publishJob-id1'),
+        progressStepsTemplate('//publishJob-id1', 1),
+        publishStartTemplate('//publish-id2', '//publishJob-id2'),
+        progressStepsTemplate('//publishJob-id2', 1, true),
+        publishStartTemplate('//publish-id3', '//publishJob-id3'),
+        progressStepsTemplate('//publishJob-id3', 1, true)
+      ]);
+
+      const queue = makeQueue(15);
+
+      await queue.publish(item1);
+      await queue.publish(item2);
+      await queue.publish(item3);
+
+      await queue.waitForAll();
+
+      expect(queue.failedJobs.length).toEqual(2);
+      expect(queue.failedJobs[0].item).toEqual(item2);
+      expect(queue.failedJobs[1].item).toEqual(item3);
+      expect(totalPolls).toEqual(3);
+      expect(totalRequests).toEqual(6);
+    });
+
+    it('should still correctly waitForAll if a previous publish is waiting to start', async () => {
+      const items = multiMock(10, 1); // 10 items, return success on the first poll (instant publish)
+
+      const queue = makeQueue(5); // After 5 concurrent requests, start waiting.
+
+      for (let i = 0; i < items.length; i++) {
+        // Deliberately avoid waiting after starting the first publish that would have to wait.
+        // This is an unlikely situation, but handling it consistently is useful.
+
+        if (i < 5) {
+          await queue.publish(items[i]);
+        } else {
+          queue.publish(items[i]);
+        }
+      }
+
+      await queue.waitForAll();
+
+      expect(totalPolls).toEqual(10);
+    });
+  });
+});

--- a/src/common/import/publish-queue.spec.ts
+++ b/src/common/import/publish-queue.spec.ts
@@ -150,10 +150,9 @@ describe('publish-queue', () => {
       return items;
     }
 
-    function makeQueue(maxWaiting: number): PublishQueue {
+    function makeQueue(): PublishQueue {
       const queue = new PublishQueue({ clientId: 'id', clientSecret: 'secret', hubId: 'hub' });
       queue.attemptDelay = 0;
-      queue.maxWaiting = maxWaiting;
 
       return queue;
     }
@@ -165,7 +164,7 @@ describe('publish-queue', () => {
         progressStepsTemplate('//publishJob-id1', 3)
       ]);
 
-      const queue = makeQueue(10);
+      const queue = makeQueue();
 
       await queue.publish(item1);
 
@@ -176,16 +175,16 @@ describe('publish-queue', () => {
       expect(totalPolls).toEqual(3);
     });
 
-    it('should wait for publish completion when hitting the concurrent limit and attempting to publish more', async () => {
+    it('should wait for publish completion when starting a publish and attempting to publish more', async () => {
       const items = multiMock(10, 1); // 10 items, return success on the first poll (instant publish)
 
-      const queue = makeQueue(5); // After 5 concurrent requests, start waiting.
+      const queue = makeQueue();
 
       for (let i = 0; i < items.length; i++) {
         await queue.publish(items[i]);
 
-        // Starts polling when i == 5, and each time we continue one job has completed.
-        expect(totalPolls).toEqual(Math.max(0, i - 4));
+        // Starts polling when i == 1, and each time we continue one job has completed.
+        expect(totalPolls).toEqual(Math.max(0, i));
       }
 
       await queue.waitForAll();
@@ -193,10 +192,10 @@ describe('publish-queue', () => {
       expect(totalPolls).toEqual(10);
     });
 
-    it('should never wait for publish completion between publishes when less than the concurrent limit', async () => {
-      const items = multiMock(10, 1); // 10 items, return success on the first poll (instant publish)
+    it('should never wait for publish completion when starting a publish, only when waiting or publishing more', async () => {
+      const items = multiMock(1, 1); // 10 items, return success on the first poll (instant publish)
 
-      const queue = makeQueue(15); // After 15 concurrent requests, start waiting.
+      const queue = makeQueue(); // After 1 concurrent request, start waiting.
 
       for (let i = 0; i < items.length; i++) {
         await queue.publish(items[i]);
@@ -206,11 +205,11 @@ describe('publish-queue', () => {
 
       await queue.waitForAll();
 
-      expect(totalPolls).toEqual(10);
+      expect(totalPolls).toEqual(1);
     });
 
     it('should complete immediately when calling waitForAll with no publishes in progress', async () => {
-      const queue = makeQueue(15); // After 15 concurrent requests, start waiting.
+      const queue = makeQueue();
 
       await queue.waitForAll();
 
@@ -226,7 +225,7 @@ describe('publish-queue', () => {
         progressStepsTemplate('//publishJob-id1', 3)
       ]);
 
-      const queue = makeQueue(15);
+      const queue = makeQueue();
 
       let threw = false;
       try {
@@ -258,7 +257,7 @@ describe('publish-queue', () => {
         progressStepsTemplate('//publishJob-id1', 3)
       ]);
 
-      const queue = makeQueue(15);
+      const queue = makeQueue();
 
       let threw = false;
       try {
@@ -289,7 +288,7 @@ describe('publish-queue', () => {
         progressStepsTemplate('//publishJob-id1', 3)
       ]);
 
-      const queue = makeQueue(15);
+      const queue = makeQueue();
 
       let threw = false;
       try {
@@ -313,7 +312,7 @@ describe('publish-queue', () => {
         progressStepsTemplate('//publishJob-id1', 3, 1)
       ]);
 
-      const queue = makeQueue(15);
+      const queue = makeQueue();
 
       await queue.publish(item1);
 
@@ -338,7 +337,7 @@ describe('publish-queue', () => {
         progressStepsTemplate('//publishJob-id3', 1, true)
       ]);
 
-      const queue = makeQueue(15);
+      const queue = makeQueue();
 
       await queue.publish(item1);
       await queue.publish(item2);
@@ -356,7 +355,7 @@ describe('publish-queue', () => {
     it('should still correctly waitForAll if a previous publish is waiting to start', async () => {
       const items = multiMock(10, 1); // 10 items, return success on the first poll (instant publish)
 
-      const queue = makeQueue(5); // After 5 concurrent requests, start waiting.
+      const queue = makeQueue();
 
       for (let i = 0; i < items.length; i++) {
         // Deliberately avoid waiting after starting the first publish that would have to wait.
@@ -375,28 +374,28 @@ describe('publish-queue', () => {
     });
 
     it('should error publishes when waiting for a publish job exceeds the maxAttempts number', async () => {
-      const items = multiMock(10, 5); // 10 items, return success on the 5th poll (after our limit)
+      const items = multiMock(3, 5); // 3 items, return success on the 5th poll (after our limit)
 
-      const queue = makeQueue(5); // After 5 concurrent requests, start waiting.
-      queue.maxAttempts = 2;
+      const queue = makeQueue(); // After 1 concurrent request, start waiting.
+      queue.maxAttempts = 2; // Fail after 2 incomplete polls.
 
       for (let i = 0; i < items.length; i++) {
         await queue.publish(items[i]);
 
         if (queue.failedJobs.length > 0) {
           // The first job should have failed.
-          expect(i).toEqual(5); // We only waited for the first job after 0-4 were in the queue.
+          expect(i).toEqual(1); // We only waited for the first job after the second was put in the queue.
           expect(queue.failedJobs[0].item).toBe(items[0]);
           break;
         }
 
-        expect(i).toBeLessThan(5);
+        expect(i).toBeLessThan(1);
       }
 
       await queue.waitForAll();
 
-      expect(totalPolls).toEqual(12); // 6 total publish requests. 2 waits before each before giving up.
-      expect(queue.failedJobs.length).toEqual(6);
+      expect(totalPolls).toEqual(4); // 2 total publish requests. 2 waits before each before giving up.
+      expect(queue.failedJobs.length).toEqual(2);
     });
   });
 });

--- a/src/common/import/publish-queue.spec.ts
+++ b/src/common/import/publish-queue.spec.ts
@@ -40,20 +40,7 @@ describe('publish-queue', () => {
       jest.resetAllMocks();
     });
 
-    // should request a publish using the REST api, with authentication given by the creation arguments
-    // should wait for publish completion when hitting the concurrent limit and attempting to publish more
-    // should never wait for publish completion between publishes when less than the concurrent limit
     // should wait for all publishes to complete when calling waitForAll
-    // should complete immediately when calling waitForAll with no publishes in progress
-
-    // should throw an error when publish link is not present
-    // should throw an error when publish fails to start (request is not OK)
-    // should throw an error when publish POST response headers do not include a Location for the job status
-
-    // should ignore an attempt waiting for job status if fetching it does not succeed, and request again later as usual
-    // should delay when a job reports as not completed and it is being waited on
-    // should throw an error when waiting for a publish job exceeds the maxAttempts number
-    // should report failed publishes in the failedJobs list
 
     function sharedMock(templates: PublishTemplate[]): void {
       (OAuth2Client.prototype.getToken as jest.Mock).mockImplementation(() => {
@@ -318,10 +305,8 @@ describe('publish-queue', () => {
       expect(totalPolls).toEqual(0);
     });
 
-    // should ignore an attempt waiting for job status if fetching it does not succeed, and request again later as usual
     // should delay when a job reports as not completed and it is being waited on
     // should throw an error when waiting for a publish job exceeds the maxAttempts number
-    // should report failed publishes in the failedJobs list
 
     it('should ignore an attempt waiting for job status if fetching it does not succeed, and request again later as usual', async () => {
       const item1 = getPublishableItem('id1');

--- a/src/common/import/publish-queue.ts
+++ b/src/common/import/publish-queue.ts
@@ -19,7 +19,7 @@ async function delay(duration: number): Promise<void> {
   });
 }
 
-interface JobRequest {
+export interface JobRequest {
   item: ContentItem;
   href: string;
 }

--- a/src/common/import/publish-queue.ts
+++ b/src/common/import/publish-queue.ts
@@ -25,7 +25,6 @@ export interface JobRequest {
 }
 
 export class PublishQueue {
-  maxWaiting = 10;
   maxAttempts = 30;
   attemptDelay = 1000;
   failedJobs: JobRequest[] = [];
@@ -138,7 +137,7 @@ export class PublishQueue {
   }
 
   private async rateLimit(): Promise<void> {
-    if (this.inProgressJobs.length != this.maxWaiting) {
+    if (this.inProgressJobs.length == 0) {
       return;
     }
 

--- a/src/common/import/publish-queue.ts
+++ b/src/common/import/publish-queue.ts
@@ -25,7 +25,7 @@ export interface JobRequest {
 }
 
 export class PublishQueue {
-  maxWaiting = 3;
+  maxWaiting = 10;
   attemptDelay = 1000;
   failedJobs: JobRequest[] = [];
 

--- a/src/common/import/publish-queue.ts
+++ b/src/common/import/publish-queue.ts
@@ -1,0 +1,165 @@
+import { ContentItem, OAuth2Client, AxiosHttpClient } from 'dc-management-sdk-js';
+import fetch, { Response } from 'node-fetch';
+import { HalLink } from 'dc-management-sdk-js/build/main/lib/hal/models/HalLink';
+import { ConfigurationParameters } from '../../commands/configure';
+
+export interface PublishingJob {
+  id: string;
+  scheduledDate: string;
+  createdDate: string;
+  createdBy: string;
+  state: 'PREPARING' | 'PUBLISHING' | 'COMPLETED' | 'FAILED';
+
+  _links?: { [name: string]: HalLink };
+}
+
+async function delay(duration: number): Promise<void> {
+  return new Promise<void>((resolve): void => {
+    setTimeout(resolve, duration);
+  });
+}
+
+interface JobRequest {
+  item: ContentItem;
+  href: string;
+}
+
+export class PublishQueue {
+  maxWaiting = 3;
+  attemptDelay = 1000;
+  failedJobs: JobRequest[] = [];
+
+  private inProgressJobs: JobRequest[] = [];
+  private waitingList: { promise: Promise<void>; resolver: () => void }[] = [];
+  private auth: OAuth2Client;
+  private awaitingAll: boolean;
+
+  waitInProgress = false;
+
+  constructor(credentials: ConfigurationParameters) {
+    const http = new AxiosHttpClient({});
+    this.auth = new OAuth2Client(
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      { client_id: credentials.clientId, client_secret: credentials.clientSecret },
+      { authUrl: process.env.AUTH_URL },
+      http
+    );
+  }
+
+  private async getToken(): Promise<string> {
+    const token = await this.auth.getToken();
+    return token.access_token;
+  }
+
+  private async fetch(href: string, method: string): Promise<Response> {
+    return await fetch(href, { method: method, headers: { Authorization: 'bearer ' + (await this.getToken()) } });
+  }
+
+  async publish(item: ContentItem): Promise<void> {
+    await this.rateLimit();
+
+    // Do publish
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const publishLink = (item._links as any)['publish'];
+
+    if (publishLink == null) {
+      throw new Error('Cannot publish the item - link not available.');
+    }
+
+    // Need to manually fetch the publish endpoint.
+
+    const publish = await this.fetch(publishLink.href, 'POST');
+    if (publish.status != 204) {
+      throw new Error(`Failed to start publish: ${publish.statusText} - ${await publish.text()}`);
+    }
+
+    const publishJobInfoHref = publish.headers.get('Location');
+
+    if (publishJobInfoHref == null) {
+      throw new Error('Expected publish job location in header. Has the publish workflow changed?');
+    }
+
+    this.inProgressJobs.push({ href: publishJobInfoHref, item });
+  }
+
+  private async waitForOldestPublish(): Promise<void> {
+    if (this.inProgressJobs.length === 0) {
+      return;
+    }
+
+    this.waitInProgress = true;
+
+    const oldestJob = this.inProgressJobs[0];
+    this.inProgressJobs.splice(0, 1);
+
+    // Request the status for the oldest ID.
+    // If it's still not published/errored, then wait a bit and try again.
+
+    while (true) {
+      let job: PublishingJob;
+      try {
+        job = await (await this.fetch(oldestJob.href, 'GET')).json();
+      } catch (e) {
+        // Could not fetch job information.
+        continue;
+      }
+
+      if (job.state === 'COMPLETED') {
+        break;
+      } else if (job.state === 'FAILED') {
+        this.failedJobs.push(oldestJob);
+        break;
+      } else {
+        await delay(this.attemptDelay);
+      }
+    }
+
+    // The wait completed. Notify the first in the queue.
+
+    const oldestWaiter = this.waitingList[0];
+    if (oldestWaiter != null) {
+      this.waitingList.splice(0, 1);
+
+      oldestWaiter.resolver(); // Resolve the promise.
+    }
+
+    if (this.waitingList.length > 0 || this.awaitingAll) {
+      // Still more waiting.
+      await this.waitForOldestPublish();
+    } else {
+      this.waitInProgress = false;
+    }
+  }
+
+  private async rateLimit(): Promise<void> {
+    if (this.inProgressJobs.length != this.maxWaiting) {
+      return;
+    }
+
+    // We need to wait.
+    let resolver: () => void = () => {};
+    const myPromise = new Promise<void>((resolve): void => {
+      resolver = resolve;
+    });
+
+    this.waitingList.push({ promise: myPromise, resolver: resolver });
+
+    if (!this.waitInProgress) {
+      // Start a wait.
+      this.waitForOldestPublish();
+    }
+
+    await myPromise;
+  }
+
+  async waitForAll(): Promise<void> {
+    if (this.waitInProgress) {
+      // Wait for the last item on the list to complete.
+      await this.waitingList[this.waitingList.length - 1].promise;
+    }
+
+    // Continue regardless of waiters.
+    this.awaitingAll = true;
+    await this.waitForOldestPublish();
+  }
+}

--- a/src/common/log-helpers.ts
+++ b/src/common/log-helpers.ts
@@ -1,0 +1,9 @@
+import { join } from 'path';
+
+export function getDefaultLogPath(type: string, action: string, platform: string = process.platform): string {
+  return join(
+    process.env[platform == 'win32' ? 'USERPROFILE' : 'HOME'] || __dirname,
+    '.amplience',
+    `logs/${type}-${action}-<DATE>.log`
+  );
+}

--- a/src/interfaces/export-item-builder-options.interface.ts
+++ b/src/interfaces/export-item-builder-options.interface.ts
@@ -4,4 +4,5 @@ export interface ExportItemBuilderOptions {
   repoId?: string[] | string;
   schemaId?: string[] | string;
   name?: string[] | string;
+  logFile?: string;
 }

--- a/src/interfaces/export-item-builder-options.interface.ts
+++ b/src/interfaces/export-item-builder-options.interface.ts
@@ -1,7 +1,7 @@
 export interface ExportItemBuilderOptions {
   dir: string;
-  folderId?: string[];
-  repoId?: string[];
-  schemaId?: string[];
-  name?: string[];
+  folderId?: string[] | string;
+  repoId?: string[] | string;
+  schemaId?: string[] | string;
+  name?: string[] | string;
 }

--- a/src/interfaces/export-item-builder-options.interface.ts
+++ b/src/interfaces/export-item-builder-options.interface.ts
@@ -1,0 +1,7 @@
+export interface ExportItemBuilderOptions {
+  dir: string;
+  folderId?: string[];
+  repoId?: string[];
+  schemaId?: string[];
+  name?: string[];
+}

--- a/src/interfaces/export-item-builder-options.interface.ts
+++ b/src/interfaces/export-item-builder-options.interface.ts
@@ -7,6 +7,7 @@ export interface ExportItemBuilderOptions {
   schemaId?: string[] | string;
   name?: string[] | string;
   logFile?: string | FileLog;
+  publish?: boolean;
 
   exportedIds?: string[];
 }

--- a/src/interfaces/export-item-builder-options.interface.ts
+++ b/src/interfaces/export-item-builder-options.interface.ts
@@ -7,4 +7,6 @@ export interface ExportItemBuilderOptions {
   schemaId?: string[] | string;
   name?: string[] | string;
   logFile?: string | FileLog;
+
+  exportedIds?: string[];
 }

--- a/src/interfaces/export-item-builder-options.interface.ts
+++ b/src/interfaces/export-item-builder-options.interface.ts
@@ -1,8 +1,10 @@
+import { FileLog } from '../common/file-log';
+
 export interface ExportItemBuilderOptions {
   dir: string;
   folderId?: string[] | string;
   repoId?: string[] | string;
   schemaId?: string[] | string;
   name?: string[] | string;
-  logFile?: string;
+  logFile?: string | FileLog;
 }

--- a/src/interfaces/import-item-builder-options.interface.ts
+++ b/src/interfaces/import-item-builder-options.interface.ts
@@ -6,4 +6,5 @@ export interface ImportItemBuilderOptions {
   force?: boolean;
   validate?: boolean;
   skipIncomplete?: boolean;
+  logFile?: string;
 }

--- a/src/interfaces/import-item-builder-options.interface.ts
+++ b/src/interfaces/import-item-builder-options.interface.ts
@@ -5,4 +5,5 @@ export interface ImportItemBuilderOptions {
   mapFile?: string;
   force?: boolean;
   validate?: boolean;
+  skipIncomplete?: boolean;
 }

--- a/src/interfaces/import-item-builder-options.interface.ts
+++ b/src/interfaces/import-item-builder-options.interface.ts
@@ -1,0 +1,8 @@
+export interface ImportItemBuilderOptions {
+  dir: string;
+  baseRepo?: string;
+  baseFolder?: string;
+  mapFile?: string;
+  force?: boolean;
+  validate?: boolean;
+}

--- a/src/interfaces/import-item-builder-options.interface.ts
+++ b/src/interfaces/import-item-builder-options.interface.ts
@@ -6,6 +6,7 @@ export interface ImportItemBuilderOptions {
   baseFolder?: string;
   mapFile?: string;
   publish?: boolean;
+  republish?: boolean;
   force?: boolean;
   validate?: boolean;
   skipIncomplete?: boolean;

--- a/src/interfaces/import-item-builder-options.interface.ts
+++ b/src/interfaces/import-item-builder-options.interface.ts
@@ -1,3 +1,5 @@
+import { FileLog } from '../common/file-log';
+
 export interface ImportItemBuilderOptions {
   dir: string;
   baseRepo?: string;
@@ -6,5 +8,7 @@ export interface ImportItemBuilderOptions {
   force?: boolean;
   validate?: boolean;
   skipIncomplete?: boolean;
-  logFile?: string;
+  logFile?: string | FileLog;
+
+  revertLog?: string;
 }

--- a/src/interfaces/import-item-builder-options.interface.ts
+++ b/src/interfaces/import-item-builder-options.interface.ts
@@ -5,6 +5,7 @@ export interface ImportItemBuilderOptions {
   baseRepo?: string;
   baseFolder?: string;
   mapFile?: string;
+  publish?: boolean;
   force?: boolean;
   validate?: boolean;
   skipIncomplete?: boolean;

--- a/src/services/export.service.ts
+++ b/src/services/export.service.ts
@@ -7,13 +7,11 @@ import readline from 'readline';
 
 export type ExportResult = 'CREATED' | 'UPDATED' | 'UP-TO-DATE';
 
-export const uniqueFilename = (dir: string, uri = '', extension: string, exportFilenames: string[]): string => {
+export const uniqueFilenamePath = (dir: string, file = '', extension: string, exportFilenames: string[]): string => {
   if (dir.substr(-1) === path.sep) {
     dir = dir.slice(0, -1);
   }
 
-  const url = new URL(uri);
-  const file = path.basename(url.pathname, '.' + extension) || url.hostname.replace('.', '_');
   let counter = 0;
   let uniqueFilename = '';
   do {
@@ -25,6 +23,12 @@ export const uniqueFilename = (dir: string, uri = '', extension: string, exportF
     counter++;
   } while (exportFilenames.includes(uniqueFilename));
   return uniqueFilename;
+};
+
+export const uniqueFilename = (dir: string, uri = '', extension: string, exportFilenames: string[]): string => {
+  const url = new URL(uri);
+  const file = path.basename(url.pathname, '.' + extension) || url.hostname.replace('.', '_');
+  return uniqueFilenamePath(dir, file, extension, exportFilenames);
 };
 
 export const writeJsonToFile = <T extends HalResource>(filename: string, resource: T): void => {


### PR DESCRIPTION
This PR adds commands for import/export. These are pretty complicated, so the testing is quite extensive but doesn't reach 100% yet on the import task.

# Export Task
`dc-cli content-item export <dir>`
The export task exports content from the configured hub into the destination folder. This content is in the format returned by the api - a wrapper object containing the metadata (eg. label, lastPublishedVersion), then the actual content under the `body` property.

By default, this command will export content from all repositories, and all folders within them, as long as they aren't archived. By using parameters, you can limit this to exporting from a specific folder, repository, and to filter items within these by name/schema id. The filters can be exact, or by regex, which can be achieved by surrounding the filter in forward slashes (like /filter.*regex/).

This command scans the content dependancies of items being exported. If they contain any items that are not included in the export scope, or are archived, then they will be exported under the folder `_dependancies/`. Dependancies are traversed recursively, so any dependancies introduced this way can also include dependancies of their own.

Parameters:
- **--repoId:** Export content from within a given repository. Directory structure will start at the specified repository. Will automatically export all contained folders.
- **--folderId:** Export content from within a given folder. Directory structure will start at the specified folder. Can be used in addition to repoId.
- **--schemaId:** Export content with a given or matching Schema ID. A regex can be provided, surrounded with forward slashes. Can be used in combination with other filters.
- **--name:** Export content with a given or matching Name. A regex can be provided, surrounded with forward slashes. Can be used in combination with other filters.
- **--logFile:** Path to a log file to write to.

# Import Task
`dc-cli content-item import <dir>`
The import task imports content from the specified directory into the configured hub. By default, this will treat folders in your directory as Repositories, and try to map them to ones of the same name in your target hub. From there, it will import content items to each repo, recreating the folder structure in each. This format is an exact match for the export format, so it is ideal for copying content within or between hubs.

Similar to the export task, you can import into a specific repo or folder. When doing this, the top level directory should just contain the content and subfolders, rather than containing individual repositories as folders. All folder structure will be created before importing content items.

If content items are imported that are missing types, or have them misconfigured, the command will be able to resolve these issues itself on user request. For example, if a content type exists in a hub, but is not assigned to a repo relevant content is being imported to, then the command can automatically create the missing assignment on user request.

At the core of the import process lies the ID mapping and the dependancy tree. When content is imported to a a new destination, it will be created with a new ID courtesy of the DC api. This will cause problems with other content that references it, as that content will now need to reference the _new_ ID for that content, which will only become available once it is imported. During import an ID mapping is built for this reason, between the IDs in the files and the new ones, and it is saved afterwards for a future use. Because of this, we need to import content in an order that ensures we already have the ID for all contained content items when importing it - a dependancy tree must be built.

The dependancy tree will follow all standard content links and references in content items, and will track dependancies and dependants for each item. It will build a list of "levels" - each level requires the content in the previous level to be imported. This way, we can import each item in order, once, and all required IDs will always be available. 

Circular dependancies do not appear on the tree: instead they are detected and placed on a separate list simply called `circularLinks`. These use a different strategy when importing - create the content first to get all the new IDs (with null or invalid references), then update it afterwards with the new IDs in the references. Circular content is not a typical use case for DC since it is unpublishable, but the case is covered here in case it is important in future.

The ID mapping is saved to a default location in the `.amplience` folder, based on the destination (hub/repo/folder, and its id). This location is printed, but you can also specify it with `--logFile`. This ID mapping is also _loaded_ on future executions of the import command, which allows you to reimport the same content by overwriting existing items, and import _new_ content with references to those you have already imported.

You have the option to import content with the `--publish` option. This will publish all content with `lastPublishedVersion` present in the metadata - so all content that was published when it was exported. This requests publishes from a "publish queue", which responsibly limits the number of concurrent publishes.

There are two key optimisations to publishing to avoid it making too many requests:
- Dependancy elimination: If content item 'A' is depended on by another content item 'B' that will be published anyways, then the publish request does not need to be made for 'A' as it will be covered when publishing 'B'. In our demo site, this roughly results in 1/3 of publishes that need to be performed.
- Don't publish when unmodified: If a content item isn't modified when it is imported with an existing mapping, then it does not need to be published again.

You can override the second item if you pass in `--republish`, for instance if you depend on some publish trigger and need it to fire.

There are 6 different situations where the import will stop and ask you if you want to continue:

- Content already exists in the mapping, asks if you want to overwrite the items rather than skipping them.
- Content Types are missing but schemas are present, asks if you want to automatically create them (or abort)
- Content Types are not assigned to target repos, asks if you want to automatically assign them (or abort)
- Content Type Schema are missing, asks if you want to skip content items that use it. (and informs you which, how many)
- Referenced Content Items (dependancies) are missing, asks if you are ok with setting them null or skipping them. (or abort)
- Repositories in the import directory could not be mapped to ones in DC. Asks if you are ok with skipping them. (or abort)

Parameters:
- **--baseRepo:** Import matching the given repository to the import base directory, by ID. Folder structure will be followed and replicated from there.
- **--baseFolder:** Import matching the given folder to the import base directory, by ID. Folder structure will be followed and replicated from there.
- **--mapFile:** Mapping file to use when updating content that already exists. Updated with any new mappings that are generated. If not present, will be created.
- **-f, --force:** Overwrite content, create and assign content types, and ignore content with missing types/references without asking.
- **-v, --validate:** Only recreate folder structure - content is validated but not imported.
- **--skipIncomplete:** Skip any content items that has one or more missing dependancy.
- **--publish:** Publish any content items that have an existing publish status in their JSON.
- **--republish:** Republish content items regardless of whether the import changed them or not. (--publish not required)
- **--logFile:** Path to a log file to write to.

# Publish Queue
The import task requires the ability to automatically publish content items. The responsibility of keeping a maximum number of concurrent publishes is on us, since there is no support in the management sdk.

The interface for the queue is very simple. All the user has to do is request publishes for specific content items, then wait for them all to complete afterwards. Each publish calls a helper function called "rateLimit", which regulates how many concurrent publishes can be active at once.

The rate limit is currently configured to 10 concurrent items being published. When 10 publishes have started, the rate limit checks to see if the oldest publish has complete. If not, then it waits for it to complete before continuing, by polling the processing job status every second. This is enforced so that we can't start any new publishes until older ones complete, so at any given time we can only have a set number of concurrent publishes in progress. Because of this, publish start can take a variable amount of time, and to wait for _all_ started publishes to complete, you will need to `waitForAll` at the end.

# Import-Revert
This is not used yet, but it will be used in future for the copy/move tasks and is fully tested.