### PR TITLE
feat(content-type-schema): make exporting archived schema optional, automatically create destination

### DIFF
--- a/src/commands/content-item/export.ts
+++ b/src/commands/content-item/export.ts
@@ -137,6 +137,7 @@ const getContentItems = async (
     let newItems: ContentItem[];
     try {
       const allItems = await paginator(repository.related.contentItems.list, { status: 'ACTIVE' });
+
       Array.prototype.push.apply(repoItems, allItems);
       newItems = allItems.filter(item => item.folderId == null);
     } catch (e) {

--- a/src/commands/content-item/import.ts
+++ b/src/commands/content-item/import.ts
@@ -691,11 +691,15 @@ const importTree = async (
   publishable = publishable.filter(entry => {
     let isTopLevel = true;
 
-    tree.traverseDependants(entry.node, dependant => {
-      if (dependant != entry.node && publishable.findIndex(entry => entry.node === dependant) !== -1) {
-        isTopLevel = false;
-      }
-    });
+    tree.traverseDependants(
+      entry.node,
+      dependant => {
+        if (dependant != entry.node && publishable.findIndex(entry => entry.node === dependant) !== -1) {
+          isTopLevel = false;
+        }
+      },
+      true
+    );
 
     if (!isTopLevel) {
       publishChildren++;

--- a/src/commands/content-item/import.ts
+++ b/src/commands/content-item/import.ts
@@ -22,7 +22,7 @@ import { ContentMapping } from '../../common/content-item/content-mapping';
 import {
   ContentDependancyTree,
   RepositoryContentItem,
-  ItemContentDependancies
+  ItemContentDependancies, ContentDependancyInfo
 } from '../../common/content-item/content-dependancy-tree';
 
 import { asyncQuestion } from '../../common/archive/archive-helpers';
@@ -614,6 +614,15 @@ const prepareContentForImport = async (
   return tree;
 };
 
+const rewriteDependancy = (dep: ContentDependancyInfo, mapping: ContentMapping): void => {
+  const id = mapping.getContentItem(dep.dependancy.id) || dep.dependancy.id;
+  if (dep.dependancy._meta.schema === '_hierarchy') {
+    dep.owner.content.body._meta.hierarchy.parentId = id;
+  } else {
+    dep.dependancy.id = id;
+  }
+}
+
 const importTree = async (
   client: DynamicContent,
   tree: ContentDependancyTree,
@@ -636,7 +645,7 @@ const importTree = async (
 
       // Replace any dependancies with the existing mapping.
       item.dependancies.forEach(dep => {
-        dep.dependancy.id = mapping.getContentItem(dep.dependancy.id) || dep.dependancy.id;
+        rewriteDependancy(dep, mapping);
       });
 
       const originalId = content.id;
@@ -707,7 +716,7 @@ const importTree = async (
       const content = item.owner.content;
 
       item.dependancies.forEach(dep => {
-        dep.dependancy.id = mapping.getContentItem(dep.dependancy.id) || dep.dependancy.id;
+        rewriteDependancy(dep, mapping);
       });
 
       const originalId = content.id;

--- a/src/commands/content-item/import.ts
+++ b/src/commands/content-item/import.ts
@@ -22,7 +22,8 @@ import { ContentMapping } from '../../common/content-item/content-mapping';
 import {
   ContentDependancyTree,
   RepositoryContentItem,
-  ItemContentDependancies, ContentDependancyInfo
+  ItemContentDependancies,
+  ContentDependancyInfo
 } from '../../common/content-item/content-dependancy-tree';
 
 import { asyncQuestion } from '../../common/archive/archive-helpers';
@@ -621,7 +622,7 @@ const rewriteDependancy = (dep: ContentDependancyInfo, mapping: ContentMapping):
   } else {
     dep.dependancy.id = id;
   }
-}
+};
 
 const importTree = async (
   client: DynamicContent,

--- a/src/commands/content-type-schema/export.spec.ts
+++ b/src/commands/content-type-schema/export.spec.ts
@@ -711,7 +711,7 @@ describe('content-type-schema export command', (): void => {
       await handler(argv);
 
       expect(mockGetHub).toHaveBeenCalledWith('hub-id');
-      expect(mockList).toHaveBeenCalled();
+      expect(mockList).toHaveBeenCalledWith({ size: 100, status: 'ACTIVE' });
       expect(loadJsonFromDirectory).toHaveBeenCalledWith(argv.dir, ContentTypeSchema);
       expect(resolveSchemaBodyMock).toHaveBeenCalledWith({}, 'my-dir');
       expect(filterContentTypeSchemasBySchemaIdSpy).toHaveBeenCalledWith(contentTypeSchemasToExport, []);
@@ -723,7 +723,19 @@ describe('content-type-schema export command', (): void => {
       await handler(argv);
 
       expect(mockGetHub).toHaveBeenCalledWith('hub-id');
-      expect(mockList).toHaveBeenCalled();
+      expect(mockList).toHaveBeenCalledWith({ size: 100, status: 'ACTIVE' });
+      expect(loadJsonFromDirectory).toHaveBeenCalledWith(argv.dir, ContentTypeSchema);
+      expect(resolveSchemaBodyMock).toHaveBeenCalledWith({}, 'my-dir');
+      expect(filterContentTypeSchemasBySchemaIdSpy).toHaveBeenCalledWith(contentTypeSchemasToExport, []);
+      expect(processContentTypeSchemasSpy).toHaveBeenCalledWith(argv.dir, {}, contentTypeSchemasToExport);
+    });
+
+    it('should export even archived content type schemas when --archived is provided', async (): Promise<void> => {
+      const argv = { ...yargArgs, ...config, dir: 'my-dir', schemaId: undefined, archived: true };
+      await handler(argv);
+
+      expect(mockGetHub).toHaveBeenCalledWith('hub-id');
+      expect(mockList).toHaveBeenCalledWith({ size: 100 });
       expect(loadJsonFromDirectory).toHaveBeenCalledWith(argv.dir, ContentTypeSchema);
       expect(resolveSchemaBodyMock).toHaveBeenCalledWith({}, 'my-dir');
       expect(filterContentTypeSchemasBySchemaIdSpy).toHaveBeenCalledWith(contentTypeSchemasToExport, []);

--- a/src/commands/content-type-schema/export.ts
+++ b/src/commands/content-type-schema/export.ts
@@ -120,13 +120,18 @@ export const getExportRecordForContentTypeSchema = (
     c => c.schemaId === contentTypeSchema.schemaId
   );
   if (indexOfExportedContentTypeSchema < 0) {
+    const filename = uniqueFilename(
+      outputDir,
+      contentTypeSchema.schemaId,
+      'json',
+      Object.keys(previouslyExportedContentTypeSchemas)
+    );
+
+    // This filename is now used.
+    previouslyExportedContentTypeSchemas[filename] = contentTypeSchema;
+
     return {
-      filename: uniqueFilename(
-        outputDir,
-        contentTypeSchema.schemaId,
-        'json',
-        Object.keys(previouslyExportedContentTypeSchemas)
-      ),
+      filename: filename,
       status: 'CREATED',
       contentTypeSchema
     };

--- a/src/commands/content-type-schema/export.ts
+++ b/src/commands/content-type-schema/export.ts
@@ -19,6 +19,7 @@ import { ExportBuilderOptions } from '../../interfaces/export-builder-options.in
 import * as path from 'path';
 import * as fs from 'fs';
 import { resolveSchemaBody } from '../../services/resolve-schema-body';
+import { ensureDirectoryExists } from '../../common/import/directory-utils';
 
 export const streamTableOptions = {
   ...baseTableConfig,
@@ -57,6 +58,11 @@ export const builder = (yargs: Argv): void => {
       describe:
         'The Schema ID of a Content Type Schema to be exported.\nIf no --schemaId option is given, all content type schemas for the hub are exported.\nA single --schemaId option may be given to export a single content type schema.\nMultiple --schemaId options may be given to export multiple content type schemas at the same time.',
       requiresArg: true
+    })
+    .option('archived', {
+      type: 'boolean',
+      describe: 'If present, archived content type schemas will also be considered.',
+      boolean: true
     });
 };
 
@@ -206,6 +212,8 @@ export const processContentTypeSchemas = async (
     nothingExportedExit();
   }
 
+  await ensureDirectoryExists(outputDir);
+
   const tableStream = (createStream(streamTableOptions) as unknown) as TableStream;
   tableStream.write([chalk.bold('File'), chalk.bold('Schema file'), chalk.bold('Schema ID'), chalk.bold('Result')]);
   for (const { filename, status, contentTypeSchema } of allExports) {
@@ -239,7 +247,10 @@ export const handler = async (argv: Arguments<ExportBuilderOptions & Configurati
   );
   const client = dynamicContentClientFactory(argv);
   const hub = await client.hubs.get(argv.hubId);
-  const storedContentTypeSchemas = await paginator(hub.related.contentTypeSchema.list);
+  const storedContentTypeSchemas = await paginator(
+    hub.related.contentTypeSchema.list,
+    argv.archived ? undefined : { status: 'ACTIVE' }
+  );
   const schemaIdArray: string[] = schemaId ? (Array.isArray(schemaId) ? schemaId : [schemaId]) : [];
   const filteredContentTypeSchemas = filterContentTypeSchemasBySchemaId(storedContentTypeSchemas, schemaIdArray);
   await processContentTypeSchemas(dir, contentTypeSchemas, filteredContentTypeSchemas);

--- a/src/commands/content-type/export.spec.ts
+++ b/src/commands/content-type/export.spec.ts
@@ -1,4 +1,5 @@
 import * as exportModule from './export';
+import * as directoryUtils from '../../common/import/directory-utils';
 import {
   builder,
   command,
@@ -21,6 +22,7 @@ import { loadJsonFromDirectory } from '../../services/import.service';
 jest.mock('../../services/dynamic-content-client-factory');
 jest.mock('./import');
 jest.mock('../../services/import.service');
+jest.mock('../../common/import/directory-utils');
 jest.mock('table');
 
 describe('content-type export command', (): void => {
@@ -304,6 +306,7 @@ describe('content-type export command', (): void => {
   });
 
   describe('processContentTypes', () => {
+    let mockEnsureDirectory: jest.Mock;
     let mockStreamWrite: jest.Mock;
     let stdoutSpy: jest.SpyInstance;
 
@@ -341,6 +344,7 @@ describe('content-type export command', (): void => {
     ];
 
     beforeEach(() => {
+      mockEnsureDirectory = directoryUtils.ensureDirectoryExists as jest.Mock;
       mockStreamWrite = jest.fn();
       (createStream as jest.Mock).mockReturnValue({
         write: mockStreamWrite
@@ -348,6 +352,10 @@ describe('content-type export command', (): void => {
       jest.spyOn(exportServiceModule, 'writeJsonToFile').mockImplementation();
       stdoutSpy = jest.spyOn(process.stdout, 'write');
       stdoutSpy.mockImplementation();
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
     });
 
     it('should output export files for the given content types if nothing previously exported', async () => {
@@ -381,6 +389,8 @@ describe('content-type export command', (): void => {
         previouslyExportedContentTypes,
         contentTypesToProcess
       );
+
+      expect(mockEnsureDirectory).toHaveBeenCalledTimes(1);
 
       expect(exportServiceModule.writeJsonToFile).toHaveBeenCalledTimes(3);
       expect(exportServiceModule.writeJsonToFile).toHaveBeenNthCalledWith(
@@ -436,6 +446,7 @@ describe('content-type export command', (): void => {
         exitError
       );
 
+      expect(mockEnsureDirectory).toHaveBeenCalledTimes(0);
       expect(exportModule.getContentTypeExports).toHaveBeenCalledTimes(0);
       expect(stdoutSpy.mock.calls).toMatchSnapshot();
       expect(exportServiceModule.writeJsonToFile).toHaveBeenCalledTimes(0);
@@ -476,6 +487,7 @@ describe('content-type export command', (): void => {
         contentTypesToProcess
       );
 
+      expect(mockEnsureDirectory).toHaveBeenCalledTimes(1);
       expect(exportServiceModule.writeJsonToFile).toHaveBeenCalledTimes(0);
 
       expect(mockStreamWrite).toHaveBeenCalledTimes(4);
@@ -550,6 +562,7 @@ describe('content-type export command', (): void => {
         mutatedContentTypes
       );
 
+      expect(mockEnsureDirectory).toHaveBeenCalledTimes(1);
       expect(exportServiceModule.writeJsonToFile).toHaveBeenCalledTimes(1);
 
       expect(mockStreamWrite).toHaveBeenCalledTimes(4);
@@ -629,6 +642,7 @@ describe('content-type export command', (): void => {
         mutatedContentTypes
       );
 
+      expect(mockEnsureDirectory).toHaveBeenCalledTimes(0);
       expect(exportServiceModule.writeJsonToFile).toHaveBeenCalledTimes(0);
       expect(mockStreamWrite).toHaveBeenCalledTimes(0);
       expect(process.exit).toHaveBeenCalled();

--- a/src/commands/content-type/export.spec.ts
+++ b/src/commands/content-type/export.spec.ts
@@ -180,13 +180,15 @@ describe('content-type export command', (): void => {
 
       jest.spyOn(exportServiceModule, 'uniqueFilename').mockReturnValueOnce('export-dir/export-filename-3.json');
 
+      const existingTypes = Object.keys(exportedContentTypes);
+
       const result = getExportRecordForContentType(newContentTypeToExport, 'export-dir', exportedContentTypes);
 
       expect(exportServiceModule.uniqueFilename).toHaveBeenCalledWith(
         'export-dir',
         newContentTypeToExport.contentTypeUri,
         'json',
-        Object.keys(exportedContentTypes)
+        existingTypes
       );
       expect(result).toEqual({
         filename: 'export-dir/export-filename-3.json',

--- a/src/commands/content-type/export.ts
+++ b/src/commands/content-type/export.ts
@@ -75,13 +75,18 @@ export const getExportRecordForContentType = (
     c => c.contentTypeUri === contentType.contentTypeUri
   );
   if (indexOfExportedContentType < 0) {
+    const filename = uniqueFilename(
+      outputDir,
+      contentType.contentTypeUri,
+      'json',
+      Object.keys(previouslyExportedContentTypes)
+    );
+
+    // This filename is now used.
+    previouslyExportedContentTypes[filename] = contentType;
+
     return {
-      filename: uniqueFilename(
-        outputDir,
-        contentType.contentTypeUri,
-        'json',
-        Object.keys(previouslyExportedContentTypes)
-      ),
+      filename: filename,
       status: 'CREATED',
       contentType
     };

--- a/src/commands/content-type/export.ts
+++ b/src/commands/content-type/export.ts
@@ -166,6 +166,7 @@ export const processContentTypes = async (
 
 export const handler = async (argv: Arguments<ExportBuilderOptions & ConfigurationParameters>): Promise<void> => {
   const { dir, schemaId } = argv;
+
   const previouslyExportedContentTypes = loadJsonFromDirectory<ContentType>(dir, ContentType);
   validateNoDuplicateContentTypeUris(previouslyExportedContentTypes);
 

--- a/src/commands/content-type/import.ts
+++ b/src/commands/content-type/import.ts
@@ -258,7 +258,11 @@ export const handler = async (
 
   const client = dynamicContentClientFactory(argv);
   const hub = await client.hubs.get(argv.hubId);
-  const storedContentTypes = await paginator(hub.related.contentTypes.list);
+
+  const activeContentTypes = await paginator(hub.related.contentTypes.list, { status: 'ACTIVE' });
+  const archivedContentTypes = await paginator(hub.related.contentTypes.list, { status: 'ARCHIVED' });
+  const storedContentTypes = [...activeContentTypes, ...archivedContentTypes];
+
   for (const [filename, importedContentType] of Object.entries(importedContentTypes)) {
     importedContentTypes[filename] = storedContentTypeMapper(importedContentType, storedContentTypes);
   }

--- a/src/common/content-item/content-dependancy-tree.ts
+++ b/src/common/content-item/content-dependancy-tree.ts
@@ -175,7 +175,8 @@ export class ContentDependancyTree {
             },
             id: item.content.body._meta.hierarchy.parentId,
             contentType: ''
-          }, owner: item
+          },
+          owner: item
         });
       }
 

--- a/src/common/content-item/content-dependancy-tree.ts
+++ b/src/common/content-item/content-dependancy-tree.ts
@@ -4,7 +4,8 @@ import { Body } from './body';
 
 type DependancyContentTypeSchema =
   | 'http://bigcontent.io/cms/schema/v1/core#/definitions/content-link'
-  | 'http://bigcontent.io/cms/schema/v1/core#/definitions/content-reference';
+  | 'http://bigcontent.io/cms/schema/v1/core#/definitions/content-reference'
+  | '_hierarchy'; // Used internally for parent dependancies.
 
 export interface RepositoryContentItem {
   repo: ContentRepository;
@@ -164,6 +165,20 @@ export class ContentDependancyTree {
     return items.map(item => {
       const result: ContentDependancyInfo[] = [];
       this.searchObjectForContentDependancies(item, item.content.body, result);
+
+      // Hierarchy parent is also a dependancy.
+      if (item.content.body._meta.hierarchy && item.content.body._meta.hierarchy.parentId) {
+        result.push({
+          dependancy: {
+            _meta: {
+              schema: '_hierarchy'
+            },
+            id: item.content.body._meta.hierarchy.parentId,
+            contentType: ''
+          }, owner: item
+        });
+      }
+
       return { owner: item, dependancies: result, dependants: [] };
     });
   }

--- a/src/interfaces/export-builder-options.interface.ts
+++ b/src/interfaces/export-builder-options.interface.ts
@@ -1,4 +1,5 @@
 export interface ExportBuilderOptions {
   dir: string;
   schemaId?: string[];
+  archived?: boolean;
 }

--- a/src/services/export.service.ts
+++ b/src/services/export.service.ts
@@ -21,7 +21,7 @@ export const uniqueFilenamePath = (dir: string, file = '', extension: string, ex
       uniqueFilename = dir + path.sep + file + '-' + counter + '.' + extension;
     }
     counter++;
-  } while (exportFilenames.includes(uniqueFilename));
+  } while (exportFilenames.find(filename => uniqueFilename.toLowerCase() === filename.toLowerCase()));
   return uniqueFilename;
 };
 

--- a/src/services/import.service.ts
+++ b/src/services/import.service.ts
@@ -13,6 +13,10 @@ export const loadJsonFromDirectory = <T extends HalResource>(
   dir: string,
   resourceType: HalResourceConstructor<T>
 ): { [p: string]: T } => {
+  if (!fs.existsSync(dir)) {
+    return {};
+  }
+
   const files = fs
     .readdirSync(dir)
     .map(file => path.resolve(dir, file))


### PR DESCRIPTION
This PR changes the functionality of existing `content-type` and `content-type-schema` export commands:

- The `export` command now generates the destination folder if it did not already exist.
  - This better matches the behaviour of the content-item export commands.
  - The tests have been updated to reflect this.
- When listing content type schema for export, explicitly list only those with "ACTIVE" status, not archived.
  - If a user wants to include archived content type schema, they can pass in the `--archived` option, which will restore the old behaviour
  - `content-type` commands do not have this treatment, as they only fetch active content-types on list. This mismatch is a problem with the API, where the behaviour where no status filter is given seems to be different between schemas and types. The request has been updated anyways with { status: 'ACTIVE' } to avoid unexpected behavioural change in future.

This fixes an issue where users trying to export and import content-type-schemas with back to back commands saw their archived content type schemas resurrecting in the target repo.