### PR TITLE
feat(content-item): archive/unarchive content item commands

### DIFF
--- a/src/commands/content-item/archive.spec.ts
+++ b/src/commands/content-item/archive.spec.ts
@@ -1,0 +1,957 @@
+import { builder, command, handler, LOG_FILENAME, filterContentItems, getContentItems, processItems } from './archive';
+import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
+import { ContentRepository, ContentItem, Folder } from 'dc-management-sdk-js';
+import Yargs from 'yargs/yargs';
+import readline from 'readline';
+import MockPage from '../../common/dc-management-sdk-js/mock-page';
+import { dirname } from 'path';
+import { promisify } from 'util';
+import { exists, readFile, unlink, mkdir, writeFile } from 'fs';
+
+jest.mock('readline');
+
+jest.mock('../../services/dynamic-content-client-factory');
+
+describe('content-item archive command', () => {
+  afterEach((): void => {
+    jest.restoreAllMocks();
+  });
+  const yargArgs = {
+    $0: 'test',
+    _: ['test'],
+    json: true
+  };
+  const config = {
+    clientId: 'client-id',
+    clientSecret: 'client-id',
+    hubId: 'hub-id'
+  };
+  const archiveMockFunc = jest.fn();
+
+  const mockValues = (
+    archiveError = false
+  ): {
+    mockGet: () => void;
+    mockGetList: () => void;
+    mockItemsList: () => void;
+    mockArchive: () => void;
+    mockItemGetById: () => void;
+    mockRepoGet: () => void;
+    mockFolderGet: () => void;
+  } => {
+    const mockGet = jest.fn();
+    const mockGetList = jest.fn();
+    const mockItemsList = jest.fn();
+    const mockArchive = jest.fn();
+    const mockItemGetById = jest.fn();
+    const mockRepoGet = jest.fn();
+    const mockFolderGet = jest.fn();
+
+    (dynamicContentClientFactory as jest.Mock).mockReturnValue({
+      hubs: {
+        get: mockGet
+      },
+      contentRepositories: {
+        get: mockRepoGet
+      },
+      contentItems: {
+        get: mockItemGetById
+      },
+      folders: {
+        get: mockFolderGet
+      }
+    });
+
+    mockFolderGet.mockResolvedValue(
+      new Folder({
+        name: 'folder1',
+        id: 'folder1',
+        client: {
+          fetchLinkedResource: mockItemsList
+        },
+        _links: {
+          'content-items': {
+            href:
+              'https://api.amplience.net/v2/content/content-repositories/repo1/content-items{?folderId,page,projection,size,sort,status}',
+            templated: true
+          }
+        },
+        related: {
+          contentItems: {
+            list: mockItemsList
+          }
+        }
+      })
+    );
+
+    mockGet.mockResolvedValue({
+      id: 'hub-id',
+      related: {
+        contentRepositories: {
+          list: mockGetList
+        }
+      }
+    });
+
+    mockGetList.mockResolvedValue(
+      new MockPage(ContentRepository, [
+        new ContentRepository({
+          name: 'repo1',
+          client: {
+            fetchLinkedResource: mockItemsList
+          },
+          _links: {
+            'content-items': {
+              href:
+                'https://api.amplience.net/v2/content/content-repositories/repo1/content-items{?folderId,page,projection,size,sort,status}',
+              templated: true
+            }
+          },
+          related: {
+            contentItems: {
+              list: mockItemsList
+            }
+          }
+        })
+      ])
+    );
+
+    mockRepoGet.mockResolvedValue(
+      new ContentRepository({
+        name: 'repo1',
+        client: {
+          fetchLinkedResource: mockItemsList
+        },
+        _links: {
+          'content-items': {
+            href:
+              'https://api.amplience.net/v2/content/content-repositories/repo1/content-items{?folderId,page,projection,size,sort,status}',
+            templated: true
+          }
+        },
+        related: {
+          contentItems: {
+            list: mockItemsList
+          }
+        }
+      })
+    );
+
+    mockItemGetById.mockResolvedValue(
+      new ContentItem({
+        id: '1',
+        label: 'item1',
+        repoId: 'repo1',
+        folderId: 'folder1',
+        status: 'ACTIVE',
+        body: {
+          _meta: {
+            schema: 'http://test.com'
+          }
+        },
+        related: { archive: mockArchive },
+        client: {
+          performActionThatReturnsResource: mockArchive
+        },
+        _links: {
+          archive: {
+            href: 'https://api.amplience.net/v2/content/content-items/1/archive'
+          }
+        }
+      })
+    );
+
+    mockItemsList.mockResolvedValue(
+      new MockPage(ContentItem, [
+        new ContentItem({
+          id: '1',
+          label: 'item1',
+          repoId: 'repo1',
+          folderId: 'folder1',
+          status: 'ACTIVE',
+          body: {
+            _meta: {
+              schema: 'http://test.com'
+            }
+          },
+          related: { archive: mockArchive },
+          client: {
+            performActionThatReturnsResource: mockArchive
+          },
+          _links: {
+            archive: {
+              href: 'https://api.amplience.net/v2/content/content-items/1/archive'
+            }
+          }
+        }),
+        new ContentItem({
+          id: '2',
+          label: 'item2',
+          repoId: 'repo1',
+          folderId: 'folder1',
+          status: 'ACTIVE',
+          body: {
+            _meta: {
+              schema: 'http://test1.com'
+            }
+          },
+          client: {
+            performActionThatReturnsResource: mockArchive
+          },
+          _links: {
+            archive: {
+              href: 'https://api.amplience.net/v2/content/content-items/2/archive'
+            }
+          },
+          related: { archive: mockArchive }
+        })
+      ])
+    );
+
+    if (archiveError) {
+      mockArchive.mockRejectedValue(new Error('Error'));
+      mockFolderGet.mockRejectedValue(new Error('Error'));
+      mockItemGetById.mockRejectedValue(new Error('Error'));
+    }
+
+    return {
+      mockGet,
+      mockGetList,
+      mockItemsList,
+      mockArchive,
+      mockItemGetById,
+      mockRepoGet,
+      mockFolderGet
+    };
+  };
+
+  const contentItems = [
+    new ContentItem({
+      id: '1',
+      label: 'item1',
+      repoId: 'repo1',
+      folderId: 'folder1',
+      status: 'ACTIVE',
+      body: {
+        _meta: {
+          schema: 'http://test.com'
+        }
+      },
+      related: { archive: archiveMockFunc },
+      client: {
+        performActionThatReturnsResource: archiveMockFunc
+      },
+      _links: {
+        archive: {
+          href: 'https://api.amplience.net/v2/content/content-items/1/archive'
+        }
+      }
+    }),
+    new ContentItem({
+      id: '2',
+      label: 'item2',
+      repoId: 'repo1',
+      folderId: 'folder1',
+      status: 'ACTIVE',
+      body: {
+        _meta: {
+          schema: 'http://test1.com'
+        }
+      },
+      client: {
+        performActionThatReturnsResource: archiveMockFunc
+      },
+      _links: {
+        archive: {
+          href: 'https://api.amplience.net/v2/content/content-items/2/archive'
+        }
+      },
+      related: { archive: archiveMockFunc }
+    })
+  ];
+
+  archiveMockFunc.mockResolvedValue({
+    message: 'Success'
+  });
+
+  it('should command should defined', function() {
+    expect(command).toEqual('archive [id]');
+  });
+
+  describe('builder tests', function() {
+    it('should configure yargs', function() {
+      const argv = Yargs(process.argv.slice(2));
+      const spyPositional = jest.spyOn(argv, 'positional').mockReturnThis();
+      const spyOption = jest.spyOn(argv, 'option').mockReturnThis();
+
+      builder(argv);
+
+      expect(spyPositional).toHaveBeenCalledWith('id', {
+        type: 'string',
+        describe:
+          'The ID of a content item to be archived. If id is not provided, this command will archive ALL content items through all content repositories in the hub.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('repoId', {
+        type: 'string',
+        describe: 'The ID of a content repository to search items in to be archived.',
+        requiresArg: false
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('folderId', {
+        type: 'string',
+        describe: 'The ID of a folder to search items in to be archived.',
+        requiresArg: false
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('name', {
+        type: 'string',
+        describe:
+          'The name of a Content Item to be archived.\nA regex can be provided to select multiple items with similar or matching names (eg /.header/).\nA single --name option may be given to match a single content item pattern.\nMultiple --name options may be given to match multiple content items patterns at the same time, or even multiple regex.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('contentType', {
+        type: 'string',
+        describe:
+          'A pattern which will only archive content items with a matching Content Type Schema ID. A single --contentType option may be given to match a single schema id pattern.\\nMultiple --contentType options may be given to match multiple schema patterns at the same time.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('revertLog', {
+        type: 'string',
+        describe:
+          'Path to a log file containing content items unarchived in a previous run of the unarchive command.\nWhen provided, archives all content items listed as UNARCHIVE in the log file.',
+        requiresArg: false
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('f', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'If present, there will be no confirmation prompt before archiving the found content.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('s', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'If present, no log file will be produced.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('ignoreError', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'If present, archive requests that fail will not abort the process.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('logFile', {
+        type: 'string',
+        default: LOG_FILENAME,
+        describe: 'Path to a log file to write to.'
+      });
+    });
+  });
+
+  describe('handler tests', function() {
+    it('should archive all content', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockGet, mockGetList, mockItemsList, mockArchive } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config
+      };
+      await handler(argv);
+
+      expect(mockGet).toHaveBeenCalled();
+      expect(mockGetList).toHaveBeenCalled();
+      expect(mockItemsList).toHaveBeenCalled();
+      expect(mockArchive).toBeCalledTimes(2);
+    });
+
+    it('should archive content by id', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockArchive, mockItemGetById } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        id: '1',
+        repoId: 'repo123'
+      };
+      await handler(argv);
+
+      expect(mockItemGetById).toHaveBeenCalled();
+      expect(mockArchive).toBeCalledTimes(1);
+    });
+
+    it("shouldn't archive content by id", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockArchive, mockItemGetById } = mockValues(true);
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        id: '1'
+      };
+      await handler(argv);
+
+      expect(mockItemGetById).toHaveBeenCalled();
+      expect(mockArchive).not.toBeCalled();
+    });
+
+    it('should archive content by repo id', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockArchive, mockRepoGet } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        repoId: 'repo1'
+      };
+      await handler(argv);
+
+      expect(mockRepoGet).toBeCalledTimes(1);
+      expect(mockArchive).toBeCalledTimes(2);
+    });
+
+    it('should archive content by repo ids', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockArchive, mockRepoGet } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        repoId: ['repo1', 'repo2']
+      };
+      await handler(argv);
+
+      expect(mockRepoGet).toBeCalledTimes(2);
+      expect(mockArchive).toBeCalledTimes(4);
+    });
+
+    it('should archive content by folder id', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockArchive, mockFolderGet, mockItemsList } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        folderId: 'folder1',
+        repoId: 'repo123'
+      };
+      await handler(argv);
+
+      expect(mockFolderGet).toBeCalledTimes(1);
+      expect(mockItemsList).toBeCalledTimes(1);
+      expect(mockArchive).toBeCalledTimes(2);
+    });
+
+    it('should archive content by folder ids', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockArchive, mockFolderGet, mockItemsList } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        folderId: ['folder1', 'folder1']
+      };
+      await handler(argv);
+
+      expect(mockFolderGet).toBeCalledTimes(2);
+      expect(mockItemsList).toBeCalledTimes(2);
+      expect(mockArchive).toBeCalledTimes(4);
+    });
+
+    it('should archive content by name', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockArchive, mockFolderGet, mockItemsList } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        folderId: 'folder1',
+        name: 'item1'
+      };
+      await handler(argv);
+
+      expect(mockFolderGet).toBeCalledTimes(1);
+      expect(mockItemsList).toBeCalledTimes(1);
+      expect(mockArchive).toBeCalledTimes(1);
+    });
+
+    it('should ented', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockArchive, mockFolderGet, mockItemsList } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        id: '123',
+        name: 'item1'
+      };
+      await handler(argv);
+
+      expect(mockFolderGet).not.toBeCalled();
+      expect(mockItemsList).not.toBeCalled();
+      expect(mockArchive).not.toBeCalled();
+    });
+
+    it("shouldn't archive content by name", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockArchive, mockFolderGet, mockItemsList } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        folderId: 'folder1',
+        name: ['item3']
+      };
+      await handler(argv);
+
+      expect(mockFolderGet).toBeCalledTimes(1);
+      expect(mockItemsList).toBeCalledTimes(1);
+      expect(mockArchive).not.toBeCalled();
+    });
+
+    it("shouldn't archive content, answer no", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['n']);
+
+      const { mockArchive, mockFolderGet, mockItemsList } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        folderId: 'folder1',
+        name: 'item1'
+      };
+      await handler(argv);
+
+      expect(mockFolderGet).toBeCalledTimes(1);
+      expect(mockItemsList).toBeCalledTimes(1);
+      expect(mockArchive).not.toBeCalled();
+    });
+
+    it('should archive content by name regexp', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockGet, mockGetList, mockArchive, mockItemsList } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        name: '/item/'
+      };
+      await handler(argv);
+
+      expect(mockGet).toHaveBeenCalled();
+      expect(mockGetList).toHaveBeenCalled();
+      expect(mockItemsList).toHaveBeenCalled();
+      expect(mockArchive).toBeCalledTimes(2);
+    });
+
+    it('should archive content by content type name', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockGet, mockGetList, mockArchive, mockItemsList } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        contentType: 'http://test.com'
+      };
+      await handler(argv);
+
+      expect(mockGet).toHaveBeenCalled();
+      expect(mockGetList).toHaveBeenCalled();
+      expect(mockItemsList).toHaveBeenCalled();
+      expect(mockArchive).toBeCalledTimes(1);
+    });
+
+    it('should archive content by content type regexp', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockGet, mockGetList, mockArchive, mockItemsList } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        contentType: '/test/'
+      };
+      await handler(argv);
+
+      expect(mockGet).toHaveBeenCalled();
+      expect(mockGetList).toHaveBeenCalled();
+      expect(mockItemsList).toHaveBeenCalled();
+      expect(mockArchive).toBeCalledTimes(2);
+    });
+
+    it("shouldn't archive content by content type regexp", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockGet, mockGetList, mockArchive, mockItemsList } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        contentType: '/test123/'
+      };
+      await handler(argv);
+
+      expect(mockGet).toHaveBeenCalled();
+      expect(mockGetList).toHaveBeenCalled();
+      expect(mockItemsList).toHaveBeenCalled();
+      expect(mockArchive).toBeCalledTimes(0);
+    });
+
+    it('should archive content with ignoreError', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockGet, mockGetList, mockArchive, mockItemsList } = mockValues(true);
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        ignoreError: true
+      };
+      await handler(argv);
+
+      expect(mockGet).toHaveBeenCalled();
+      expect(mockGetList).toHaveBeenCalled();
+      expect(mockItemsList).toHaveBeenCalled();
+      expect(mockArchive).toBeCalledTimes(2);
+    });
+
+    it("shouldn't archive content with ignoreError", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockGet, mockGetList, mockArchive, mockItemsList } = mockValues(true);
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        ignoreError: false
+      };
+      await handler(argv);
+
+      expect(mockGet).toHaveBeenCalled();
+      expect(mockGetList).toHaveBeenCalled();
+      expect(mockItemsList).toHaveBeenCalled();
+      expect(mockArchive).toBeCalledTimes(1);
+    });
+
+    it('should archive content items without asking if --force is provided', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['input', 'ignored']);
+
+      const { mockGet, mockGetList, mockArchive, mockItemsList } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        force: true
+      };
+      await handler(argv);
+
+      expect(mockGet).toHaveBeenCalled();
+      expect(mockGetList).toHaveBeenCalled();
+      expect(mockItemsList).toHaveBeenCalled();
+      expect(mockArchive).toBeCalledTimes(2);
+    });
+
+    it('should archive content items specified in the provided --revertLog', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const logFileName = 'temp/content-item-unrachive.log';
+      const log = '// Type log test file\n' + 'UNARCHIVE 1\n' + 'UNARCHIVE 2\n' + 'UNARCHIVE idMissing';
+
+      const dir = dirname(logFileName);
+      if (!(await promisify(exists)(dir))) {
+        await promisify(mkdir)(dir);
+      }
+      await promisify(writeFile)(logFileName, log);
+
+      const { mockGet, mockGetList, mockArchive, mockItemsList } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        logFile: LOG_FILENAME(),
+        silent: true,
+        force: true,
+        revertLog: logFileName
+      };
+      await handler(argv);
+
+      expect(mockGet).toHaveBeenCalled();
+      expect(mockGetList).toHaveBeenCalled();
+      expect(mockItemsList).toHaveBeenCalled();
+      expect(mockArchive).toBeCalledTimes(2);
+    });
+
+    it("shouldn't archive content items, getFolder error", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['input', 'ignored']);
+
+      const { mockFolderGet, mockArchive, mockItemsList } = mockValues(true);
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        folderId: 'folder1'
+      };
+      await handler(argv);
+
+      expect(mockFolderGet).toBeCalledTimes(1);
+      expect(mockItemsList).not.toBeCalled();
+      expect(mockArchive).not.toBeCalled();
+    });
+
+    it("shouldn't archive content items, revertLog error", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      if (await promisify(exists)('temp/content-item-unarchive.log')) {
+        await promisify(unlink)('temp/content-item-unarchive.log');
+      }
+
+      const logFileName = 'temp/content-item-unrachive.log';
+      const log = '// Type log test file\n' + 'UNARCHIVE 1\n' + 'UNARCHIVE 2\n' + 'UNARCHIVE idMissing';
+
+      const dir = dirname(logFileName);
+      if (!(await promisify(exists)(dir))) {
+        await promisify(mkdir)(dir);
+      }
+      await promisify(writeFile)(logFileName, log);
+
+      const { mockGet, mockGetList, mockArchive, mockItemsList } = mockValues(true);
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        logFile: LOG_FILENAME(),
+        silent: true,
+        force: true,
+        revertLog: 'wrongFileName.log'
+      };
+      await handler(argv);
+
+      expect(mockGet).toHaveBeenCalled();
+      expect(mockGetList).toHaveBeenCalled();
+      expect(mockItemsList).toHaveBeenCalled();
+      expect(mockArchive).not.toBeCalled();
+    });
+
+    it('should archive content items, write log file', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      if (await promisify(exists)('temp/content-item-archive.log')) {
+        await promisify(unlink)('temp/content-item-archive.log');
+      }
+
+      const { mockItemGetById, mockArchive } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        logFile: 'temp/content-item-archive.log',
+        id: '1'
+      };
+
+      await handler(argv);
+
+      expect(mockItemGetById).toHaveBeenCalled();
+      expect(mockArchive).toBeCalled();
+
+      const logExists = await promisify(exists)('temp/content-item-archive.log');
+
+      expect(logExists).toBeTruthy();
+
+      const log = await promisify(readFile)('temp/content-item-archive.log', 'utf8');
+
+      const logLines = log.split('\n');
+      let total = 0;
+      logLines.forEach(line => {
+        if (line.indexOf('ARCHIVE') !== -1) {
+          total++;
+        }
+      });
+
+      expect(total).toEqual(1);
+
+      await promisify(unlink)('temp/content-item-archive.log');
+    });
+  });
+
+  describe('getContentItems tests', () => {
+    it('should get content items by id', async () => {
+      const result = await getContentItems({
+        client: dynamicContentClientFactory({
+          ...config,
+          ...yargArgs
+        }),
+        id: '1',
+        hubId: 'hub1'
+      });
+
+      if (result) {
+        expect(result.contentItems.length).toBeGreaterThanOrEqual(1);
+
+        expect(result.contentItems[0].id).toMatch('1');
+      }
+    });
+
+    it('should get content items all', async () => {
+      const result = await getContentItems({
+        client: dynamicContentClientFactory({
+          ...config,
+          ...yargArgs
+        }),
+        hubId: 'hub1'
+      });
+
+      if (result) {
+        expect(result.contentItems.length).toBe(2);
+      }
+    });
+
+    it('should get content items by repo', async () => {
+      const result = await getContentItems({
+        client: dynamicContentClientFactory({
+          ...config,
+          ...yargArgs
+        }),
+        hubId: 'hub1',
+        repoId: 'repo1'
+      });
+
+      if (result) {
+        expect(result.contentItems.length).toBe(2);
+      }
+    });
+
+    it('should get content items by folder', async () => {
+      const result = await getContentItems({
+        client: dynamicContentClientFactory({
+          ...config,
+          ...yargArgs
+        }),
+        hubId: 'hub1',
+        folderId: 'folder1'
+      });
+
+      if (result) {
+        expect(result.contentItems.length).toBe(2);
+      }
+    });
+  });
+
+  describe('filterContentItems tests', () => {
+    it('should filter content items', async () => {
+      const result = await filterContentItems({
+        contentItems
+      });
+
+      expect(result).toMatchObject({
+        contentItems,
+        missingContent: false
+      });
+    });
+
+    it('should filter content items by content type', async () => {
+      const result = await filterContentItems({
+        contentItems,
+        contentType: '/test.com/'
+      });
+
+      expect(result).toMatchObject({
+        contentItems: [contentItems[0]],
+        missingContent: false
+      });
+    });
+
+    it('should filter content items by content types', async () => {
+      const result = await filterContentItems({
+        contentItems,
+        contentType: ['/test.com/', '/test1.com/']
+      });
+
+      expect(result).toMatchObject({
+        contentItems,
+        missingContent: false
+      });
+    });
+
+    it('should filter content items by name', async () => {
+      const result = await filterContentItems({
+        contentItems,
+        name: ['/item1/']
+      });
+
+      if (result) {
+        expect(result.contentItems.length).toBeGreaterThanOrEqual(1);
+
+        expect(result.contentItems[0].id).toMatch('1');
+      }
+    });
+  });
+
+  describe('processItems tests', () => {
+    it('should archive content items', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      await processItems({
+        contentItems,
+        allContent: true,
+        missingContent: false,
+        logFile: './logFile.log'
+      });
+
+      expect(archiveMockFunc).toBeCalledTimes(2);
+
+      if (await promisify(exists)('./logFile.log')) {
+        await promisify(unlink)('./logFile.log');
+      }
+    });
+
+    it('should not archive content items', async () => {
+      jest.spyOn(global.console, 'log');
+
+      await processItems({
+        contentItems: [],
+        allContent: true,
+        missingContent: false
+      });
+
+      expect(console.log).toBeCalled();
+      expect(console.log).toHaveBeenLastCalledWith('Nothing found to archive, aborting.');
+    });
+  });
+});

