### PR TITLE
feat(content-item): add copy and move commands

### DIFF
--- a/src/commands/content-item/__mocks__/copy.ts
+++ b/src/commands/content-item/__mocks__/copy.ts
@@ -1,0 +1,23 @@
+import { CopyItemBuilderOptions } from '../../../interfaces/copy-item-builder-options.interface';
+import { ConfigurationParameters } from '../../configure';
+import { Arguments } from 'yargs';
+
+let outputIds: string[];
+let forceFail = false;
+export const calls: Arguments<CopyItemBuilderOptions & ConfigurationParameters>[] = [];
+
+export const setOutputIds = (ids: string[]): void => {
+  outputIds = ids;
+};
+
+export const setForceFail = (fail: boolean): void => {
+  forceFail = fail;
+};
+
+export const handler = async (argv: Arguments<CopyItemBuilderOptions & ConfigurationParameters>): Promise<boolean> => {
+  calls.push(argv);
+  const idOut = argv.exportedIds as string[];
+  idOut.push(...outputIds);
+
+  return !forceFail;
+};

--- a/src/commands/content-item/__mocks__/import.ts
+++ b/src/commands/content-item/__mocks__/import.ts
@@ -2,12 +2,22 @@ import { ImportItemBuilderOptions } from '../../../interfaces/import-item-builde
 import { ConfigurationParameters } from '../../configure';
 import { Arguments } from 'yargs';
 
+type ReturnType = boolean | 'throw';
+let expectedReturn: ReturnType = true;
+
 export const calls: Arguments<ImportItemBuilderOptions & ConfigurationParameters>[] = [];
+export const setExpectedReturn = (value: ReturnType): void => {
+  expectedReturn = value;
+};
 
 export const handler = async (
   argv: Arguments<ImportItemBuilderOptions & ConfigurationParameters>
 ): Promise<boolean> => {
   calls.push(argv);
 
-  return true;
+  if (expectedReturn == 'throw') {
+    throw new Error('Forced throw in test.');
+  }
+
+  return expectedReturn;
 };

--- a/src/commands/content-item/copy.spec.ts
+++ b/src/commands/content-item/copy.spec.ts
@@ -121,6 +121,31 @@ describe('content-item copy command', () => {
         default: LOG_FILENAME,
         describe: 'Path to a log file to write to.'
       });
+
+      expect(spyOption).toHaveBeenCalledWith('copyConfig', {
+        type: 'string',
+        describe:
+          'Path to a JSON configuration file for source/destination account. If the given file does not exist, it will be generated from the arguments.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('lastPublish', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'When available, export the last published version of a content item rather than its newest version.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('publish', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'Publish any content items that have an existing publish status in their JSON.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('republish', {
+        type: 'boolean',
+        boolean: true,
+        describe:
+          'Republish content items regardless of whether the import changed them or not. (--publish not required)'
+      });
     });
   });
 