--- a/src/commands/content-item/archive.ts
+++ b/src/commands/content-item/archive.ts
@@ -1,0 +1,333 @@
+import { Arguments, Argv } from 'yargs';
+import { ConfigurationParameters } from '../configure';
+import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
+import { ArchiveLog } from '../../common/archive/archive-log';
+import paginator from '../../common/dc-management-sdk-js/paginator';
+import { confirmArchive } from '../../common/archive/archive-helpers';
+import ArchiveOptions from '../../common/archive/archive-options';
+import { ContentItem, DynamicContent } from 'dc-management-sdk-js';
+import { equalsOrRegex } from '../../common/filter/filter';
+import { getDefaultLogPath } from '../../common/log-helpers';
+
+export const command = 'archive [id]';
+
+export const desc = 'Archive Content Items';
+
+export const LOG_FILENAME = (platform: string = process.platform): string =>
+  getDefaultLogPath('content-item', 'archive', platform);
+
+export const builder = (yargs: Argv): void => {
+  yargs
+    .positional('id', {
+      type: 'string',
+      describe:
+        'The ID of a content item to be archived. If id is not provided, this command will archive ALL content items through all content repositories in the hub.'
+    })
+    .option('repoId', {
+      type: 'string',
+      describe: 'The ID of a content repository to search items in to be archived.',
+      requiresArg: false
+    })
+    .option('folderId', {
+      type: 'string',
+      describe: 'The ID of a folder to search items in to be archived.',
+      requiresArg: false
+    })
+    .option('name', {
+      type: 'string',
+      describe:
+        'The name of a Content Item to be archived.\nA regex can be provided to select multiple items with similar or matching names (eg /.header/).\nA single --name option may be given to match a single content item pattern.\nMultiple --name options may be given to match multiple content items patterns at the same time, or even multiple regex.'
+    })
+    .option('contentType', {
+      type: 'string',
+      describe:
+        'A pattern which will only archive content items with a matching Content Type Schema ID. A single --contentType option may be given to match a single schema id pattern.\\nMultiple --contentType options may be given to match multiple schema patterns at the same time.'
+    })
+    .option('revertLog', {
+      type: 'string',
+      describe:
+        'Path to a log file containing content items unarchived in a previous run of the unarchive command.\nWhen provided, archives all content items listed as UNARCHIVE in the log file.',
+      requiresArg: false
+    })
+    .alias('f', 'force')
+    .option('f', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'If present, there will be no confirmation prompt before archiving the found content.'
+    })
+    .alias('s', 'silent')
+    .option('s', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'If present, no log file will be produced.'
+    })
+    .option('ignoreError', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'If present, archive requests that fail will not abort the process.'
+    })
+    .option('logFile', {
+      type: 'string',
+      default: LOG_FILENAME,
+      describe: 'Path to a log file to write to.'
+    });
+};
+
+export const filterContentItems = async ({
+  revertLog,
+  name,
+  contentType,
+  contentItems
+}: {
+  revertLog?: string;
+  name?: string | string[];
+  contentType?: string | string[];
+  contentItems: ContentItem[];
+}): Promise<{ contentItems: ContentItem[]; missingContent: boolean } | undefined> => {
+  try {
+    let missingContent = false;
+
+    if (revertLog != null) {
+      const log = await new ArchiveLog().loadFromFile(revertLog);
+      const ids = log.getData('UNARCHIVE');
+      const contentItemsFiltered = contentItems.filter(contentItem => ids.indexOf(contentItem.id || '') != -1);
+      if (contentItems.length != ids.length) {
+        missingContent = true;
+      }
+
+      return {
+        contentItems: contentItemsFiltered,
+        missingContent
+      };
+    }
+
+    if (name != null) {
+      const itemsArray: string[] = Array.isArray(name) ? name : [name];
+      const contentItemsFiltered = contentItems.filter(
+        item => itemsArray.findIndex(id => equalsOrRegex(item.label || '', id)) != -1
+      );
+
+      return {
+        contentItems: contentItemsFiltered,
+        missingContent
+      };
+    }
+
+    if (contentType != null) {
+      const itemsArray: string[] = Array.isArray(contentType) ? contentType : [contentType];
+      const contentItemsFiltered = contentItems.filter(item => {
+        return itemsArray.findIndex(id => equalsOrRegex(item.body._meta.schema, id)) != -1;
+      });
+
+      return {
+        contentItems: contentItemsFiltered,
+        missingContent
+      };
+    }
+
+    return {
+      contentItems,
+      missingContent
+    };
+  } catch (err) {
+    console.log(err);
+    return {
+      contentItems: [],
+      missingContent: false
+    };
+  }
+};
+
+export const getContentItems = async ({
+  client,
+  id,
+  hubId,
+  repoId,
+  folderId,
+  revertLog,
+  name,
+  contentType
+}: {
+  client: DynamicContent;
+  id?: string;
+  hubId: string;
+  repoId?: string | string[];
+  folderId?: string | string[];
+  revertLog?: string;
+  name?: string | string[];
+  contentType?: string | string[];
+}): Promise<{ contentItems: ContentItem[]; missingContent: boolean }> => {
+  try {
+    const contentItems: ContentItem[] = [];
+
+    if (id != null) {
+      contentItems.push(await client.contentItems.get(id));
+
+      return {
+        contentItems,
+        missingContent: false
+      };
+    }
+
+    const hub = await client.hubs.get(hubId);
+    const repoIds = typeof repoId === 'string' ? [repoId] : repoId || [];
+    const folderIds = typeof folderId === 'string' ? [folderId] : folderId || [];
+    const contentRepositories = await (repoId != null
+      ? Promise.all(repoIds.map(id => client.contentRepositories.get(id)))
+      : paginator(hub.related.contentRepositories.list));
+
+    const folders = folderId != null ? await Promise.all(folderIds.map(id => client.folders.get(id))) : [];
+
+    folderId != null
+      ? await Promise.all(
+          folders.map(async source => {
+            const items = await paginator(source.related.contentItems.list);
+
+            contentItems.push(...items.filter(item => item.status == 'ACTIVE'));
+          })
+        )
+      : await Promise.all(
+          contentRepositories.map(async source => {
+            const items = await paginator(source.related.contentItems.list, { status: 'ACTIVE' });
+            contentItems.push(...items);
+          })
+        );
+
+    return (
+      (await filterContentItems({
+        revertLog,
+        name,
+        contentType,
+        contentItems
+      })) || {
+        contentItems: [],
+        missingContent: false
+      }
+    );
+  } catch (err) {
+    console.log(err);
+
+    return {
+      contentItems: [],
+      missingContent: false
+    };
+  }
+};
+
+export const processItems = async ({
+  contentItems,
+  force,
+  silent,
+  logFile,
+  allContent,
+  missingContent,
+  ignoreError
+}: {
+  contentItems: ContentItem[];
+  force?: boolean;
+  silent?: boolean;
+  logFile?: string;
+  allContent: boolean;
+  missingContent: boolean;
+  ignoreError?: boolean;
+}): Promise<void> => {
+  if (contentItems.length == 0) {
+    console.log('Nothing found to archive, aborting.');
+    return;
+  }
+
+  console.log('The following content items will be archived:');
+  contentItems.forEach((contentItem: ContentItem) => {
+    console.log(` ${contentItem.label} (${contentItem.id})`);
+  });
+  console.log(`Total: ${contentItems.length}`);
+
+  if (!force) {
+    const yes = await confirmArchive('archive', 'content item', allContent, missingContent);
+    if (!yes) {
+      return;
+    }
+  }
+
+  const timestamp = Date.now().toString();
+  const log = new ArchiveLog(`Content Items Archive Log - ${timestamp}\n`);
+
+  let successCount = 0;
+
+  for (let i = 0; i < contentItems.length; i++) {
+    try {
+      await contentItems[i].related.archive();
+
+      log.addAction('ARCHIVE', `${contentItems[i].id}\n`);
+      successCount++;
+    } catch (e) {
+      log.addComment(`ARCHIVE FAILED: ${contentItems[i].id}`);
+      log.addComment(e.toString());
+
+      if (ignoreError) {
+        console.log(
+          `Failed to archive ${contentItems[i].label} (${contentItems[i].id}), continuing. Error: \n${e.toString()}`
+        );
+      } else {
+        console.log(
+          `Failed to archive ${contentItems[i].label} (${contentItems[i].id}), aborting. Error: \n${e.toString()}`
+        );
+        break;
+      }
+    }
+  }
+
+  if (!silent && logFile) {
+    await log.writeToFile(logFile.replace('<DATE>', timestamp));
+  }
+
+  console.log(`Archived ${successCount} content items.`);
+};
+
+export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationParameters>): Promise<void> => {
+  const { id, logFile, force, silent, ignoreError, hubId, revertLog, repoId, folderId, name, contentType } = argv;
+  const client = dynamicContentClientFactory(argv);
+
+  const allContent = !id && !name && !contentType && !revertLog;
+
+  if (repoId && id) {
+    console.log('ID of content item is specified, ignoring repository ID');
+  }
+
+  if (id && name) {
+    console.log('Please specify either a item name or an ID - not both.');
+    return;
+  }
+
+  if (repoId && folderId) {
+    console.log('Folder is specified, ignoring repository ID');
+  }
+
+  if (allContent) {
+    console.log('No filter was given, archiving all content');
+  }
+
+  const { contentItems, missingContent } = await getContentItems({
+    client,
+    id,
+    hubId,
+    repoId,
+    folderId,
+    revertLog,
+    contentType,
+    name
+  });
+
+  await processItems({
+    contentItems,
+    force,
+    silent,
+    logFile,
+    allContent,
+    missingContent,
+    ignoreError
+  });
+};
+
+// log format:
+// ARCHIVE <content item id>

--- a/src/commands/content-item/unarchive.spec.ts
+++ b/src/commands/content-item/unarchive.spec.ts
@@ -1,0 +1,965 @@
+import {
+  builder,
+  command,
+  handler,
+  LOG_FILENAME,
+  filterContentItems,
+  getContentItems,
+  processItems
+} from './unarchive';
+import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
+import { ContentRepository, ContentItem, Folder } from 'dc-management-sdk-js';
+import Yargs from 'yargs/yargs';
+import readline from 'readline';
+import MockPage from '../../common/dc-management-sdk-js/mock-page';
+import { dirname } from 'path';
+import { promisify } from 'util';
+import { exists, readFile, unlink, mkdir, writeFile } from 'fs';
+
+jest.mock('readline');
+
+jest.mock('../../services/dynamic-content-client-factory');
+
+describe('content-item unarchive command', () => {
+  afterEach((): void => {
+    jest.restoreAllMocks();
+  });
+  const yargArgs = {
+    $0: 'test',
+    _: ['test'],
+    json: true
+  };
+  const config = {
+    clientId: 'client-id',
+    clientSecret: 'client-id',
+    hubId: 'hub-id'
+  };
+  const unarchiveMockFunc = jest.fn();
+
+  const mockValues = (
+    unarchiveError = false
+  ): {
+    mockGet: () => void;
+    mockGetList: () => void;
+    mockItemsList: () => void;
+    mockUnarchive: () => void;
+    mockItemGetById: () => void;
+    mockRepoGet: () => void;
+    mockFolderGet: () => void;
+  } => {
+    const mockGet = jest.fn();
+    const mockGetList = jest.fn();
+    const mockItemsList = jest.fn();
+    const mockUnarchive = jest.fn();
+    const mockItemGetById = jest.fn();
+    const mockRepoGet = jest.fn();
+    const mockFolderGet = jest.fn();
+
+    (dynamicContentClientFactory as jest.Mock).mockReturnValue({
+      hubs: {
+        get: mockGet
+      },
+      contentRepositories: {
+        get: mockRepoGet
+      },
+      contentItems: {
+        get: mockItemGetById
+      },
+      folders: {
+        get: mockFolderGet
+      }
+    });
+
+    mockFolderGet.mockResolvedValue(
+      new Folder({
+        name: 'folder1',
+        id: 'folder1',
+        client: {
+          fetchLinkedResource: mockItemsList
+        },
+        _links: {
+          'content-items': {
+            href:
+              'https://api.amplience.net/v2/content/content-repositories/repo1/content-items{?folderId,page,projection,size,sort,status}',
+            templated: true
+          }
+        },
+        related: {
+          contentItems: {
+            list: mockItemsList
+          }
+        }
+      })
+    );
+
+    mockGet.mockResolvedValue({
+      id: 'hub-id',
+      related: {
+        contentRepositories: {
+          list: mockGetList
+        }
+      }
+    });
+
+    mockGetList.mockResolvedValue(
+      new MockPage(ContentRepository, [
+        new ContentRepository({
+          name: 'repo1',
+          client: {
+            fetchLinkedResource: mockItemsList
+          },
+          _links: {
+            'content-items': {
+              href:
+                'https://api.amplience.net/v2/content/content-repositories/repo1/content-items{?folderId,page,projection,size,sort,status}',
+              templated: true
+            }
+          },
+          related: {
+            contentItems: {
+              list: mockItemsList
+            }
+          }
+        })
+      ])
+    );
+
+    mockRepoGet.mockResolvedValue(
+      new ContentRepository({
+        name: 'repo1',
+        client: {
+          fetchLinkedResource: mockItemsList
+        },
+        _links: {
+          'content-items': {
+            href:
+              'https://api.amplience.net/v2/content/content-repositories/repo1/content-items{?folderId,page,projection,size,sort,status}',
+            templated: true
+          }
+        },
+        related: {
+          contentItems: {
+            list: mockItemsList
+          }
+        }
+      })
+    );
+
+    mockItemGetById.mockResolvedValue(
+      new ContentItem({
+        id: '1',
+        label: 'item1',
+        repoId: 'repo1',
+        folderId: 'folder1',
+        status: 'ACTIVE',
+        body: {
+          _meta: {
+            schema: 'http://test.com'
+          }
+        },
+        related: { unarchive: mockUnarchive },
+        client: {
+          performActionThatReturnsResource: mockUnarchive
+        },
+        _links: {
+          unarchive: {
+            href: 'https://api.amplience.net/v2/content/content-items/1/unarchive'
+          }
+        }
+      })
+    );
+
+    mockItemsList.mockResolvedValue(
+      new MockPage(ContentItem, [
+        new ContentItem({
+          id: '1',
+          label: 'item1',
+          repoId: 'repo1',
+          folderId: 'folder1',
+          status: 'ACTIVE',
+          body: {
+            _meta: {
+              schema: 'http://test.com'
+            }
+          },
+          related: { unarchive: mockUnarchive },
+          client: {
+            performActionThatReturnsResource: mockUnarchive
+          },
+          _links: {
+            unarchive: {
+              href: 'https://api.amplience.net/v2/content/content-items/1/unarchive'
+            }
+          }
+        }),
+        new ContentItem({
+          id: '2',
+          label: 'item2',
+          repoId: 'repo1',
+          folderId: 'folder1',
+          status: 'ACTIVE',
+          body: {
+            _meta: {
+              schema: 'http://test1.com'
+            }
+          },
+          client: {
+            performActionThatReturnsResource: mockUnarchive
+          },
+          _links: {
+            unarchive: {
+              href: 'https://api.amplience.net/v2/content/content-items/2/unarchive'
+            }
+          },
+          related: { unarchive: mockUnarchive }
+        })
+      ])
+    );
+
+    if (unarchiveError) {
+      mockUnarchive.mockRejectedValue(new Error('Error'));
+      mockFolderGet.mockRejectedValue(new Error('Error'));
+      mockItemGetById.mockRejectedValue(new Error('Error'));
+    }
+
+    return {
+      mockGet,
+      mockGetList,
+      mockItemsList,
+      mockUnarchive,
+      mockItemGetById,
+      mockRepoGet,
+      mockFolderGet
+    };
+  };
+
+  const contentItems = [
+    new ContentItem({
+      id: '1',
+      label: 'item1',
+      repoId: 'repo1',
+      folderId: 'folder1',
+      status: 'ACTIVE',
+      body: {
+        _meta: {
+          schema: 'http://test.com'
+        }
+      },
+      related: { unarchive: unarchiveMockFunc },
+      client: {
+        performActionThatReturnsResource: unarchiveMockFunc
+      },
+      _links: {
+        unarchive: {
+          href: 'https://api.amplience.net/v2/content/content-items/1/unarchive'
+        }
+      }
+    }),
+    new ContentItem({
+      id: '2',
+      label: 'item2',
+      repoId: 'repo1',
+      folderId: 'folder1',
+      status: 'ACTIVE',
+      body: {
+        _meta: {
+          schema: 'http://test1.com'
+        }
+      },
+      client: {
+        performActionThatReturnsResource: unarchiveMockFunc
+      },
+      _links: {
+        unarchive: {
+          href: 'https://api.amplience.net/v2/content/content-items/2/unarchive'
+        }
+      },
+      related: { unarchive: unarchiveMockFunc }
+    })
+  ];
+
+  unarchiveMockFunc.mockResolvedValue({
+    message: 'Success'
+  });
+
+  it('should command should defined', function() {
+    expect(command).toEqual('unarchive [id]');
+  });
+
+  describe('builder tests', function() {
+    it('should configure yargs', function() {
+      const argv = Yargs(process.argv.slice(2));
+      const spyPositional = jest.spyOn(argv, 'positional').mockReturnThis();
+      const spyOption = jest.spyOn(argv, 'option').mockReturnThis();
+
+      builder(argv);
+
+      expect(spyPositional).toHaveBeenCalledWith('id', {
+        type: 'string',
+        describe:
+          'The ID of a content item to be unarchived. If id is not provided, this command will unarchive ALL content items through all content repositories in the hub.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('repoId', {
+        type: 'string',
+        describe: 'The ID of a content repository to search items in to be unarchived.',
+        requiresArg: false
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('folderId', {
+        type: 'string',
+        describe: 'The ID of a folder to search items in to be unarchived.',
+        requiresArg: false
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('name', {
+        type: 'string',
+        describe:
+          'The name of a Content Item to be unarchived.\nA regex can be provided to select multiple items with similar or matching names (eg /.header/).\nA single --name option may be given to match a single content item pattern.\nMultiple --name options may be given to match multiple content items patterns at the same time, or even multiple regex.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('contentType', {
+        type: 'string',
+        describe:
+          'A pattern which will only unarchive content items with a matching Content Type Schema ID. A single --contentType option may be given to match a single schema id pattern.\\nMultiple --contentType options may be given to match multiple schema patterns at the same time.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('revertLog', {
+        type: 'string',
+        describe:
+          'Path to a log file containing content items archived in a previous run of the archive command.\nWhen provided, archives all content items listed as ARCHIVE in the log file.',
+        requiresArg: false
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('f', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'If present, there will be no confirmation prompt before unarchiving the found content.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('s', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'If present, no log file will be produced.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('ignoreError', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'If present, unarchive requests that fail will not abort the process.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('logFile', {
+        type: 'string',
+        default: LOG_FILENAME,
+        describe: 'Path to a log file to write to.'
+      });
+    });
+  });
+
+  describe('handler tests', function() {
+    it('should unarchive all content', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockGet, mockGetList, mockItemsList, mockUnarchive } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config
+      };
+      await handler(argv);
+
+      expect(mockGet).toHaveBeenCalled();
+      expect(mockGetList).toHaveBeenCalled();
+      expect(mockItemsList).toHaveBeenCalled();
+      expect(mockUnarchive).toBeCalledTimes(2);
+    });
+
+    it('should unarchive content by id', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockUnarchive, mockItemGetById } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        id: '1',
+        repoId: 'repo123'
+      };
+      await handler(argv);
+
+      expect(mockItemGetById).toHaveBeenCalled();
+      expect(mockUnarchive).toBeCalledTimes(1);
+    });
+
+    it("shouldn't unarchive content by id", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockUnarchive, mockItemGetById } = mockValues(true);
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        id: '1'
+      };
+      await handler(argv);
+
+      expect(mockItemGetById).toHaveBeenCalled();
+      expect(mockUnarchive).not.toBeCalled();
+    });
+
+    it('should unarchive content by repo id', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockUnarchive, mockRepoGet } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        repoId: 'repo1'
+      };
+      await handler(argv);
+
+      expect(mockRepoGet).toBeCalledTimes(1);
+      expect(mockUnarchive).toBeCalledTimes(2);
+    });
+
+    it('should unarchive content by repo ids', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockUnarchive, mockRepoGet } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        repoId: ['repo1', 'repo2']
+      };
+      await handler(argv);
+
+      expect(mockRepoGet).toBeCalledTimes(2);
+      expect(mockUnarchive).toBeCalledTimes(4);
+    });
+
+    it('should unarchive content by folder id', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockUnarchive, mockFolderGet, mockItemsList } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        folderId: 'folder1',
+        repoId: 'repo123'
+      };
+      await handler(argv);
+
+      expect(mockFolderGet).toBeCalledTimes(1);
+      expect(mockItemsList).toBeCalledTimes(1);
+      expect(mockUnarchive).toBeCalledTimes(2);
+    });
+
+    it('should unarchive content by folder ids', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockUnarchive, mockFolderGet, mockItemsList } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        folderId: ['folder1', 'folder1']
+      };
+      await handler(argv);
+
+      expect(mockFolderGet).toBeCalledTimes(2);
+      expect(mockItemsList).toBeCalledTimes(2);
+      expect(mockUnarchive).toBeCalledTimes(4);
+    });
+
+    it('should unarchive content by name', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockUnarchive, mockFolderGet, mockItemsList } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        folderId: 'folder1',
+        name: 'item1'
+      };
+      await handler(argv);
+
+      expect(mockFolderGet).toBeCalledTimes(1);
+      expect(mockItemsList).toBeCalledTimes(1);
+      expect(mockUnarchive).toBeCalledTimes(1);
+    });
+
+    it('should ented', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockUnarchive, mockFolderGet, mockItemsList } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        id: '123',
+        name: 'item1'
+      };
+      await handler(argv);
+
+      expect(mockFolderGet).not.toBeCalled();
+      expect(mockItemsList).not.toBeCalled();
+      expect(mockUnarchive).not.toBeCalled();
+    });
+
+    it("shouldn't unarchive content by name", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockUnarchive, mockFolderGet, mockItemsList } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        folderId: 'folder1',
+        name: ['item3']
+      };
+      await handler(argv);
+
+      expect(mockFolderGet).toBeCalledTimes(1);
+      expect(mockItemsList).toBeCalledTimes(1);
+      expect(mockUnarchive).not.toBeCalled();
+    });
+
+    it("shouldn't unarchive content, answer no", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['n']);
+
+      const { mockUnarchive, mockFolderGet, mockItemsList } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        folderId: 'folder1',
+        name: 'item1'
+      };
+      await handler(argv);
+
+      expect(mockFolderGet).toBeCalledTimes(1);
+      expect(mockItemsList).toBeCalledTimes(1);
+      expect(mockUnarchive).not.toBeCalled();
+    });
+
+    it('should unarchive content by name regexp', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockGet, mockGetList, mockUnarchive, mockItemsList } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        name: '/item/'
+      };
+      await handler(argv);
+
+      expect(mockGet).toHaveBeenCalled();
+      expect(mockGetList).toHaveBeenCalled();
+      expect(mockItemsList).toHaveBeenCalled();
+      expect(mockUnarchive).toBeCalledTimes(2);
+    });
+
+    it('should unarchive content by content type name', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockGet, mockGetList, mockUnarchive, mockItemsList } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        contentType: 'http://test.com'
+      };
+      await handler(argv);
+
+      expect(mockGet).toHaveBeenCalled();
+      expect(mockGetList).toHaveBeenCalled();
+      expect(mockItemsList).toHaveBeenCalled();
+      expect(mockUnarchive).toBeCalledTimes(1);
+    });
+
+    it('should unarchive content by content type regexp', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockGet, mockGetList, mockUnarchive, mockItemsList } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        contentType: '/test/'
+      };
+      await handler(argv);
+
+      expect(mockGet).toHaveBeenCalled();
+      expect(mockGetList).toHaveBeenCalled();
+      expect(mockItemsList).toHaveBeenCalled();
+      expect(mockUnarchive).toBeCalledTimes(2);
+    });
+
+    it("shouldn't unarchive content by content type regexp", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockGet, mockGetList, mockUnarchive, mockItemsList } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        contentType: '/test123/'
+      };
+      await handler(argv);
+
+      expect(mockGet).toHaveBeenCalled();
+      expect(mockGetList).toHaveBeenCalled();
+      expect(mockItemsList).toHaveBeenCalled();
+      expect(mockUnarchive).toBeCalledTimes(0);
+    });
+
+    it('should unarchive content with ignoreError', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockGet, mockGetList, mockUnarchive, mockItemsList } = mockValues(true);
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        ignoreError: true
+      };
+      await handler(argv);
+
+      expect(mockGet).toHaveBeenCalled();
+      expect(mockGetList).toHaveBeenCalled();
+      expect(mockItemsList).toHaveBeenCalled();
+      expect(mockUnarchive).toBeCalledTimes(2);
+    });
+
+    it("shouldn't unarchive content with ignoreError", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const { mockGet, mockGetList, mockUnarchive, mockItemsList } = mockValues(true);
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        ignoreError: false
+      };
+      await handler(argv);
+
+      expect(mockGet).toHaveBeenCalled();
+      expect(mockGetList).toHaveBeenCalled();
+      expect(mockItemsList).toHaveBeenCalled();
+      expect(mockUnarchive).toBeCalledTimes(1);
+    });
+
+    it('should unarchive content items without asking if --force is provided', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['input', 'ignored']);
+
+      const { mockGet, mockGetList, mockUnarchive, mockItemsList } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        force: true
+      };
+      await handler(argv);
+
+      expect(mockGet).toHaveBeenCalled();
+      expect(mockGetList).toHaveBeenCalled();
+      expect(mockItemsList).toHaveBeenCalled();
+      expect(mockUnarchive).toBeCalledTimes(2);
+    });
+
+    it('should unarchive content items specified in the provided --revertLog', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const logFileName = 'temp/content-item-unrachive.log';
+      const log = '// Type log test file\n' + 'ARCHIVE 1\n' + 'ARCHIVE 2\n' + 'ARCHIVE idMissing';
+
+      const dir = dirname(logFileName);
+      if (!(await promisify(exists)(dir))) {
+        await promisify(mkdir)(dir);
+      }
+      await promisify(writeFile)(logFileName, log);
+
+      const { mockGet, mockGetList, mockUnarchive, mockItemsList } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        logFile: LOG_FILENAME(),
+        silent: true,
+        force: true,
+        revertLog: logFileName
+      };
+      await handler(argv);
+
+      expect(mockGet).toHaveBeenCalled();
+      expect(mockGetList).toHaveBeenCalled();
+      expect(mockItemsList).toHaveBeenCalled();
+      expect(mockUnarchive).toBeCalledTimes(2);
+    });
+
+    it("shouldn't unarchive content items, getFolder error", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['input', 'ignored']);
+
+      const { mockFolderGet, mockUnarchive, mockItemsList } = mockValues(true);
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        folderId: 'folder1'
+      };
+      await handler(argv);
+
+      expect(mockFolderGet).toBeCalledTimes(1);
+      expect(mockItemsList).not.toBeCalled();
+      expect(mockUnarchive).not.toBeCalled();
+    });
+
+    it("shouldn't unarchive content items, revertLog error", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      if (await promisify(exists)('temp/content-item-archive.log')) {
+        await promisify(unlink)('temp/content-item-archive.log');
+      }
+
+      const logFileName = 'temp/content-item-unrachive.log';
+      const log = '// Type log test file\n' + 'ARCHIVE 1\n' + 'ARCHIVE 2\n' + 'ARCHIVE idMissing';
+
+      const dir = dirname(logFileName);
+      if (!(await promisify(exists)(dir))) {
+        await promisify(mkdir)(dir);
+      }
+      await promisify(writeFile)(logFileName, log);
+
+      const { mockGet, mockGetList, mockUnarchive, mockItemsList } = mockValues(true);
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        logFile: LOG_FILENAME(),
+        silent: true,
+        force: true,
+        revertLog: 'wrongFileName.log'
+      };
+      await handler(argv);
+
+      expect(mockGet).toHaveBeenCalled();
+      expect(mockGetList).toHaveBeenCalled();
+      expect(mockItemsList).toHaveBeenCalled();
+      expect(mockUnarchive).not.toBeCalled();
+    });
+
+    it('should unarchive content items, write log file', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      if (await promisify(exists)('temp/content-item-unarchive.log')) {
+        await promisify(unlink)('temp/content-item-unarchive.log');
+      }
+
+      const { mockItemGetById, mockUnarchive } = mockValues();
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        logFile: 'temp/content-item-unarchive.log',
+        id: '1'
+      };
+
+      await handler(argv);
+
+      expect(mockItemGetById).toHaveBeenCalled();
+      expect(mockUnarchive).toBeCalled();
+
+      const logExists = await promisify(exists)('temp/content-item-unarchive.log');
+
+      expect(logExists).toBeTruthy();
+
+      const log = await promisify(readFile)('temp/content-item-unarchive.log', 'utf8');
+
+      const logLines = log.split('\n');
+      let total = 0;
+      logLines.forEach(line => {
+        if (line.indexOf('ARCHIVE') !== -1) {
+          total++;
+        }
+      });
+
+      expect(total).toEqual(1);
+
+      await promisify(unlink)('temp/content-item-unarchive.log');
+    });
+  });
+
+  describe('getContentItems tests', () => {
+    it('should get content items by id', async () => {
+      const result = await getContentItems({
+        client: dynamicContentClientFactory({
+          ...config,
+          ...yargArgs
+        }),
+        id: '1',
+        hubId: 'hub1'
+      });
+
+      if (result) {
+        expect(result.contentItems.length).toBeGreaterThanOrEqual(1);
+
+        expect(result.contentItems[0].id).toMatch('1');
+      }
+    });
+
+    it('should get content items all', async () => {
+      const result = await getContentItems({
+        client: dynamicContentClientFactory({
+          ...config,
+          ...yargArgs
+        }),
+        hubId: 'hub1'
+      });
+
+      if (result) {
+        expect(result.contentItems.length).toBe(2);
+      }
+    });
+
+    it('should get content items by repo', async () => {
+      const result = await getContentItems({
+        client: dynamicContentClientFactory({
+          ...config,
+          ...yargArgs
+        }),
+        hubId: 'hub1',
+        repoId: 'repo1'
+      });
+
+      if (result) {
+        expect(result.contentItems.length).toBe(2);
+      }
+    });
+
+    it('should get content items by folder', async () => {
+      const result = await getContentItems({
+        client: dynamicContentClientFactory({
+          ...config,
+          ...yargArgs
+        }),
+        hubId: 'hub1',
+        folderId: 'folder1'
+      });
+
+      if (result) {
+        expect(result.contentItems.length).toBe(2);
+      }
+    });
+  });
+
+  describe('filterContentItems tests', () => {
+    it('should filter content items', async () => {
+      const result = await filterContentItems({
+        contentItems
+      });
+
+      expect(result).toMatchObject({
+        contentItems,
+        missingContent: false
+      });
+    });
+
+    it('should filter content items by content type', async () => {
+      const result = await filterContentItems({
+        contentItems,
+        contentType: '/test.com/'
+      });
+
+      expect(result).toMatchObject({
+        contentItems: [contentItems[0]],
+        missingContent: false
+      });
+    });
+
+    it('should filter content items by content types', async () => {
+      const result = await filterContentItems({
+        contentItems,
+        contentType: ['/test.com/', '/test1.com/']
+      });
+
+      expect(result).toMatchObject({
+        contentItems,
+        missingContent: false
+      });
+    });
+
+    it('should filter content items by name', async () => {
+      const result = await filterContentItems({
+        contentItems,
+        name: ['/item1/']
+      });
+
+      if (result) {
+        expect(result.contentItems.length).toBeGreaterThanOrEqual(1);
+
+        expect(result.contentItems[0].id).toMatch('1');
+      }
+    });
+  });
+
+  describe('processItems tests', () => {
+    it('should unarchive content items', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      await processItems({
+        contentItems,
+        allContent: true,
+        missingContent: false,
+        logFile: './logFile.log'
+      });
+
+      expect(unarchiveMockFunc).toBeCalledTimes(2);
+
+      if (await promisify(exists)('./logFile.log')) {
+        await promisify(unlink)('./logFile.log');
+      }
+    });
+
+    it('should not unarchive content items', async () => {
+      jest.spyOn(global.console, 'log');
+
+      await processItems({
+        contentItems: [],
+        allContent: true,
+        missingContent: false
+      });
+
+      expect(console.log).toBeCalled();
+      expect(console.log).toHaveBeenLastCalledWith('Nothing found to unarchive, aborting.');
+    });
+  });
+});