@@ -190,7 +215,11 @@ describe('content-item copy command', () => {
         mapFile: 'map.json',
         force: false,
         validate: false,
-        skipIncomplete: false
+        skipIncomplete: false,
+
+        lastPublish: true,
+        publish: true,
+        republish: true
       };
       await handler(argv);
 
@@ -203,6 +232,7 @@ describe('content-item copy command', () => {
       expect(exportCalls[0].schemaId).toEqual(argv.schemaId);
       expect(exportCalls[0].name).toEqual(argv.name);
       expect(exportCalls[0].repoId).toEqual(argv.srcRepo);
+      expect(exportCalls[0].publish).toEqual(argv.lastPublish);
 
       expect(importCalls[0].clientId).toEqual(argv.dstClientId);
       expect(importCalls[0].clientSecret).toEqual(argv.dstSecret);
@@ -213,6 +243,9 @@ describe('content-item copy command', () => {
       expect(importCalls[0].force).toEqual(argv.force);
       expect(importCalls[0].validate).toEqual(argv.validate);
       expect(importCalls[0].skipIncomplete).toEqual(argv.skipIncomplete);
+
+      expect(importCalls[0].publish).toEqual(argv.publish);
+      expect(importCalls[0].republish).toEqual(argv.republish);
     });
 
     it('should forward to import-revert when revertLog is present.', async () => {

--- a/src/commands/content-item/copy.spec.ts
+++ b/src/commands/content-item/copy.spec.ts
@@ -1,0 +1,236 @@
+// Copy tests are rather simple since they most of the work is done by import/export.
+// Unique features are revert, throwing when parameters are wrong/missing,
+// and forwarding input parameters to both import and export.
+
+import { builder, command, handler, LOG_FILENAME } from './copy';
+import Yargs from 'yargs/yargs';
+import * as exporter from './export';
+import * as importer from './import';
+import * as reverter from './import-revert';
+
+import rmdir from 'rimraf';
+import { Arguments } from 'yargs';
+import { ExportItemBuilderOptions } from '../../interfaces/export-item-builder-options.interface';
+import { ConfigurationParameters } from '../configure';
+import { ImportItemBuilderOptions } from '../../interfaces/import-item-builder-options.interface';
+
+jest.mock('../../services/dynamic-content-client-factory');
+
+jest.mock('./export');
+jest.mock('./import');
+jest.mock('./import-revert');
+
+function rimraf(dir: string): Promise<Error> {
+  return new Promise((resolve): void => {
+    rmdir(dir, resolve);
+  });
+}
+
+describe('content-item copy command', () => {
+  afterEach((): void => {
+    jest.restoreAllMocks();
+  });
+
+  it('should command should defined', function() {
+    expect(command).toEqual('copy');
+  });
+
+  describe('builder tests', function() {
+    it('should configure yargs', function() {
+      const argv = Yargs(process.argv.slice(2));
+      const spyOption = jest.spyOn(argv, 'option').mockReturnThis();
+
+      builder(argv);
+
+      expect(spyOption).toHaveBeenCalledWith('revertLog', {
+        type: 'string',
+        describe:
+          'Path to a log file to revert a copy for. This will archive the most recently copied resources, and revert updated ones.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('srcRepo', {
+        type: 'string',
+        describe:
+          'Copy content from within a given repository. Directory structure will start at the specified repository. Will automatically export all contained folders.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('srcFolder', {
+        type: 'string',
+        describe:
+          'Copy content from within a given folder. Directory structure will start at the specified folder. Can be used in addition to repoId.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('dstRepo', {
+        type: 'string',
+        describe:
+          'Copy matching the given repository to the source base directory, by ID. Folder structure will be followed and replicated from there.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('dstFolder', {
+        type: 'string',
+        describe:
+          'Copy matching the given folder to the source base directory, by ID. Folder structure will be followed and replicated from there.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('dstHub', {
+        type: 'string',
+        describe: 'Destination hub ID. If not specified, it will be the same as the source.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('dstClientId', {
+        type: 'string',
+        describe: "Destination account's client ID. If not specified, it will be the same as the source."
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('dstSecret', {
+        type: 'string',
+        describe: "Destination account's secret. Must be used alongside dstClientId."
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('mapFile', {
+        type: 'string',
+        describe:
+          'Mapping file to use when updating content that already exists. Updated with any new mappings that are generated. If not present, will be created.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('f', {
+        type: 'boolean',
+        boolean: true,
+        describe:
+          'Overwrite content, create and assign content types, and ignore content with missing types/references without asking.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('v', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'Only recreate folder structure - content is validated but not imported.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('skipIncomplete', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'Skip any content item that has one or more missing dependancy.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('logFile', {
+        type: 'string',
+        default: LOG_FILENAME,
+        describe: 'Path to a log file to write to.'
+      });
+    });
+  });
+
+  describe('handler tests', function() {
+    const yargArgs = {
+      $0: 'test',
+      _: ['test'],
+      json: true
+    };
+    const config = {
+      clientId: 'client-id',
+      clientSecret: 'client-id',
+      hubId: 'hub-id'
+    };
+
+    beforeAll(async () => {
+      await rimraf('temp/copy/');
+    });
+
+    const clearArray = (array: object[]): void => {
+      array.splice(0, array.length);
+    };
+
+    beforeEach(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const exportCalls: Arguments<ExportItemBuilderOptions & ConfigurationParameters>[] = (exporter as any).calls;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const importCalls: Arguments<ImportItemBuilderOptions & ConfigurationParameters>[] = (importer as any).calls;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const revertCalls: Arguments<ImportItemBuilderOptions & ConfigurationParameters>[] = (reverter as any).calls;
+
+      clearArray(exportCalls);
+      clearArray(importCalls);
+      clearArray(revertCalls);
+    });
+
+    it('should call both export and import with the correct parameters', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const exportCalls: Arguments<ExportItemBuilderOptions & ConfigurationParameters>[] = (exporter as any).calls;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const importCalls: Arguments<ImportItemBuilderOptions & ConfigurationParameters>[] = (importer as any).calls;
+
+      // TODO: mock handlers for export and import
+      const argv = {
+        ...yargArgs,
+        ...config,
+
+        srcRepo: 'repo1-id',
+
+        dstRepo: 'repo2-id',
+
+        dstHub: 'hub2-id',
+        dstClientId: 'acc2-id',
+        dstSecret: 'acc2-secret',
+
+        schemaId: '/./',
+        name: '/./',
+
+        mapFile: 'map.json',
+        force: false,
+        validate: false,
+        skipIncomplete: false
+      };
+      await handler(argv);
+
+      expect(exportCalls.length).toEqual(1);
+      expect(importCalls.length).toEqual(1);
+
+      expect(exportCalls[0].clientId).toEqual(config.clientId);
+      expect(exportCalls[0].clientSecret).toEqual(config.clientSecret);
+      expect(exportCalls[0].hubId).toEqual(config.hubId);
+      expect(exportCalls[0].schemaId).toEqual(argv.schemaId);
+      expect(exportCalls[0].name).toEqual(argv.name);
+      expect(exportCalls[0].repoId).toEqual(argv.srcRepo);
+
+      expect(importCalls[0].clientId).toEqual(argv.dstClientId);
+      expect(importCalls[0].clientSecret).toEqual(argv.dstSecret);
+      expect(importCalls[0].hubId).toEqual(argv.dstHub);
+      expect(importCalls[0].baseRepo).toEqual(argv.dstRepo);
+
+      expect(importCalls[0].mapFile).toEqual(argv.mapFile);
+      expect(importCalls[0].force).toEqual(argv.force);
+      expect(importCalls[0].validate).toEqual(argv.validate);
+      expect(importCalls[0].skipIncomplete).toEqual(argv.skipIncomplete);
+    });
+
+    it('should forward to import-revert when revertLog is present.', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const exportCalls: Arguments<ExportItemBuilderOptions & ConfigurationParameters>[] = (exporter as any).calls;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const importCalls: Arguments<ImportItemBuilderOptions & ConfigurationParameters>[] = (importer as any).calls;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const revertCalls: Arguments<ImportItemBuilderOptions & ConfigurationParameters>[] = (reverter as any).calls;
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+
+        dstHub: 'hub2-id',
+        dstClientId: 'acc2-id',
+        dstSecret: 'acc2-secret',
+
+        revertLog: 'revertTest.txt'
+      };
+      await handler(argv);
+
+      expect(exportCalls.length).toEqual(0);
+      expect(importCalls.length).toEqual(0);
+      expect(revertCalls.length).toEqual(1);
+
+      expect(revertCalls[0].clientId).toEqual(argv.dstClientId);
+      expect(revertCalls[0].clientSecret).toEqual(argv.dstSecret);
+      expect(revertCalls[0].hubId).toEqual(argv.dstHub);
+      expect(revertCalls[0].revertLog).toEqual(argv.revertLog);
+    });
+  });
+});

--- a/src/commands/content-item/copy.spec.ts
+++ b/src/commands/content-item/copy.spec.ts
@@ -116,12 +116,6 @@ describe('content-item copy command', () => {
         describe: 'Skip any content item that has one or more missing dependancy.'
       });
 
-      expect(spyOption).toHaveBeenCalledWith('logFile', {
-        type: 'string',
-        default: LOG_FILENAME,
-        describe: 'Path to a log file to write to.'
-      });
-
       expect(spyOption).toHaveBeenCalledWith('copyConfig', {
         type: 'string',
         describe:
@@ -145,6 +139,18 @@ describe('content-item copy command', () => {
         boolean: true,
         describe:
           'Republish content items regardless of whether the import changed them or not. (--publish not required)'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('excludeKeys', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'Exclude delivery keys when importing content items.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('logFile', {
+        type: 'string',
+        default: LOG_FILENAME,
+        describe: 'Path to a log file to write to.'
       });
     });
   });
@@ -219,7 +225,9 @@ describe('content-item copy command', () => {
 
         lastPublish: true,
         publish: true,
-        republish: true
+        republish: true,
+
+        excludeKeys: true
       };
       await handler(argv);
 
@@ -246,6 +254,8 @@ describe('content-item copy command', () => {
 
       expect(importCalls[0].publish).toEqual(argv.publish);
       expect(importCalls[0].republish).toEqual(argv.republish);
+
+      expect(importCalls[0].excludeKeys).toEqual(argv.excludeKeys);
     });
 
     it('should forward to import-revert when revertLog is present.', async () => {
@@ -283,7 +293,7 @@ describe('content-item copy command', () => {
       const exportCalls: Arguments<ExportItemBuilderOptions & ConfigurationParameters>[] = (exporter as any).calls;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const importCalls: Arguments<ImportItemBuilderOptions & ConfigurationParameters>[] = (importer as any).calls;
-
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (importer as any).setExpectedReturn(false);
 
       const argv = {
@@ -313,6 +323,7 @@ describe('content-item copy command', () => {
 
       expect(result).toBeFalsy();
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (importer as any).setExpectedReturn('throw');
 
       const result2 = await handler(argv);

--- a/src/commands/content-item/copy.ts
+++ b/src/commands/content-item/copy.ts
@@ -107,6 +107,24 @@ export const builder = (yargs: Argv): void => {
       type: 'string',
       describe:
         'Path to a JSON configuration file for source/destination account. If the given file does not exist, it will be generated from the arguments.'
+    })
+
+    .option('lastPublish', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'When available, export the last published version of a content item rather than its newest version.'
+    })
+
+    .option('publish', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'Publish any content items that have an existing publish status in their JSON.'
+    })
+
+    .option('republish', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'Republish content items regardless of whether the import changed them or not. (--publish not required)'
     });
 };
 
@@ -167,7 +185,10 @@ export const handler = async (argv: Arguments<CopyItemBuilderOptions & Configura
         name: argv.name,
         logFile: log,
 
-        dir: tempFolder
+        dir: tempFolder,
+
+        exportedIds: argv.exportedIds,
+        publish: argv.publish
       });
 
       log.appendLine('=== Importing to destination... ===');
@@ -186,7 +207,10 @@ export const handler = async (argv: Arguments<CopyItemBuilderOptions & Configura
         force: argv.force,
         validate: argv.validate,
         skipIncomplete: argv.skipIncomplete,
-        logFile: log
+        logFile: log,
+
+        republish: argv.republish,
+        publish: argv.publish
       });
 
       if (importResult) {

--- a/src/commands/content-item/copy.ts
+++ b/src/commands/content-item/copy.ts
@@ -97,12 +97,6 @@ export const builder = (yargs: Argv): void => {
       describe: 'Skip any content item that has one or more missing dependancy.'
     })
 
-    .option('logFile', {
-      type: 'string',
-      default: LOG_FILENAME,
-      describe: 'Path to a log file to write to.'
-    })
-
     .option('copyConfig', {
       type: 'string',
       describe:
@@ -125,6 +119,18 @@ export const builder = (yargs: Argv): void => {
       type: 'boolean',
       boolean: true,
       describe: 'Republish content items regardless of whether the import changed them or not. (--publish not required)'
+    })
+
+    .option('excludeKeys', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'Exclude delivery keys when importing content items.'
+    })
+
+    .option('logFile', {
+      type: 'string',
+      default: LOG_FILENAME,
+      describe: 'Path to a log file to write to.'
     });
 };
 
@@ -210,7 +216,9 @@ export const handler = async (argv: Arguments<CopyItemBuilderOptions & Configura
         logFile: log,
 
         republish: argv.republish,
-        publish: argv.publish
+        publish: argv.publish,
+
+        excludeKeys: argv.excludeKeys
       });
 
       if (importResult) {

--- a/src/commands/content-item/copy.ts
+++ b/src/commands/content-item/copy.ts
@@ -188,7 +188,7 @@ export const handler = async (argv: Arguments<CopyItemBuilderOptions & Configura
         dir: tempFolder,
 
         exportedIds: argv.exportedIds,
-        publish: argv.publish
+        publish: argv.lastPublish
       });
 
       log.appendLine('=== Importing to destination... ===');

--- a/src/commands/content-item/copy.ts
+++ b/src/commands/content-item/copy.ts
@@ -1,0 +1,189 @@
+import { getDefaultLogPath } from '../../common/log-helpers';
+import { Argv, Arguments } from 'yargs';
+import { join } from 'path';
+import { CopyItemBuilderOptions } from '../../interfaces/copy-item-builder-options.interface';
+import { ConfigurationParameters } from '../configure';
+import rmdir from 'rimraf';
+
+import { handler as exporter } from './export';
+import { handler as importer } from './import';
+import { ensureDirectoryExists } from '../../common/import/directory-utils';
+import { FileLog } from '../../common/file-log';
+import { revert } from './import-revert';
+
+export function getTempFolder(name: string, platform: string = process.platform): string {
+  return join(process.env[platform == 'win32' ? 'USERPROFILE' : 'HOME'] || __dirname, '.amplience', `copy-${name}/`);
+}
+
+export const command = 'copy';
+
+export const desc = 'Copy content items. The active account and hub are the source for the copy.';
+
+export const LOG_FILENAME = (platform: string = process.platform): string =>
+  getDefaultLogPath('item', 'copy', platform);
+
+export const builder = (yargs: Argv): void => {
+  yargs
+    .option('revertLog', {
+      type: 'string',
+      describe:
+        'Path to a log file to revert a copy for. This will archive the most recently copied resources, and revert updated ones.'
+    })
+
+    .option('srcRepo', {
+      type: 'string',
+      describe:
+        'Copy content from within a given repository. Directory structure will start at the specified repository. Will automatically export all contained folders.'
+    })
+
+    .option('srcFolder', {
+      type: 'string',
+      describe:
+        'Copy content from within a given folder. Directory structure will start at the specified folder. Can be used in addition to repoId.'
+    })
+
+    .option('dstRepo', {
+      type: 'string',
+      describe:
+        'Copy matching the given repository to the source base directory, by ID. Folder structure will be followed and replicated from there.'
+    })
+
+    .option('dstFolder', {
+      type: 'string',
+      describe:
+        'Copy matching the given folder to the source base directory, by ID. Folder structure will be followed and replicated from there.'
+    })
+
+    .option('dstHub', {
+      type: 'string',
+      describe: 'Destination hub ID. If not specified, it will be the same as the source.'
+    })
+
+    .option('dstClientId', {
+      type: 'string',
+      describe: "Destination account's client ID. If not specified, it will be the same as the source."
+    })
+
+    .option('dstSecret', {
+      type: 'string',
+      describe: "Destination account's secret. Must be used alongside dstClientId."
+    })
+
+    .option('mapFile', {
+      type: 'string',
+      describe:
+        'Mapping file to use when updating content that already exists. Updated with any new mappings that are generated. If not present, will be created.'
+    })
+
+    .alias('f', 'force')
+    .option('f', {
+      type: 'boolean',
+      boolean: true,
+      describe:
+        'Overwrite content, create and assign content types, and ignore content with missing types/references without asking.'
+    })
+
+    .alias('v', 'validate')
+    .option('v', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'Only recreate folder structure - content is validated but not imported.'
+    })
+
+    .option('skipIncomplete', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'Skip any content item that has one or more missing dependancy.'
+    })
+
+    .option('logFile', {
+      type: 'string',
+      default: LOG_FILENAME,
+      describe: 'Path to a log file to write to.'
+    });
+};
+
+function rimraf(dir: string): Promise<Error> {
+  return new Promise((resolve): void => {
+    rmdir(dir, resolve);
+  });
+}
+
+export const handler = async (argv: Arguments<CopyItemBuilderOptions & ConfigurationParameters>): Promise<boolean> => {
+  const logFile = argv.logFile;
+  const log = typeof logFile === 'string' || logFile == null ? new FileLog(logFile) : logFile;
+  const tempFolder = getTempFolder(Date.now().toString());
+
+  const yargArgs = {
+    $0: '',
+    _: [],
+    json: true
+  };
+
+  if (argv.revertLog) {
+    await revert({
+      ...yargArgs,
+      hubId: argv.dstHub || argv.hubId,
+      clientId: argv.dstClientId || argv.clientId,
+      clientSecret: argv.dstSecret || argv.clientSecret,
+
+      dir: tempFolder, // unused
+
+      revertLog: argv.revertLog
+    });
+  } else {
+    await ensureDirectoryExists(tempFolder);
+
+    try {
+      log.appendLine('=== Exporting from source... ===');
+
+      await exporter({
+        ...yargArgs,
+        hubId: argv.hubId,
+        clientId: argv.clientId,
+        clientSecret: argv.clientSecret,
+
+        folderId: argv.srcFolder,
+        repoId: argv.srcRepo,
+        schemaId: argv.schemaId,
+        name: argv.name,
+        logFile: log,
+
+        dir: tempFolder
+      });
+
+      log.appendLine('=== Importing to destination... ===');
+
+      const importResult = await importer({
+        ...yargArgs,
+        hubId: argv.dstHub || argv.hubId,
+        clientId: argv.dstClientId || argv.clientId,
+        clientSecret: argv.dstSecret || argv.clientSecret,
+
+        dir: tempFolder,
+
+        baseRepo: argv.dstRepo,
+        baseFolder: argv.dstFolder,
+        mapFile: argv.mapFile,
+        force: argv.force,
+        validate: argv.validate,
+        skipIncomplete: argv.skipIncomplete,
+        logFile: log
+      });
+
+      if (!importResult) {
+        await log.close();
+        return false;
+      }
+
+      log.appendLine('=== Done! ===');
+    } catch (e) {
+      log.appendLine('An unexpected error occurred: \n' + e.toString());
+    }
+
+    await rimraf(tempFolder);
+  }
+
+  await log.close();
+  return true;
+};

--- a/src/commands/content-item/copy.ts
+++ b/src/commands/content-item/copy.ts
@@ -120,12 +120,18 @@ export const handler = async (argv: Arguments<CopyItemBuilderOptions & Configura
     json: true
   };
 
+  let result = false;
+
+  const dstHubId = argv.dstHub || argv.hubId;
+  const dstClientId = argv.dstClientId || argv.clientId;
+  const dstSecret = argv.dstSecret || argv.clientSecret;
+
   if (argv.revertLog) {
-    await revert({
+    result = await revert({
       ...yargArgs,
-      hubId: argv.dstHub || argv.hubId,
-      clientId: argv.dstClientId || argv.clientId,
-      clientSecret: argv.dstSecret || argv.clientSecret,
+      hubId: dstHubId,
+      clientId: dstClientId,
+      clientSecret: dstSecret,
 
       dir: tempFolder, // unused
 
@@ -156,9 +162,9 @@ export const handler = async (argv: Arguments<CopyItemBuilderOptions & Configura
 
       const importResult = await importer({
         ...yargArgs,
-        hubId: argv.dstHub || argv.hubId,
-        clientId: argv.dstClientId || argv.clientId,
-        clientSecret: argv.dstSecret || argv.clientSecret,
+        hubId: dstHubId,
+        clientId: dstClientId,
+        clientSecret: dstSecret,
 
         dir: tempFolder,
 
@@ -173,10 +179,10 @@ export const handler = async (argv: Arguments<CopyItemBuilderOptions & Configura
 
       if (!importResult) {
         await log.close();
-        return false;
+      } else {
+        log.appendLine('=== Done! ===');
+        result = true;
       }
-
-      log.appendLine('=== Done! ===');
     } catch (e) {
       log.appendLine('An unexpected error occurred: \n' + e.toString());
     }
@@ -185,5 +191,5 @@ export const handler = async (argv: Arguments<CopyItemBuilderOptions & Configura
   }
 
   await log.close();
-  return true;
+  return result;
 };

--- a/src/commands/content-item/export.spec.ts
+++ b/src/commands/content-item/export.spec.ts
@@ -791,5 +791,42 @@ describe('content-item export command', () => {
 
       await rimraf('temp/export/version/');
     });
+
+    it('should populate exportedIds with the ids of exported content items when present', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (readline as any).setResponses(['y']);
+
+      const exists: ItemTemplate[] = [
+        { id: 'id1', label: 'item2', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'exportedIds' },
+        { id: 'id2', label: 'item3', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'exportedIds/nested' }
+      ];
+
+      const skips: ItemTemplate[] = [
+        { label: 'item1', repoId: 'repo1', typeSchemaUri: 'http://type' },
+        { label: 'item4', repoId: 'repo1', typeSchemaUri: 'http://type', folderPath: 'folder2' }
+      ];
+
+      const templates = skips.concat(exists);
+
+      new MockContent(dynamicContentClientFactory as jest.Mock).importItemTemplates(templates);
+
+      const exportedIds: string[] = [];
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/export/exportedIds',
+        folderId: 'exportedIds',
+        exportedIds
+      };
+      await handler(argv);
+
+      await itemsExist('temp/export/', exists);
+      await itemsDontExist('temp/export/', skips);
+
+      expect(exportedIds).toEqual(exists.map(item => item.id as string));
+
+      await rimraf('temp/export/exportedIds/');
+    });
   });
 });

--- a/src/commands/content-item/export.ts
+++ b/src/commands/content-item/export.ts
@@ -340,6 +340,10 @@ export const handler = async (argv: Arguments<ExportItemBuilderOptions & Configu
     log.appendLine(resolvedPath);
     await ensureDirectoryExists(directory);
 
+    if (argv.exportedIds) {
+      argv.exportedIds.push(item.id as string);
+    }
+
     writeJsonToFile(resolvedPath, item);
   }
 

--- a/src/commands/content-item/export.ts
+++ b/src/commands/content-item/export.ts
@@ -137,6 +137,7 @@ const getContentItems = async (
     let newItems: ContentItem[];
     try {
       const allItems = await paginator(repository.related.contentItems.list, { status: 'ACTIVE' });
+
       Array.prototype.push.apply(repoItems, allItems);
       newItems = allItems.filter(item => item.folderId == null);
     } catch (e) {
@@ -342,5 +343,7 @@ export const handler = async (argv: Arguments<ExportItemBuilderOptions & Configu
     writeJsonToFile(resolvedPath, item);
   }
 
-  log.close();
+  if (typeof logFile !== 'object') {
+    await log.close();
+  }
 };

--- a/src/commands/content-item/import.spec.ts
+++ b/src/commands/content-item/import.spec.ts
@@ -111,6 +111,12 @@ describe('content-item import command', () => {
           'Republish content items regardless of whether the import changed them or not. (--publish not required)'
       });
 
+      expect(spyOption).toHaveBeenCalledWith('excludeKeys', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'Exclude delivery keys when importing content items.'
+      });
+
       expect(spyOption).toHaveBeenCalledWith('logFile', {
         type: 'string',
         default: LOG_FILENAME,
@@ -764,7 +770,14 @@ describe('content-item import command', () => {
 
       const oldTemplates: ItemTemplate[] = [
         { id: 'old1', label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type' },
-        { id: 'old2', label: 'item2', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest' }
+        {
+          id: 'old2',
+          label: 'item2',
+          repoId: 'repo',
+          typeSchemaUri: 'http://type',
+          folderPath: 'folderTest',
+          status: 'ARCHIVED'
+        }
       ];
 
       const newTemplates = oldTemplates.map(old => ({ ...old, id: 'new' + (old.id as string)[3] }));
@@ -812,6 +825,7 @@ describe('content-item import command', () => {
 
       expect(mockContent.metrics.itemsCreated).toEqual(2);
       expect(mockContent.metrics.itemsUpdated).toEqual(2);
+      expect(mockContent.metrics.itemsUnarchived).toEqual(1); // The existing archived item should be unarchived.
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((readline as any).responsesLeft()).toEqual(0); // All responses consumed.

--- a/src/commands/content-item/import.ts
+++ b/src/commands/content-item/import.ts
@@ -237,7 +237,7 @@ const createOrUpdateContent = async (
     item.version = oldItem.version;
     if (oldItem.status !== Status.ACTIVE) {
       // If an item is archived, it must be unarchived before updating it.
-      await oldItem.related.unarchive();
+      oldItem = await oldItem.related.unarchive();
     }
     result = { newItem: await oldItem.related.update(item), oldVersion };
   }

--- a/src/commands/content-item/import.ts
+++ b/src/commands/content-item/import.ts
@@ -106,6 +106,12 @@ export const builder = (yargs: Argv): void => {
       describe: 'Republish content items regardless of whether the import changed them or not. (--publish not required)'
     })
 
+    .option('excludeKeys', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'Exclude delivery keys when importing content items.'
+    })
+
     .option('logFile', {
       type: 'string',
       default: LOG_FILENAME,
@@ -351,7 +357,7 @@ const prepareContentForImport = async (
         label: contentJSON.label,
         locale: contentJSON.locale,
         body: contentJSON.body,
-        deliveryId: contentJSON.deliveryId == contentJSON.Id ? undefined : contentJSON.deliveryId,
+        deliveryId: contentJSON.deliveryId == contentJSON.Id || argv.excludeKeys ? undefined : contentJSON.deliveryId,
         folderId: folder == null ? null : folder.id,
         publish: contentJSON.lastPublishedVersion != null
       };

--- a/src/commands/content-item/import.ts
+++ b/src/commands/content-item/import.ts
@@ -16,7 +16,8 @@ import {
   Hub,
   ContentRepository,
   ContentType,
-  ContentTypeSchema
+  ContentTypeSchema,
+  Status
 } from 'dc-management-sdk-js';
 import { ContentMapping } from '../../common/content-item/content-mapping';
 import {
@@ -234,6 +235,10 @@ const createOrUpdateContent = async (
   } else {
     const oldVersion = oldItem.version || 0;
     item.version = oldItem.version;
+    if (oldItem.status !== Status.ACTIVE) {
+      // If an item is archived, it must be unarchived before updating it.
+      await oldItem.related.unarchive();
+    }
     result = { newItem: await oldItem.related.update(item), oldVersion };
   }
 

--- a/src/commands/content-item/import.ts
+++ b/src/commands/content-item/import.ts
@@ -367,6 +367,10 @@ const prepareContentForImport = async (
         publish: contentJSON.lastPublishedVersion != null
       };
 
+      if (argv.excludeKeys) {
+        delete filteredContent.body._meta.deliveryKey;
+      }
+
       schemaNames.add(contentJSON.body._meta.schema);
 
       contentItems.push({ repo: repo, content: new ContentItem(filteredContent) });

--- a/src/commands/content-item/move.spec.ts
+++ b/src/commands/content-item/move.spec.ts
@@ -231,6 +231,7 @@ describe('content-item move command', () => {
 
     it('should attempt to unarchive based on MOVE actions when passing a revert log', async () => {
       const copyCalls: Arguments<CopyItemBuilderOptions & ConfigurationParameters>[] = copierAny.calls;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const revertCalls: Arguments<ImportItemBuilderOptions & ConfigurationParameters>[] = (reverter as any).calls;
 
       copyCalls.splice(0, copyCalls.length);
@@ -286,18 +287,16 @@ describe('content-item move command', () => {
       expect(copyCalls.length).toEqual(0);
 
       expect(revertCalls.length).toEqual(1);
-      expect(revertCalls[0]).toMatchInlineSnapshot(`
-        Object {
-          "$0": "",
-          "_": Array [],
-          "clientId": "acc2-id",
-          "clientSecret": "acc2-secret",
-          "dir": "",
-          "hubId": "hub2-id",
-          "json": true,
-          "revertLog": "temp/move/moveRevert.txt",
-        }
-      `);
+      expect(revertCalls[0]).toEqual({
+        '$0': '',
+        '_': [],
+        json: true,
+        clientId: 'acc2-id',
+        clientSecret: 'acc2-secret',
+        dir: '',
+        hubId: 'hub2-id',
+        revertLog: 'temp/move/moveRevert.txt'
+      });
 
       rimraf('temp/move/moveRevert.txt');
     });

--- a/src/commands/content-item/move.spec.ts
+++ b/src/commands/content-item/move.spec.ts
@@ -122,6 +122,12 @@ describe('content-item move command', () => {
         describe: 'Skip any content item that has one or more missing dependancy.'
       });
 
+      expect(spyOption).toHaveBeenCalledWith('excludeKeys', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'Exclude delivery keys when importing content items.'
+      });
+
       expect(spyOption).toHaveBeenCalledWith('logFile', {
         type: 'string',
         default: LOG_FILENAME,

--- a/src/commands/content-item/move.spec.ts
+++ b/src/commands/content-item/move.spec.ts
@@ -1,0 +1,441 @@
+// Copy tests are rather simple since they most of the work is done by import/export.
+// Unique features are revert, throwing when parameters are wrong/missing,
+// and forwarding input parameters to both import and export.
+
+import { builder, command, handler, LOG_FILENAME } from './move';
+import Yargs from 'yargs/yargs';
+import * as copier from './copy';
+
+import { writeFile } from 'fs';
+import { dirname } from 'path';
+import { promisify } from 'util';
+
+import rmdir from 'rimraf';
+import { Arguments } from 'yargs';
+import { ConfigurationParameters } from '../configure';
+import { CopyItemBuilderOptions } from '../../interfaces/copy-item-builder-options.interface';
+import { ItemTemplate, MockContent } from '../../common/dc-management-sdk-js/mock-content';
+import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
+import { ensureDirectoryExists } from '../../common/import/directory-utils';
+
+jest.mock('../../services/dynamic-content-client-factory');
+jest.mock('./copy');
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const copierAny = copier as any;
+
+function rimraf(dir: string): Promise<Error> {
+  return new Promise((resolve): void => {
+    rmdir(dir, resolve);
+  });
+}
+
+describe('content-item move command', () => {
+  afterEach((): void => {
+    jest.restoreAllMocks();
+  });
+
+  it('should command should defined', function() {
+    expect(command).toEqual('move');
+  });
+
+  describe('builder tests', function() {
+    it('should configure yargs', function() {
+      const argv = Yargs(process.argv.slice(2));
+      const spyOption = jest.spyOn(argv, 'option').mockReturnThis();
+
+      builder(argv);
+
+      expect(spyOption).toHaveBeenCalledWith('revertLog', {
+        type: 'string',
+        describe:
+          'Path to a log file to revert a move for. This will archive the most recently moved resources from the destination, unarchive from the source, and revert updated ones.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('srcRepo', {
+        type: 'string',
+        describe:
+          'Copy content from within a given repository. Directory structure will start at the specified repository. Will automatically export all contained folders.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('srcFolder', {
+        type: 'string',
+        describe:
+          'Copy content from within a given folder. Directory structure will start at the specified folder. Can be used in addition to repoId.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('dstRepo', {
+        type: 'string',
+        describe:
+          'Copy matching the given repository to the source base directory, by ID. Folder structure will be followed and replicated from there.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('dstFolder', {
+        type: 'string',
+        describe:
+          'Copy matching the given folder to the source base directory, by ID. Folder structure will be followed and replicated from there.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('dstHub', {
+        type: 'string',
+        describe: 'Destination hub ID. If not specified, it will be the same as the source.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('dstClientId', {
+        type: 'string',
+        describe: "Destination account's client ID. If not specified, it will be the same as the source."
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('dstSecret', {
+        type: 'string',
+        describe: "Destination account's secret. Must be used alongside dstClientId."
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('mapFile', {
+        type: 'string',
+        describe:
+          'Mapping file to use when updating content that already exists. Updated with any new mappings that are generated. If not present, will be created.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('f', {
+        type: 'boolean',
+        boolean: true,
+        describe:
+          'Overwrite content, create and assign content types, and ignore content with missing types/references without asking.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('v', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'Only recreate folder structure - content is validated but not imported.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('skipIncomplete', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'Skip any content item that has one or more missing dependancy.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('logFile', {
+        type: 'string',
+        default: LOG_FILENAME,
+        describe: 'Path to a log file to write to.'
+      });
+    });
+  });
+
+  describe('handler tests', function() {
+    const yargArgs = {
+      $0: 'test',
+      _: ['test'],
+      json: true
+    };
+    const config = {
+      clientId: 'client-id',
+      clientSecret: 'client-id',
+      hubId: 'hub-id'
+    };
+
+    beforeAll(async () => {
+      await rimraf('temp/move/');
+    });
+
+    const clearArray = (array: object[]): void => {
+      array.splice(0, array.length);
+    };
+
+    beforeEach(() => {
+      const copyCalls: Arguments<CopyItemBuilderOptions & ConfigurationParameters>[] = copierAny.calls;
+      clearArray(copyCalls);
+    });
+
+    async function createLog(logFileName: string, log: string): Promise<void> {
+      const dir = dirname(logFileName);
+      await ensureDirectoryExists(dir);
+      await promisify(writeFile)(logFileName, log);
+    }
+
+    it('should call copy with the correct parameters, and archive content reported as "exported"', async () => {
+      const copyCalls: Arguments<CopyItemBuilderOptions & ConfigurationParameters>[] = copierAny.calls;
+
+      copierAny.setForceFail(false);
+      const exportIds = ['example-id', 'example-id2'];
+      copierAny.setOutputIds(exportIds);
+
+      const templates: ItemTemplate[] = [
+        { id: 'example-id', label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type' },
+        { id: 'example-id2', label: 'item2', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest' }
+      ];
+
+      const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+      mockContent.createMockRepository('repo');
+      mockContent.registerContentType('http://type', 'type', 'repo');
+      mockContent.importItemTemplates(templates);
+
+      // TODO: mock handlers for export and import
+      const argv: Arguments<CopyItemBuilderOptions & ConfigurationParameters> = {
+        ...yargArgs,
+        ...config,
+
+        srcRepo: 'repo1-id',
+
+        dstRepo: 'repo2-id',
+
+        dstHub: 'hub2-id',
+        dstClientId: 'acc2-id',
+        dstSecret: 'acc2-secret',
+
+        schemaId: '/./',
+        name: '/./',
+
+        mapFile: 'map.json',
+        force: false,
+        validate: false,
+        skipIncomplete: false
+      };
+      await handler(argv);
+
+      expect(copyCalls.length).toEqual(1);
+
+      expect(copyCalls[0].clientId).toEqual(config.clientId);
+      expect(copyCalls[0].clientSecret).toEqual(config.clientSecret);
+      expect(copyCalls[0].hubId).toEqual(config.hubId);
+      expect(copyCalls[0].schemaId).toEqual(argv.schemaId);
+      expect(copyCalls[0].name).toEqual(argv.name);
+      expect(copyCalls[0].srcRepo).toEqual(argv.srcRepo);
+      expect(copyCalls[0].dstRepo).toEqual(argv.dstRepo);
+      expect(copyCalls[0].dstHub).toEqual(argv.dstHub);
+      expect(copyCalls[0].dstSecret).toEqual(argv.dstSecret);
+
+      expect(copyCalls[0].force).toEqual(argv.force);
+      expect(copyCalls[0].validate).toEqual(argv.validate);
+      expect(copyCalls[0].skipIncomplete).toEqual(argv.skipIncomplete);
+
+      expect(argv.exportedIds).toEqual(exportIds);
+
+      expect(mockContent.metrics.itemsArchived).toEqual(2);
+    });
+
+    it('should attempt to unarchive based on MOVE actions when passing a revert log', async () => {
+      const copyCalls: Arguments<CopyItemBuilderOptions & ConfigurationParameters>[] = copierAny.calls;
+
+      await createLog('temp/move/moveRevert.txt', 'MOVED id1\nMOVED id2\nMOVED id3\nMOVED id4');
+
+      // Create content to revert
+
+      const templates: ItemTemplate[] = [
+        { id: 'id1', label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type', status: 'ARCHIVED' },
+        {
+          id: 'id2',
+          label: 'item2',
+          repoId: 'repo',
+          typeSchemaUri: 'http://type',
+          folderPath: 'folderTest',
+          status: 'ARCHIVED'
+        },
+        {
+          id: 'id3',
+          label: 'item3',
+          repoId: 'repo',
+          typeSchemaUri: 'http://type',
+          folderPath: 'folderTest/nested',
+          status: 'ARCHIVED'
+        },
+
+        // This item is already unarchived, so it will be skipped.
+        { id: 'id4', label: 'item4', repoId: 'repo', typeSchemaUri: 'http://type' },
+        // This item shouldn't be unarchived, since it is not in the log.
+        { id: 'id5', label: 'item5', repoId: 'repo', typeSchemaUri: 'http://type', status: 'ARCHIVED' }
+      ];
+
+      const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+      mockContent.createMockRepository('repo');
+      mockContent.registerContentType('http://type', 'type', 'repo');
+      mockContent.importItemTemplates(templates);
+
+      // TODO: mock handlers for export and import
+      const argv: Arguments<CopyItemBuilderOptions & ConfigurationParameters> = {
+        ...yargArgs,
+        ...config,
+
+        dstHub: 'hub2-id',
+        dstClientId: 'acc2-id',
+        dstSecret: 'acc2-secret',
+
+        revertLog: 'temp/move/moveRevert.txt'
+      };
+      await handler(argv);
+
+      expect(mockContent.metrics.itemsUnarchived).toEqual(3);
+      expect(copyCalls.length).toEqual(0);
+
+      rimraf('temp/move/moveRevert.txt');
+    });
+
+    it('should revert uninterrupted when fetching an item fails', async () => {
+      const copyCalls: Arguments<CopyItemBuilderOptions & ConfigurationParameters>[] = copierAny.calls;
+
+      // NOTE: id3 doesn't exist, but that's OK
+      await createLog('temp/move/moveRevertFetch.txt', 'MOVED id1\nMOVED id2\nMOVED id3');
+
+      // Create content to revert
+      const templates: ItemTemplate[] = [
+        { id: 'id1', label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type', status: 'ARCHIVED' },
+        {
+          id: 'id2',
+          label: 'item2',
+          repoId: 'repo',
+          typeSchemaUri: 'http://type',
+          folderPath: 'folderTest',
+          status: 'ARCHIVED'
+        }
+      ];
+
+      const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+      mockContent.failItemActions = 'all';
+      mockContent.createMockRepository('repo');
+      mockContent.registerContentType('http://type', 'type', 'repo');
+      mockContent.importItemTemplates(templates);
+
+      // TODO: mock handlers for export and import
+      const argv: Arguments<CopyItemBuilderOptions & ConfigurationParameters> = {
+        ...yargArgs,
+        ...config,
+
+        dstHub: 'hub2-id',
+        dstClientId: 'acc2-id',
+        dstSecret: 'acc2-secret',
+
+        revertLog: 'temp/move/moveRevertFetch.txt'
+      };
+      await handler(argv);
+
+      expect(mockContent.metrics.itemsUnarchived).toEqual(0);
+      expect(copyCalls.length).toEqual(0);
+
+      rimraf('temp/move/moveRevertFetch.txt');
+    });
+
+    // should revert uninterrupted when unarchiving an item fails
+
+    // should abort early when passing a missing revert log
+
+    it('should abort early when passing a missing revert log', async () => {
+      const copyCalls: Arguments<CopyItemBuilderOptions & ConfigurationParameters>[] = copierAny.calls;
+
+      // Create content, shouldn't be reverted.
+      const templates: ItemTemplate[] = [
+        { id: 'id1', label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type', status: 'ARCHIVED' }
+      ];
+
+      const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+      mockContent.createMockRepository('repo');
+      mockContent.registerContentType('http://type', 'type', 'repo');
+      mockContent.importItemTemplates(templates);
+
+      // TODO: mock handlers for export and import
+      const argv: Arguments<CopyItemBuilderOptions & ConfigurationParameters> = {
+        ...yargArgs,
+        ...config,
+
+        dstHub: 'hub2-id',
+        dstClientId: 'acc2-id',
+        dstSecret: 'acc2-secret',
+
+        revertLog: 'temp/move/moveRevertMissing.txt'
+      };
+      await handler(argv);
+
+      expect(mockContent.metrics.itemsUnarchived).toEqual(0);
+      expect(copyCalls.length).toEqual(0);
+    });
+
+    it('should abort early when copy fails', async () => {
+      const copyCalls: Arguments<CopyItemBuilderOptions & ConfigurationParameters>[] = copierAny.calls;
+
+      // These should not be archived
+      const exportIds = ['example-id', 'example-id2'];
+      copierAny.setOutputIds(exportIds);
+      copierAny.setForceFail(true);
+
+      // Create content, shouldn't be reverted.
+      const templates: ItemTemplate[] = [
+        { id: 'example-id', label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type' },
+        { id: 'example-id2', label: 'item2', repoId: 'repo', typeSchemaUri: 'http://type' }
+      ];
+
+      const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+      mockContent.createMockRepository('repo');
+      mockContent.registerContentType('http://type', 'type', 'repo');
+      mockContent.importItemTemplates(templates);
+
+      // TODO: mock handlers for export and import
+      const argv: Arguments<CopyItemBuilderOptions & ConfigurationParameters> = {
+        ...yargArgs,
+        ...config,
+
+        dstHub: 'hub2-id',
+        dstClientId: 'acc2-id',
+        dstSecret: 'acc2-secret',
+
+        logFile: LOG_FILENAME()
+      };
+      await handler(argv);
+
+      expect(mockContent.metrics.itemsArchived).toEqual(0);
+      expect(copyCalls.length).toEqual(1);
+    });
+
+    it('should continue if archiving moved content fails, and record the failures in the log', async () => {
+      const copyCalls: Arguments<CopyItemBuilderOptions & ConfigurationParameters>[] = copierAny.calls;
+
+      copierAny.setForceFail(false);
+      const exportIds = ['example-id', 'example-id2'];
+      copierAny.setOutputIds(exportIds);
+
+      const templates: ItemTemplate[] = [
+        { id: 'example-id', label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type' },
+        { id: 'example-id2', label: 'item2', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest' }
+      ];
+
+      const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
+      mockContent.failItemActions = 'all';
+      mockContent.createMockRepository('repo');
+      mockContent.registerContentType('http://type', 'type', 'repo');
+      mockContent.importItemTemplates(templates);
+
+      // TODO: mock handlers for export and import
+      const argv: Arguments<CopyItemBuilderOptions & ConfigurationParameters> = {
+        ...yargArgs,
+        ...config,
+
+        srcRepo: 'repo1-id',
+
+        dstRepo: 'repo2-id',
+
+        dstHub: 'hub2-id',
+        dstClientId: 'acc2-id',
+        dstSecret: 'acc2-secret',
+
+        schemaId: '/./',
+        name: '/./',
+
+        mapFile: 'map.json',
+        force: false,
+        validate: false,
+        skipIncomplete: false,
+
+        logFile: 'temp/move/failLog.txt'
+      };
+      await handler(argv);
+
+      expect(copyCalls.length).toEqual(1);
+
+      expect(argv.exportedIds).toEqual(exportIds);
+
+      expect(mockContent.metrics.itemsArchived).toEqual(0);
+    });
+
+    // should return early when copy fails, without archiving any content from the source
+  });
+});

--- a/src/commands/content-item/move.spec.ts
+++ b/src/commands/content-item/move.spec.ts
@@ -288,8 +288,8 @@ describe('content-item move command', () => {
 
       expect(revertCalls.length).toEqual(1);
       expect(revertCalls[0]).toEqual({
-        '$0': '',
-        '_': [],
+        $0: '',
+        _: [],
         json: true,
         clientId: 'acc2-id',
         clientSecret: 'acc2-secret',

--- a/src/commands/content-item/move.spec.ts
+++ b/src/commands/content-item/move.spec.ts
@@ -17,9 +17,11 @@ import { CopyItemBuilderOptions } from '../../interfaces/copy-item-builder-optio
 import { ItemTemplate, MockContent } from '../../common/dc-management-sdk-js/mock-content';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
 import { ensureDirectoryExists } from '../../common/import/directory-utils';
+import { getDefaultLogPath } from '../../common/log-helpers';
 
 jest.mock('../../services/dynamic-content-client-factory');
 jest.mock('./copy');
+jest.mock('../../common/log-helpers');
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const copierAny = copier as any;
@@ -154,6 +156,12 @@ describe('content-item move command', () => {
       await ensureDirectoryExists(dir);
       await promisify(writeFile)(logFileName, log);
     }
+
+    it('should use getDefaultLogPath for LOG_FILENAME with process.platform as default', function() {
+      LOG_FILENAME();
+
+      expect(getDefaultLogPath).toHaveBeenCalledWith('item', 'move', process.platform);
+    });
 
     it('should call copy with the correct parameters, and archive content reported as "exported"', async () => {
       const copyCalls: Arguments<CopyItemBuilderOptions & ConfigurationParameters>[] = copierAny.calls;
@@ -413,9 +421,9 @@ describe('content-item move command', () => {
 
         dstRepo: 'repo2-id',
 
-        dstHub: 'hub2-id',
-        dstClientId: 'acc2-id',
-        dstSecret: 'acc2-secret',
+        hubId: 'hub2-id',
+        clientId: 'acc2-id',
+        clientSecret: 'acc2-secret',
 
         schemaId: '/./',
         name: '/./',

--- a/src/commands/content-item/move.ts
+++ b/src/commands/content-item/move.ts
@@ -101,6 +101,24 @@ export const builder = (yargs: Argv): void => {
       type: 'string',
       describe:
         'Path to a JSON configuration file for source/destination account. If the given file does not exist, it will be generated from the arguments.'
+    })
+
+    .option('lastPublish', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'When available, export the last published version of a content item rather than its newest version.'
+    })
+
+    .option('publish', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'Publish any content items that have an existing publish status in their JSON.'
+    })
+
+    .option('republish', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'Republish content items regardless of whether the import changed them or not. (--publish not required)'
     });
 };
 

--- a/src/commands/content-item/move.ts
+++ b/src/commands/content-item/move.ts
@@ -92,12 +92,6 @@ export const builder = (yargs: Argv): void => {
       describe: 'Skip any content item that has one or more missing dependancy.'
     })
 
-    .option('logFile', {
-      type: 'string',
-      default: LOG_FILENAME,
-      describe: 'Path to a log file to write to.'
-    })
-
     .option('copyConfig', {
       type: 'string',
       describe:
@@ -120,6 +114,18 @@ export const builder = (yargs: Argv): void => {
       type: 'boolean',
       boolean: true,
       describe: 'Republish content items regardless of whether the import changed them or not. (--publish not required)'
+    })
+
+    .option('excludeKeys', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'Exclude delivery keys when importing content items.'
+    })
+
+    .option('logFile', {
+      type: 'string',
+      default: LOG_FILENAME,
+      describe: 'Path to a log file to write to.'
     });
 };
 

--- a/src/commands/content-item/move.ts
+++ b/src/commands/content-item/move.ts
@@ -9,12 +9,6 @@ import { FileLog } from '../../common/file-log';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
 import { ContentItem, Status } from 'dc-management-sdk-js';
 
-/*
-export function getTempFolder(name: string, platform: string = process.platform): string {
-  return join(process.env[platform == 'win32' ? 'USERPROFILE' : 'HOME'] || __dirname, '.amplience', `move-${name}/`);
-}
-*/
-
 export const command = 'move';
 
 export const desc = 'Move content items. The active account and hub are the source for the move.';
@@ -159,17 +153,15 @@ export const handler = async (argv: Arguments<CopyItemBuilderOptions & Configura
 
   const exported = argv.exportedIds;
 
-  if (exported.length > 0) {
-    for (let i = 0; i < exported.length; i++) {
-      const item = await client.contentItems.get(exported[i]);
+  for (let i = 0; i < exported.length; i++) {
+    const item = await client.contentItems.get(exported[i]);
 
-      try {
-        await item.related.archive();
-        log.addAction('MOVED', item.id as string);
-      } catch (e) {
-        log.addComment(`ARCHIVE FAILED: ${item.id}`);
-        log.addComment(e.toString());
-      }
+    try {
+      await item.related.archive();
+      log.addAction('MOVED', item.id as string);
+    } catch (e) {
+      log.addComment(`ARCHIVE FAILED: ${item.id}`);
+      log.addComment(e.toString());
     }
   }
 };

--- a/src/commands/content-item/move.ts
+++ b/src/commands/content-item/move.ts
@@ -9,6 +9,7 @@ import { FileLog } from '../../common/file-log';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
 import { ContentItem, Status } from 'dc-management-sdk-js';
 import { loadCopyConfig } from '../../common/content-item/copy-config';
+import { revert } from './import-revert';
 
 export const command = 'move';
 
@@ -172,7 +173,23 @@ export const handler = async (argv: Arguments<CopyItemBuilderOptions & Configura
       }
     }
 
-    console.log('Done!');
+    const yargArgs = {
+      $0: '',
+      _: [],
+      json: true
+    };
+
+    await revert({
+      ...yargArgs,
+
+      hubId: copyConfig.dstHubId,
+      clientId: copyConfig.dstClientId,
+      clientSecret: copyConfig.dstSecret,
+
+      dir: '', // unused
+
+      revertLog: argv.revertLog
+    });
   } else {
     const log = new FileLog(argv.logFile as string);
     argv.logFile = log;

--- a/src/commands/content-item/move.ts
+++ b/src/commands/content-item/move.ts
@@ -206,7 +206,6 @@ export const handler = async (argv: Arguments<CopyItemBuilderOptions & Configura
       return;
     }
 
-    const client = dynamicContentClientFactory(argv);
     argv.copyConfig = copyConfig;
 
     const copySuccess = await copy.handler(argv);
@@ -214,6 +213,13 @@ export const handler = async (argv: Arguments<CopyItemBuilderOptions & Configura
     if (!copySuccess) {
       return;
     }
+
+    const client = dynamicContentClientFactory({
+      ...argv,
+      hubId: copyConfig.srcHubId,
+      clientId: copyConfig.srcClientId,
+      clientSecret: copyConfig.srcSecret
+    });
 
     // Only archive the result of the export once the copy has completed.
     // This ensures the content is always active in one location if something goes wrong.

--- a/src/commands/content-item/move.ts
+++ b/src/commands/content-item/move.ts
@@ -1,0 +1,175 @@
+import { getDefaultLogPath } from '../../common/log-helpers';
+import { Argv, Arguments } from 'yargs';
+import { CopyItemBuilderOptions } from '../../interfaces/copy-item-builder-options.interface';
+import { ConfigurationParameters } from '../configure';
+
+import * as copy from './copy';
+
+import { FileLog } from '../../common/file-log';
+import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
+import { ContentItem, Status } from 'dc-management-sdk-js';
+
+/*
+export function getTempFolder(name: string, platform: string = process.platform): string {
+  return join(process.env[platform == 'win32' ? 'USERPROFILE' : 'HOME'] || __dirname, '.amplience', `move-${name}/`);
+}
+*/
+
+export const command = 'move';
+
+export const desc = 'Move content items. The active account and hub are the source for the move.';
+
+export const LOG_FILENAME = (platform: string = process.platform): string =>
+  getDefaultLogPath('item', 'move', platform);
+
+export const builder = (yargs: Argv): void => {
+  yargs
+    .option('revertLog', {
+      type: 'string',
+      describe:
+        'Path to a log file to revert a move for. This will archive the most recently moved resources from the destination, unarchive from the source, and revert updated ones.'
+    })
+
+    .option('srcRepo', {
+      type: 'string',
+      describe:
+        'Copy content from within a given repository. Directory structure will start at the specified repository. Will automatically export all contained folders.'
+    })
+
+    .option('srcFolder', {
+      type: 'string',
+      describe:
+        'Copy content from within a given folder. Directory structure will start at the specified folder. Can be used in addition to repoId.'
+    })
+
+    .option('dstRepo', {
+      type: 'string',
+      describe:
+        'Copy matching the given repository to the source base directory, by ID. Folder structure will be followed and replicated from there.'
+    })
+
+    .option('dstFolder', {
+      type: 'string',
+      describe:
+        'Copy matching the given folder to the source base directory, by ID. Folder structure will be followed and replicated from there.'
+    })
+
+    .option('dstHub', {
+      type: 'string',
+      describe: 'Destination hub ID. If not specified, it will be the same as the source.'
+    })
+
+    .option('dstClientId', {
+      type: 'string',
+      describe: "Destination account's client ID. If not specified, it will be the same as the source."
+    })
+
+    .option('dstSecret', {
+      type: 'string',
+      describe: "Destination account's secret. Must be used alongside dstClientId."
+    })
+
+    .option('mapFile', {
+      type: 'string',
+      describe:
+        'Mapping file to use when updating content that already exists. Updated with any new mappings that are generated. If not present, will be created.'
+    })
+
+    .alias('f', 'force')
+    .option('f', {
+      type: 'boolean',
+      boolean: true,
+      describe:
+        'Overwrite content, create and assign content types, and ignore content with missing types/references without asking.'
+    })
+
+    .alias('v', 'validate')
+    .option('v', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'Only recreate folder structure - content is validated but not imported.'
+    })
+
+    .option('skipIncomplete', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'Skip any content item that has one or more missing dependancy.'
+    })
+
+    .option('logFile', {
+      type: 'string',
+      default: LOG_FILENAME,
+      describe: 'Path to a log file to write to.'
+    });
+};
+
+export const handler = async (argv: Arguments<CopyItemBuilderOptions & ConfigurationParameters>): Promise<void> => {
+  argv.exportedIds = [];
+
+  const client = dynamicContentClientFactory(argv);
+
+  if (argv.revertLog != null) {
+    const log = new FileLog();
+    try {
+      await log.loadFromFile(argv.revertLog as string);
+    } catch (e) {
+      console.log('Could not open the import log! Aborting.');
+      return;
+    }
+
+    const toUnarchive = log.getData('MOVED'); // Undo moved content by unarchiving it.
+
+    for (let i = 0; i < toUnarchive.length; i++) {
+      const id = toUnarchive[i];
+
+      let item: ContentItem;
+      try {
+        item = await client.contentItems.get(id);
+      } catch {
+        console.log(`Could not find item with id ${id}, skipping.`);
+        continue;
+      }
+
+      if (item.status !== Status.ACTIVE) {
+        try {
+          await item.related.unarchive();
+        } catch {
+          console.log(`Could not unarchive item with id ${id}, skipping.`);
+          continue;
+        }
+      } else {
+        console.log(`Item with id ${id} is already unarchived, skipping.`);
+      }
+    }
+
+    console.log('Done!');
+    return;
+  }
+
+  const log = new FileLog(argv.logFile as string);
+  argv.logFile = log;
+  const copySuccess = await copy.handler(argv);
+
+  if (!copySuccess) {
+    return;
+  }
+
+  // Only archive the result of the export once the copy has completed.
+  // This ensures the content is always active in one location if something goes wrong.
+
+  const exported = argv.exportedIds;
+
+  if (exported.length > 0) {
+    for (let i = 0; i < exported.length; i++) {
+      const item = await client.contentItems.get(exported[i]);
+
+      try {
+        await item.related.archive();
+        log.addAction('MOVED', item.id as string);
+      } catch (e) {
+        log.addComment(`ARCHIVE FAILED: ${item.id}`);
+        log.addComment(e.toString());
+      }
+    }
+  }
+};

--- a/src/common/content-item/copy-config.spec.ts
+++ b/src/common/content-item/copy-config.spec.ts
@@ -1,0 +1,345 @@
+import { CopyConfigFile, loadCopyConfig } from './copy-config';
+import { Arguments } from 'yargs';
+import { ConfigurationParameters } from '../../commands/configure';
+import { FileLog } from '../file-log';
+import { CopyItemBuilderOptions } from '../../interfaces/copy-item-builder-options.interface';
+
+import * as fs from 'fs';
+
+jest.mock('fs');
+
+const yargArgs = {
+  $0: 'test',
+  _: ['test'],
+  json: true
+};
+
+describe('copy-config', () => {
+  const writeFileMock = (fs.writeFile as any) as jest.Mock;
+  const existsMock = (fs.existsSync as any) as jest.Mock;
+  const readFileMock = (fs.readFile as any) as jest.Mock;
+  const mkdirMock = (fs.mkdir as any) as jest.Mock;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('loadCopyConfig', () => {
+    it('should load a config file given a non-empty copyConfig argument', async () => {
+      const testConfig = {
+        dstClientId: 'test2',
+        dstHubId: 'test',
+        dstSecret: 'test3',
+        srcClientId: 'test2',
+        srcHubId: 'test',
+        srcSecret: 'test3'
+      };
+
+      const oldLoad = CopyConfigFile.prototype.load;
+
+      const loadMock = jest.fn().mockImplementation(function() {
+        this.config = testConfig;
+        return Promise.resolve(true);
+      });
+      CopyConfigFile.prototype.load = loadMock;
+
+      const log = new FileLog();
+      const argv: Arguments<ConfigurationParameters & CopyItemBuilderOptions> = {
+        ...yargArgs,
+        hubId: 'skipped',
+        clientId: 'skipped',
+        clientSecret: 'skipped',
+
+        copyConfig: 'config.json'
+      };
+
+      const config = await loadCopyConfig(argv, log);
+
+      expect(loadMock).toBeCalledWith(argv.copyConfig);
+      expect(config).toEqual(testConfig);
+
+      CopyConfigFile.prototype.load = oldLoad;
+    });
+
+    it('should log and return null if config file cannot be loaded', async () => {
+      const oldLoad = CopyConfigFile.prototype.load;
+
+      const loadMock = jest.fn().mockImplementation(function() {
+        throw new Error('Loading failed.');
+      });
+      CopyConfigFile.prototype.load = loadMock;
+
+      const log = new FileLog();
+      const argv: Arguments<ConfigurationParameters & CopyItemBuilderOptions> = {
+        ...yargArgs,
+        hubId: 'skipped',
+        clientId: 'skipped',
+        clientSecret: 'skipped',
+
+        copyConfig: 'config.json'
+      };
+
+      const config = await loadCopyConfig(argv, log);
+
+      expect(loadMock).toBeCalledWith(argv.copyConfig);
+      expect(config).toBeNull();
+
+      CopyConfigFile.prototype.load = oldLoad;
+    });
+
+    it('should return a config object based on the arguments when no config file argument is given', async () => {
+      const log = new FileLog();
+      const argv: Arguments<ConfigurationParameters> = {
+        ...yargArgs,
+        hubId: 'test',
+        clientId: 'test2',
+        clientSecret: 'test3'
+      };
+
+      const config = await loadCopyConfig(argv, log);
+
+      expect(config).toMatchInlineSnapshot(`
+        Object {
+          "dstClientId": "test2",
+          "dstHubId": "test",
+          "dstSecret": "test3",
+          "srcClientId": "test2",
+          "srcHubId": "test",
+          "srcSecret": "test3",
+        }
+      `);
+
+      const argv2: Arguments<ConfigurationParameters & CopyItemBuilderOptions> = {
+        ...yargArgs,
+        hubId: 'test4',
+        clientId: 'test5',
+        clientSecret: 'test6',
+
+        dstHubId: 'test7',
+        dstClientId: 'test8',
+        dstSecret: 'test9'
+      };
+
+      const config2 = await loadCopyConfig(argv2, log);
+
+      expect(config2).toMatchInlineSnapshot(`
+        Object {
+          "dstClientId": "test8",
+          "dstHubId": "test7",
+          "dstSecret": "test9",
+          "srcClientId": "test5",
+          "srcHubId": "test4",
+          "srcSecret": "test6",
+        }
+      `);
+    });
+
+    it("should create a config file based on the arguments when it doesn't already exist", async () => {
+      const oldLoad = CopyConfigFile.prototype.load;
+      const oldSave = CopyConfigFile.prototype.save;
+
+      const loadMock = jest.fn().mockImplementation(function(filename: string) {
+        expect(filename).toEqual('filename.json');
+        return Promise.resolve(false);
+      });
+      CopyConfigFile.prototype.load = loadMock;
+
+      const saveMock = jest.fn().mockImplementation(function(filename: string) {
+        expect(filename).toEqual('filename.json');
+        return Promise.resolve();
+      });
+      CopyConfigFile.prototype.save = saveMock;
+
+      const log = new FileLog();
+      const argv: Arguments<ConfigurationParameters & CopyItemBuilderOptions> = {
+        ...yargArgs,
+        hubId: 'test',
+        clientId: 'test2',
+        clientSecret: 'test3',
+
+        dstHubId: 'test4',
+        dstClientId: 'test5',
+        dstSecret: 'test6',
+
+        copyConfig: 'filename.json'
+      };
+
+      const config = await loadCopyConfig(argv, log);
+
+      expect(config).toMatchInlineSnapshot(`
+        Object {
+          "dstClientId": "test5",
+          "dstHubId": "test4",
+          "dstSecret": "test6",
+          "srcClientId": "test2",
+          "srcHubId": "test",
+          "srcSecret": "test3",
+        }
+      `);
+
+      CopyConfigFile.prototype.load = oldLoad;
+      CopyConfigFile.prototype.save = oldSave;
+    });
+
+    it('should continue normally even if new config cannot be saved', async () => {
+      const oldLoad = CopyConfigFile.prototype.load;
+      const oldSave = CopyConfigFile.prototype.save;
+
+      const loadMock = jest.fn().mockImplementation(function(filename: string) {
+        expect(filename).toEqual('filename.json');
+        return Promise.resolve(false);
+      });
+      CopyConfigFile.prototype.load = loadMock;
+
+      const saveMock = jest.fn().mockImplementation(function(filename: string) {
+        expect(filename).toEqual('filename.json');
+        throw new Error("Couldn't save");
+      });
+      CopyConfigFile.prototype.save = saveMock;
+
+      const log = new FileLog();
+      const argv: Arguments<ConfigurationParameters & CopyItemBuilderOptions> = {
+        ...yargArgs,
+        hubId: 'test',
+        clientId: 'test2',
+        clientSecret: 'test3',
+
+        dstHubId: 'test4',
+        dstClientId: 'test5',
+        dstSecret: 'test6',
+
+        copyConfig: 'filename.json'
+      };
+
+      const config = await loadCopyConfig(argv, log);
+
+      expect(config).toMatchInlineSnapshot(`
+        Object {
+          "dstClientId": "test5",
+          "dstHubId": "test4",
+          "dstSecret": "test6",
+          "srcClientId": "test2",
+          "srcHubId": "test",
+          "srcSecret": "test3",
+        }
+      `);
+
+      CopyConfigFile.prototype.load = oldLoad;
+      CopyConfigFile.prototype.save = oldSave;
+    });
+  });
+
+  describe('copy-config-file', () => {
+    it('should write the config as json to the given filename on save (creating dir)', async () => {
+      existsMock.mockImplementation(input => {
+        expect(input).toEqual('folder');
+        return false;
+      });
+
+      mkdirMock.mockImplementation((input, callback) => {
+        expect(input).toEqual('folder');
+        callback();
+      });
+
+      writeFileMock.mockImplementation((filename, input, config, callback) => {
+        expect(filename).toEqual('folder/write.json');
+        expect(input).toMatchInlineSnapshot(
+          `"{\\"srcHubId\\":\\"test\\",\\"srcClientId\\":\\"test2\\",\\"srcSecret\\":\\"test3\\",\\"dstHubId\\":\\"test4\\",\\"dstClientId\\":\\"test5\\",\\"dstSecret\\":\\"test6\\"}"`
+        );
+        callback();
+      });
+
+      const file = new CopyConfigFile();
+      file.config = {
+        srcHubId: 'test',
+        srcClientId: 'test2',
+        srcSecret: 'test3',
+
+        dstHubId: 'test4',
+        dstClientId: 'test5',
+        dstSecret: 'test6'
+      };
+      await file.save('folder/write.json');
+    });
+
+    it('should write the config as json to the given filename on save (dir exists)', async () => {
+      existsMock.mockImplementation(path => {
+        expect(path).toEqual('folder');
+        return true;
+      });
+
+      writeFileMock.mockImplementation((filename, input, config, callback) => {
+        debugger;
+        expect(filename).toEqual('folder/write.json');
+        expect(input).toMatchInlineSnapshot(
+          `"{\\"srcHubId\\":\\"test\\",\\"srcClientId\\":\\"test2\\",\\"srcSecret\\":\\"test3\\",\\"dstHubId\\":\\"test4\\",\\"dstClientId\\":\\"test5\\",\\"dstSecret\\":\\"test6\\"}"`
+        );
+        callback();
+      });
+
+      const file = new CopyConfigFile();
+      file.config = {
+        srcHubId: 'test',
+        srcClientId: 'test2',
+        srcSecret: 'test3',
+
+        dstHubId: 'test4',
+        dstClientId: 'test5',
+        dstSecret: 'test6'
+      };
+
+      try {
+        await file.save('folder/write.json');
+      } catch (err) {
+        debugger;
+      }
+
+      debugger;
+      expect(mkdirMock).not.toHaveBeenCalled();
+    });
+
+    it('should read the config as json from the given filename on load', async () => {
+      readFileMock.mockImplementationOnce((input, config, callback) => {
+        expect(input).toEqual('goodFile.json');
+        callback(false, '{ "srcClientId": "jsonString" }');
+      });
+
+      const file = new CopyConfigFile();
+      const result = await file.load('goodFile.json');
+
+      expect(result).toBeTruthy();
+      expect(file.config).toMatchInlineSnapshot(`
+        Object {
+          "srcClientId": "jsonString",
+        }
+      `);
+    });
+
+    it('should throw if the given file does not contain valid JSON', async () => {
+      readFileMock.mockImplementationOnce((input, config, callback) => {
+        callback(false, 'not json');
+      });
+
+      const file = new CopyConfigFile();
+      let throws = false;
+      try {
+        await file.load('invalidFile.json');
+      } catch {
+        throws = true;
+      }
+
+      expect(throws).toBeTruthy();
+    });
+
+    it('should return false if the file does not exist', async () => {
+      readFileMock.mockImplementationOnce(() => {
+        throw new Error('Not found.');
+      });
+
+      const file = new CopyConfigFile();
+      const result = await file.load('badFile.json');
+
+      expect(result).toBeFalsy();
+    });
+  });
+});

--- a/src/common/content-item/copy-config.spec.ts
+++ b/src/common/content-item/copy-config.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { CopyConfigFile, loadCopyConfig } from './copy-config';
 import { Arguments } from 'yargs';
 import { ConfigurationParameters } from '../../commands/configure';

--- a/src/common/content-item/copy-config.ts
+++ b/src/common/content-item/copy-config.ts
@@ -1,0 +1,88 @@
+import { readFile, writeFile, existsSync, mkdir } from 'fs';
+import { dirname } from 'path';
+import { promisify } from 'util';
+import { Arguments } from 'yargs';
+import { ConfigurationParameters } from '../../commands/configure';
+import { CopyItemBuilderOptions } from '../../interfaces/copy-item-builder-options.interface';
+import { FileLog } from '../file-log';
+
+export interface CopyConfig {
+  srcHubId: string;
+  srcClientId: string;
+  srcSecret: string;
+
+  dstHubId: string;
+  dstClientId: string;
+  dstSecret: string;
+}
+
+export class CopyConfigFile {
+  config: CopyConfig;
+
+  async save(filename: string): Promise<void> {
+    const text = JSON.stringify(this.config);
+
+    const dir = dirname(filename);
+    if (!existsSync(dir)) {
+      await promisify(mkdir)(dir);
+    }
+    await promisify(writeFile)(filename, text, { encoding: 'utf8' });
+  }
+
+  async load(filename: string): Promise<boolean> {
+    let text: string;
+
+    try {
+      text = await promisify(readFile)(filename, { encoding: 'utf8' });
+    } catch (e) {
+      return false;
+    }
+
+    this.config = JSON.parse(text);
+
+    return true;
+  }
+}
+
+export async function loadCopyConfig(
+  argv: Arguments<CopyItemBuilderOptions & ConfigurationParameters>,
+  log: FileLog
+): Promise<CopyConfig | null> {
+  let copyConfig: CopyConfig = {
+    srcHubId: argv.hubId,
+    srcClientId: argv.clientId,
+    srcSecret: argv.clientSecret,
+
+    dstHubId: argv.dstHubId || argv.hubId,
+    dstClientId: argv.dstClientId || argv.clientId,
+    dstSecret: argv.dstSecret || argv.clientSecret
+  };
+
+  if (argv.copyConfig != null && typeof argv.copyConfig === 'string') {
+    const configFile = new CopyConfigFile();
+    let exists = false;
+    try {
+      exists = await configFile.load(argv.copyConfig);
+    } catch (e) {
+      log.addComment(`Failed to load configuration file: ${e.toString()}`);
+      await log.close();
+
+      return null;
+    }
+
+    if (exists) {
+      copyConfig = configFile.config;
+    } else {
+      // Save the current arguments as a config file.
+      configFile.config = copyConfig;
+      try {
+        configFile.save(argv.copyConfig);
+      } catch (e) {
+        log.addComment(`Failed to save configuration file: ${e.toString()}`);
+        log.addComment('Continuing.');
+      }
+    }
+  }
+
+  return copyConfig;
+}

--- a/src/common/file-log.ts
+++ b/src/common/file-log.ts
@@ -1,6 +1,8 @@
 import { ArchiveLog } from './archive/archive-log';
 
 export class FileLog extends ArchiveLog {
+  closed: boolean;
+
   constructor(private filename?: string) {
     super((filename || '').replace('<DATE>', Date.now().toString()));
 
@@ -20,5 +22,7 @@ export class FileLog extends ArchiveLog {
     if (this.filename != null) {
       await this.writeToFile(this.filename);
     }
+
+    this.closed = true;
   }
 }

--- a/src/interfaces/copy-item-builder-options.interface.ts
+++ b/src/interfaces/copy-item-builder-options.interface.ts
@@ -1,0 +1,26 @@
+import { FileLog } from '../common/file-log';
+
+export interface CopyItemBuilderOptions {
+  srcRepo?: string;
+  srcFolder?: string;
+
+  dstRepo?: string;
+  dstFolder?: string;
+
+  dstHub?: string;
+  dstClientId?: string;
+  dstSecret?: string;
+
+  schemaId?: string[] | string;
+  name?: string[] | string;
+
+  mapFile?: string;
+  force?: boolean;
+  validate?: boolean;
+  skipIncomplete?: boolean;
+  logFile?: string | FileLog;
+
+  revertLog?: string;
+
+  exportedIds?: string[];
+}

--- a/src/interfaces/copy-item-builder-options.interface.ts
+++ b/src/interfaces/copy-item-builder-options.interface.ts
@@ -1,3 +1,4 @@
+import { CopyConfig } from '../common/content-item/copy-config';
 import { FileLog } from '../common/file-log';
 
 export interface CopyItemBuilderOptions {
@@ -7,7 +8,7 @@ export interface CopyItemBuilderOptions {
   dstRepo?: string;
   dstFolder?: string;
 
-  dstHub?: string;
+  dstHubId?: string;
   dstClientId?: string;
   dstSecret?: string;
 
@@ -19,6 +20,7 @@ export interface CopyItemBuilderOptions {
   validate?: boolean;
   skipIncomplete?: boolean;
   logFile?: string | FileLog;
+  copyConfig?: string | CopyConfig;
 
   revertLog?: string;
 

--- a/src/interfaces/copy-item-builder-options.interface.ts
+++ b/src/interfaces/copy-item-builder-options.interface.ts
@@ -24,5 +24,9 @@ export interface CopyItemBuilderOptions {
 
   revertLog?: string;
 
+  lastPublish?: boolean;
+  publish?: boolean;
+  republish?: boolean;
+
   exportedIds?: string[];
 }

--- a/src/interfaces/copy-item-builder-options.interface.ts
+++ b/src/interfaces/copy-item-builder-options.interface.ts
@@ -28,5 +28,7 @@ export interface CopyItemBuilderOptions {
   publish?: boolean;
   republish?: boolean;
 
+  excludeKeys?: boolean;
+
   exportedIds?: string[];
 }

--- a/src/interfaces/import-item-builder-options.interface.ts
+++ b/src/interfaces/import-item-builder-options.interface.ts
@@ -10,6 +10,7 @@ export interface ImportItemBuilderOptions {
   force?: boolean;
   validate?: boolean;
   skipIncomplete?: boolean;
+  excludeKeys?: boolean;
   logFile?: string | FileLog;
 
   revertLog?: string;

--- a/temp/move/failLog.txt
+++ b/temp/move/failLog.txt
@@ -1,0 +1,5 @@
+// temp/move/failLog.txt
+// ARCHIVE FAILED: example-id
+// Error: Simulated network failure.
+// ARCHIVE FAILED: example-id2
+// Error: Simulated network failure.


### PR DESCRIPTION
This PR adds `copy` and `move` commands to the `content-item` set of commands. These are essentially a nice wrapper for `import` and `export`, which does the work of creating and deleting a temp folder for you, and can work with one command.

By default, the source and destination hubs for these commands are both defined by your dc-cli config, meaning a copy/move within the same hub. If you want the destination to be different from the source, you'll need to specify the destination's config in the commands, eg: `--dstHub <hubID> --dstClientId <clientId> --dstSecret <secret>`

Copies, moves and imports are also now revertable. Pass in the parameter `--revertLog <log path>` with your destination hub info and log generated from copy/move, and it will archive or revert any content items created or changed by that copy/move command.