--- a/src/commands/content-item/unarchive.ts
+++ b/src/commands/content-item/unarchive.ts
@@ -1,0 +1,333 @@
+import { Arguments, Argv } from 'yargs';
+import { ConfigurationParameters } from '../configure';
+import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
+import { ArchiveLog } from '../../common/archive/archive-log';
+import paginator from '../../common/dc-management-sdk-js/paginator';
+import { confirmArchive } from '../../common/archive/archive-helpers';
+import UnarchiveOptions from '../../common/archive/unarchive-options';
+import { ContentItem, DynamicContent } from 'dc-management-sdk-js';
+import { equalsOrRegex } from '../../common/filter/filter';
+import { getDefaultLogPath } from '../../common/log-helpers';
+
+export const command = 'unarchive [id]';
+
+export const desc = 'Unarchive Content Items';
+
+export const LOG_FILENAME = (platform: string = process.platform): string =>
+  getDefaultLogPath('content-item', 'unarchive', platform);
+
+export const builder = (yargs: Argv): void => {
+  yargs
+    .positional('id', {
+      type: 'string',
+      describe:
+        'The ID of a content item to be unarchived. If id is not provided, this command will unarchive ALL content items through all content repositories in the hub.'
+    })
+    .option('repoId', {
+      type: 'string',
+      describe: 'The ID of a content repository to search items in to be unarchived.',
+      requiresArg: false
+    })
+    .option('folderId', {
+      type: 'string',
+      describe: 'The ID of a folder to search items in to be unarchived.',
+      requiresArg: false
+    })
+    .option('name', {
+      type: 'string',
+      describe:
+        'The name of a Content Item to be unarchived.\nA regex can be provided to select multiple items with similar or matching names (eg /.header/).\nA single --name option may be given to match a single content item pattern.\nMultiple --name options may be given to match multiple content items patterns at the same time, or even multiple regex.'
+    })
+    .option('contentType', {
+      type: 'string',
+      describe:
+        'A pattern which will only unarchive content items with a matching Content Type Schema ID. A single --contentType option may be given to match a single schema id pattern.\\nMultiple --contentType options may be given to match multiple schema patterns at the same time.'
+    })
+    .option('revertLog', {
+      type: 'string',
+      describe:
+        'Path to a log file containing content items archived in a previous run of the archive command.\nWhen provided, archives all content items listed as ARCHIVE in the log file.',
+      requiresArg: false
+    })
+    .alias('f', 'force')
+    .option('f', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'If present, there will be no confirmation prompt before unarchiving the found content.'
+    })
+    .alias('s', 'silent')
+    .option('s', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'If present, no log file will be produced.'
+    })
+    .option('ignoreError', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'If present, unarchive requests that fail will not abort the process.'
+    })
+    .option('logFile', {
+      type: 'string',
+      default: LOG_FILENAME,
+      describe: 'Path to a log file to write to.'
+    });
+};
+
+export const filterContentItems = async ({
+  revertLog,
+  name,
+  contentType,
+  contentItems
+}: {
+  revertLog?: string;
+  name?: string | string[];
+  contentType?: string | string[];
+  contentItems: ContentItem[];
+}): Promise<{ contentItems: ContentItem[]; missingContent: boolean } | undefined> => {
+  try {
+    let missingContent = false;
+
+    if (revertLog != null) {
+      const log = await new ArchiveLog().loadFromFile(revertLog);
+      const ids = log.getData('ARCHIVE');
+      const contentItemsFiltered = contentItems.filter(contentItem => ids.indexOf(contentItem.id || '') != -1);
+      if (contentItems.length != ids.length) {
+        missingContent = true;
+      }
+
+      return {
+        contentItems: contentItemsFiltered,
+        missingContent
+      };
+    }
+
+    if (name != null) {
+      const itemsArray: string[] = Array.isArray(name) ? name : [name];
+      const contentItemsFiltered = contentItems.filter(
+        item => itemsArray.findIndex(id => equalsOrRegex(item.label || '', id)) != -1
+      );
+
+      return {
+        contentItems: contentItemsFiltered,
+        missingContent
+      };
+    }
+
+    if (contentType != null) {
+      const itemsArray: string[] = Array.isArray(contentType) ? contentType : [contentType];
+      const contentItemsFiltered = contentItems.filter(item => {
+        return itemsArray.findIndex(id => equalsOrRegex(item.body._meta.schema, id)) != -1;
+      });
+
+      return {
+        contentItems: contentItemsFiltered,
+        missingContent
+      };
+    }
+
+    return {
+      contentItems,
+      missingContent
+    };
+  } catch (err) {
+    console.log(err);
+    return {
+      contentItems: [],
+      missingContent: false
+    };
+  }
+};
+
+export const getContentItems = async ({
+  client,
+  id,
+  hubId,
+  repoId,
+  folderId,
+  revertLog,
+  name,
+  contentType
+}: {
+  client: DynamicContent;
+  id?: string;
+  hubId: string;
+  repoId?: string | string[];
+  folderId?: string | string[];
+  revertLog?: string;
+  name?: string | string[];
+  contentType?: string | string[];
+}): Promise<{ contentItems: ContentItem[]; missingContent: boolean }> => {
+  try {
+    const contentItems: ContentItem[] = [];
+
+    if (id != null) {
+      contentItems.push(await client.contentItems.get(id));
+
+      return {
+        contentItems,
+        missingContent: false
+      };
+    }
+
+    const hub = await client.hubs.get(hubId);
+    const repoIds = typeof repoId === 'string' ? [repoId] : repoId || [];
+    const folderIds = typeof folderId === 'string' ? [folderId] : folderId || [];
+    const contentRepositories = await (repoId != null
+      ? Promise.all(repoIds.map(id => client.contentRepositories.get(id)))
+      : paginator(hub.related.contentRepositories.list));
+
+    const folders = folderId != null ? await Promise.all(folderIds.map(id => client.folders.get(id))) : [];
+
+    folderId != null
+      ? await Promise.all(
+          folders.map(async source => {
+            const items = await paginator(source.related.contentItems.list);
+
+            contentItems.push(...items.filter(item => item.status == 'ACTIVE'));
+          })
+        )
+      : await Promise.all(
+          contentRepositories.map(async source => {
+            const items = await paginator(source.related.contentItems.list, { status: 'ACTIVE' });
+            contentItems.push(...items);
+          })
+        );
+
+    return (
+      (await filterContentItems({
+        revertLog,
+        name,
+        contentType,
+        contentItems
+      })) || {
+        contentItems: [],
+        missingContent: false
+      }
+    );
+  } catch (err) {
+    console.log(err);
+
+    return {
+      contentItems: [],
+      missingContent: false
+    };
+  }
+};
+
+export const processItems = async ({
+  contentItems,
+  force,
+  silent,
+  logFile,
+  allContent,
+  missingContent,
+  ignoreError
+}: {
+  contentItems: ContentItem[];
+  force?: boolean;
+  silent?: boolean;
+  logFile?: string;
+  allContent: boolean;
+  missingContent: boolean;
+  ignoreError?: boolean;
+}): Promise<void> => {
+  if (contentItems.length == 0) {
+    console.log('Nothing found to unarchive, aborting.');
+    return;
+  }
+
+  console.log('The following content items will be unarchived:');
+  contentItems.forEach((contentItem: ContentItem) => {
+    console.log(` ${contentItem.label} (${contentItem.id})`);
+  });
+  console.log(`Total: ${contentItems.length}`);
+
+  if (!force) {
+    const yes = await confirmArchive('unarchive', 'content item', allContent, missingContent);
+    if (!yes) {
+      return;
+    }
+  }
+
+  const timestamp = Date.now().toString();
+  const log = new ArchiveLog(`Content Items Unarchive Log - ${timestamp}\n`);
+
+  let successCount = 0;
+
+  for (let i = 0; i < contentItems.length; i++) {
+    try {
+      await contentItems[i].related.unarchive();
+
+      log.addAction('UNARCHIVE', `${contentItems[i].id}\n`);
+      successCount++;
+    } catch (e) {
+      log.addComment(`UNARCHIVE FAILED: ${contentItems[i].id}`);
+      log.addComment(e.toString());
+
+      if (ignoreError) {
+        console.log(
+          `Failed to unarchive ${contentItems[i].label} (${contentItems[i].id}), continuing. Error: \n${e.toString()}`
+        );
+      } else {
+        console.log(
+          `Failed to unarchive ${contentItems[i].label} (${contentItems[i].id}), aborting. Error: \n${e.toString()}`
+        );
+        break;
+      }
+    }
+  }
+
+  if (!silent && logFile) {
+    await log.writeToFile(logFile.replace('<DATE>', timestamp));
+  }
+
+  console.log(`Unarchived ${successCount} content items.`);
+};
+
+export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationParameters>): Promise<void> => {
+  const { id, logFile, force, silent, ignoreError, hubId, revertLog, repoId, folderId, name, contentType } = argv;
+  const client = dynamicContentClientFactory(argv);
+
+  const allContent = !id && !name && !contentType && !revertLog;
+
+  if (repoId && id) {
+    console.log('ID of content item is specified, ignoring repository ID');
+  }
+
+  if (id && name) {
+    console.log('Please specify either a item name or an ID - not both.');
+    return;
+  }
+
+  if (repoId && folderId) {
+    console.log('Folder is specified, ignoring repository ID');
+  }
+
+  if (allContent) {
+    console.log('No filter was given, archiving all content');
+  }
+
+  const { contentItems, missingContent } = await getContentItems({
+    client,
+    id,
+    hubId,
+    repoId,
+    folderId,
+    revertLog,
+    contentType,
+    name
+  });
+
+  await processItems({
+    contentItems,
+    force,
+    silent,
+    logFile,
+    allContent,
+    missingContent,
+    ignoreError
+  });
+};
+
+// log format:
+// UNARCHIVE <content item id>

--- a/src/commands/content-type-schema/archive.ts
+++ b/src/commands/content-type-schema/archive.ts
@@ -155,7 +155,7 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
     }
   }
 
-  if (!silent) {
+  if (!silent && logFile) {
     await log.writeToFile(logFile.replace('<DATE>', timestamp));
   }
 

--- a/src/commands/content-type-schema/unarchive.ts
+++ b/src/commands/content-type-schema/unarchive.ts
@@ -156,7 +156,7 @@ export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationPa
     console.log('Unarchived: ' + schemas[i].schemaId);
   }
 
-  if (!silent) {
+  if (!silent && logFile) {
     await log.writeToFile(logFile.replace('<DATE>', timestamp));
   }
 

--- a/src/commands/content-type/archive.ts
+++ b/src/commands/content-type/archive.ts
@@ -160,7 +160,7 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
     }
   }
 
-  if (!silent) {
+  if (!silent && logFile) {
     await log.writeToFile(logFile.replace('<DATE>', timestamp));
   }
 

--- a/src/commands/content-type/unarchive.ts
+++ b/src/commands/content-type/unarchive.ts
@@ -158,7 +158,7 @@ export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationPa
     console.log('Unarchived: ' + label);
   }
 
-  if (!silent) {
+  if (!silent && logFile) {
     await log.writeToFile(logFile.replace('<DATE>', timestamp));
   }
 

--- a/src/common/archive/archive-options.ts
+++ b/src/common/archive/archive-options.ts
@@ -1,8 +1,12 @@
 export default interface ArchiveOptions {
   id?: string;
   schemaId?: string | string[];
-  logFile: string;
   revertLog?: string;
+  repoId?: string | string[];
+  folderId?: string | string[];
+  name?: string | string[];
+  contentType?: string | string[];
+  logFile?: string;
   force?: boolean;
   silent?: boolean;
   ignoreError?: boolean;

--- a/src/common/archive/unarchive-options.ts
+++ b/src/common/archive/unarchive-options.ts
@@ -1,8 +1,13 @@
 export default interface UnarchiveOptions {
   id?: string;
   schemaId?: string | string[];
-  logFile: string;
   revertLog?: string;
   silent?: boolean;
   ignoreError?: boolean;
+  repoId?: string | string[];
+  folderId?: string | string[];
+  name?: string | string[];
+  contentType?: string | string[];
+  force?: boolean;
+  logFile?: string;
 }


### PR DESCRIPTION
This PR adds commands for **archive/unarchive** of content item.

You can archive by exact **content item ID**, **name** or by **repository ID**, **folder ID**, **content type URI**. Regex arguments are passed with forward slashes on either side, though when they contain spaces they still must be passed with quotes surrounding them like any other string argument (eg. `"/regex with space/"`). Not providing any argument will perform the action on **all content items** through all repositories in a specified hub, which can be useful.

The user is given a summary of all actions that will be taken in the command line, and must answer (y/n) for the action to be taken. If the user passes the `--force` argument, the answer `y` will be assumed.

These commands output a **"revert log"**, which is a log file that describes all the actions that were taken in a format both readable to people, and readable to the dc-cli itself to revert any action taken at a later date. A log produced by an archive command can be used later by an unarchive command to undo all archives done by the previous action. This philosophy will carry forward into future PRs that have actions we might want to reverse.

The output location of the log file defaults to a a subfolder called logs/ in the .amplience/ folder used for configuration, but can be manually controlled with `--logFile <path>`. Either way, the log file path is printed when the command finishes executing, so that the user knows where their log is located. This log can be used in any future command by passing `--revertLog <path>`. Log files can be suppressed entirely by passing `--silent`.