### PR TITLE
fix(export): content type schemas and content types special characters

### DIFF
--- a/src/commands/content-type-schema/export.ts
+++ b/src/commands/content-type-schema/export.ts
@@ -247,7 +247,8 @@ export const processContentTypeSchemas = async (
       delete contentTypeSchema.id; // do not export id
       const schemaBody = contentTypeSchema.body;
       const schemaBodyFilename = generateSchemaPath(filename);
-      contentTypeSchema.body = '.' + path.sep + schemaBodyFilename;
+      const posixFilename = schemaBodyFilename.split(path.sep).join(path.posix.sep);
+      contentTypeSchema.body = '.' + path.posix.sep + posixFilename;
       schemaFilename = outputDir + path.sep + schemaBodyFilename;
       writeSchemaBody(schemaFilename, schemaBody);
       writeJsonToFile(

--- a/src/commands/content-type/__snapshots__/export.spec.ts.snap
+++ b/src/commands/content-type/__snapshots__/export.spec.ts.snap
@@ -10,6 +10,7 @@ Array [
   Array [
     Object {
       "contentTypeUri": "content-type-uri-1",
+      "repositories": Array [],
       "settings": Object {
         "label": "content type 1",
       },
@@ -18,12 +19,14 @@ Array [
     Object {
       "export-dir/export-filename-1.json": Object {
         "contentTypeUri": "content-type-uri-1",
+        "repositories": Array [],
         "settings": Object {
           "label": "content type 1",
         },
       },
       "export-dir/export-filename-2.json": Object {
         "contentTypeUri": "content-type-uri-2",
+        "repositories": Array [],
         "settings": Object {
           "label": "content type 2",
         },
@@ -33,6 +36,7 @@ Array [
   Array [
     Object {
       "contentTypeUri": "content-type-uri-2",
+      "repositories": Array [],
       "settings": Object {
         "label": "content type 2",
       },
@@ -41,12 +45,14 @@ Array [
     Object {
       "export-dir/export-filename-1.json": Object {
         "contentTypeUri": "content-type-uri-1",
+        "repositories": Array [],
         "settings": Object {
           "label": "content type 1",
         },
       },
       "export-dir/export-filename-2.json": Object {
         "contentTypeUri": "content-type-uri-2",
+        "repositories": Array [],
         "settings": Object {
           "label": "content type 2",
         },
@@ -61,6 +67,7 @@ Array [
   Object {
     "contentType": Object {
       "contentTypeUri": "content-type-uri-1",
+      "repositories": Array [],
       "settings": Object {
         "label": "content type 1",
       },
@@ -71,6 +78,7 @@ Array [
   Object {
     "contentType": Object {
       "contentTypeUri": "content-type-uri-2",
+      "repositories": Array [],
       "settings": Object {
         "label": "content type 2",
       },
@@ -95,6 +103,7 @@ Array [
   Array [
     Object {
       "contentTypeUri": "content-type-uri-1",
+      "repositories": Array [],
       "settings": Object {
         "label": "content type 1",
       },
@@ -105,6 +114,7 @@ Array [
   Array [
     Object {
       "contentTypeUri": "content-type-uri-2",
+      "repositories": Array [],
       "settings": Object {
         "label": "content type 2",
       },
@@ -120,6 +130,7 @@ Array [
   Object {
     "contentType": Object {
       "contentTypeUri": "content-type-uri-1",
+      "repositories": Array [],
       "settings": Object {
         "label": "content type 1",
       },
@@ -130,6 +141,7 @@ Array [
   Object {
     "contentType": Object {
       "contentTypeUri": "content-type-uri-2",
+      "repositories": Array [],
       "settings": Object {
         "label": "content type 2",
       },

--- a/src/commands/content-type/__snapshots__/export.spec.ts.snap
+++ b/src/commands/content-type/__snapshots__/export.spec.ts.snap
@@ -103,7 +103,17 @@ Array [
     },
     "export-dir",
     Object {},
-    undefined,
+    Array [
+      Object {
+        "contentTypes": Array [
+          Object {
+            "contentTypeUri": "content-type-uri-1",
+            "hubContentTypeId": "1",
+          },
+        ],
+        "name": "repo1",
+      },
+    ],
   ],
   Array [
     Object {
@@ -114,7 +124,17 @@ Array [
     },
     "export-dir",
     Object {},
-    undefined,
+    Array [
+      Object {
+        "contentTypes": Array [
+          Object {
+            "contentTypeUri": "content-type-uri-1",
+            "hubContentTypeId": "1",
+          },
+        ],
+        "name": "repo1",
+      },
+    ],
   ],
 ]
 `;
@@ -124,6 +144,10 @@ Array [
   Object {
     "contentType": Object {
       "contentTypeUri": "content-type-uri-1",
+      "id": "1",
+      "repositories": Array [
+        "repo1",
+      ],
       "settings": Object {
         "label": "content type 1",
       },
@@ -141,6 +165,12 @@ Array [
     "filename": "export-dir/export-filename-2.json",
     "status": "CREATED",
   },
+]
+`;
+
+exports[`content-type export command getReposNamesForContentType should return names of repos to which content type is assigned 1`] = `
+Array [
+  "repo2",
 ]
 `;
 

--- a/src/commands/content-type/__snapshots__/export.spec.ts.snap
+++ b/src/commands/content-type/__snapshots__/export.spec.ts.snap
@@ -10,7 +10,6 @@ Array [
   Array [
     Object {
       "contentTypeUri": "content-type-uri-1",
-      "repositories": Array [],
       "settings": Object {
         "label": "content type 1",
       },
@@ -19,24 +18,22 @@ Array [
     Object {
       "export-dir/export-filename-1.json": Object {
         "contentTypeUri": "content-type-uri-1",
-        "repositories": Array [],
         "settings": Object {
           "label": "content type 1",
         },
       },
       "export-dir/export-filename-2.json": Object {
         "contentTypeUri": "content-type-uri-2",
-        "repositories": Array [],
         "settings": Object {
           "label": "content type 2",
         },
       },
     },
+    undefined,
   ],
   Array [
     Object {
       "contentTypeUri": "content-type-uri-2",
-      "repositories": Array [],
       "settings": Object {
         "label": "content type 2",
       },
@@ -45,19 +42,18 @@ Array [
     Object {
       "export-dir/export-filename-1.json": Object {
         "contentTypeUri": "content-type-uri-1",
-        "repositories": Array [],
         "settings": Object {
           "label": "content type 1",
         },
       },
       "export-dir/export-filename-2.json": Object {
         "contentTypeUri": "content-type-uri-2",
-        "repositories": Array [],
         "settings": Object {
           "label": "content type 2",
         },
       },
     },
+    undefined,
   ],
 ]
 `;
@@ -67,7 +63,6 @@ Array [
   Object {
     "contentType": Object {
       "contentTypeUri": "content-type-uri-1",
-      "repositories": Array [],
       "settings": Object {
         "label": "content type 1",
       },
@@ -78,7 +73,6 @@ Array [
   Object {
     "contentType": Object {
       "contentTypeUri": "content-type-uri-2",
-      "repositories": Array [],
       "settings": Object {
         "label": "content type 2",
       },
@@ -103,24 +97,24 @@ Array [
   Array [
     Object {
       "contentTypeUri": "content-type-uri-1",
-      "repositories": Array [],
       "settings": Object {
         "label": "content type 1",
       },
     },
     "export-dir",
     Object {},
+    undefined,
   ],
   Array [
     Object {
       "contentTypeUri": "content-type-uri-2",
-      "repositories": Array [],
       "settings": Object {
         "label": "content type 2",
       },
     },
     "export-dir",
     Object {},
+    undefined,
   ],
 ]
 `;
@@ -130,7 +124,6 @@ Array [
   Object {
     "contentType": Object {
       "contentTypeUri": "content-type-uri-1",
-      "repositories": Array [],
       "settings": Object {
         "label": "content type 1",
       },
@@ -141,7 +134,6 @@ Array [
   Object {
     "contentType": Object {
       "contentTypeUri": "content-type-uri-2",
-      "repositories": Array [],
       "settings": Object {
         "label": "content type 2",
       },

--- a/src/commands/content-type/__snapshots__/import.spec.ts.snap
+++ b/src/commands/content-type/__snapshots__/import.spec.ts.snap
@@ -14,8 +14,6 @@ exports[`content-type import command doUpdate should throw an error when unable 
 
 exports[`content-type import command handler tests should throw an error when no content found in import directory 1`] = `"No content types found in my-empty-dir"`;
 
-exports[`content-type import command synchronizeContentTypeRepositories should throw an error if content type has an unknown repository 1`] = `"Unable to find a Content Repository named: not-found"`;
-
 exports[`content-type import command validateNoDuplicateContentTypeUris should throw and error when there are duplicate uris 1`] = `
 "Content Types must have unique uri values. Duplicate values found:-
   uri: 'type-uri-1' in files: ['file-1', 'file-4']

--- a/src/commands/content-type/export.spec.ts
+++ b/src/commands/content-type/export.spec.ts
@@ -8,7 +8,8 @@ import {
   getExportRecordForContentType,
   handler,
   LOG_FILENAME,
-  processContentTypes
+  processContentTypes,
+  getReposNamesForContentType
 } from './export';
 import Yargs from 'yargs/yargs';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
@@ -324,6 +325,68 @@ describe('content-type export command', (): void => {
       expect(() =>
         filterContentTypesByUri(listToFilter, ['content-type-uri-1', 'content-type-uri-4', 'content-type-uri-3'])
       ).toThrowErrorMatchingSnapshot();
+    });
+  });
+
+  describe('getReposNamesForContentType', () => {
+    const repositoriesList = [
+      new ContentRepository({
+        name: 'repo1',
+        contentTypes: []
+      }),
+      new ContentRepository({
+        name: 'repo2',
+        contentTypes: [
+          {
+            hubContentTypeId: '1',
+            contentTypeUri: 'content-type-uri-1'
+          },
+          {
+            hubContentTypeId: '2',
+            contentTypeUri: 'content-type-uri-1'
+          }
+        ]
+      }),
+      new ContentRepository({
+        contentTypes: [
+          {
+            hubContentTypeId: '1',
+            contentTypeUri: 'content-type-uri-1'
+          },
+          {
+            hubContentTypeId: '2',
+            contentTypeUri: 'content-type-uri-1'
+          }
+        ]
+      })
+    ];
+
+    it('should return names of repos to which content type is assigned', async () => {
+      const result = getReposNamesForContentType(
+        repositoriesList,
+        new ContentType({
+          contentTypeUri: 'content-type-uri-1',
+          id: '1',
+          settings: {
+            label: 'content type 1'
+          }
+        })
+      );
+      expect(result).toEqual(expect.arrayContaining(['repo2']));
+    });
+
+    it('should return empty array', async () => {
+      const result = getReposNamesForContentType(
+        repositoriesList,
+        new ContentType({
+          contentTypeUri: 'content-type-uri-3',
+          id: '3',
+          settings: {
+            label: 'content type 3'
+          }
+        })
+      );
+      expect(result).toEqual([]);
     });
   });
 

--- a/src/commands/content-type/export.spec.ts
+++ b/src/commands/content-type/export.spec.ts
@@ -103,6 +103,13 @@ describe('content-type export command', (): void => {
       'export-dir/export-filename-2.json': contentTypesToExport[1]
     };
 
+    const exportedContentTypeWithRepos = {
+      id: '1',
+      contentTypeUri: 'content-type-uri-1',
+      repositories: ['repo1'],
+      settings: { label: 'content type 1' }
+    };
+
     beforeEach(() => {
       getExportRecordForContentTypeSpy = jest.spyOn(exportModule, 'getExportRecordForContentType');
     });
@@ -112,7 +119,7 @@ describe('content-type export command', (): void => {
         .mockReturnValueOnce({
           filename: 'export-dir/export-filename-1.json',
           status: 'CREATED',
-          contentType: contentTypesToExport[0]
+          contentType: exportedContentTypeWithRepos
         })
         .mockReturnValueOnce({
           filename: 'export-dir/export-filename-2.json',
@@ -120,7 +127,17 @@ describe('content-type export command', (): void => {
           contentType: contentTypesToExport[1]
         });
 
-      const [allExports, updatedExportsMap] = getContentTypeExports('export-dir', {}, contentTypesToExport);
+      const [allExports, updatedExportsMap] = getContentTypeExports('export-dir', {}, contentTypesToExport, [
+        new ContentRepository({
+          name: 'repo1',
+          contentTypes: [
+            {
+              hubContentTypeId: '1',
+              contentTypeUri: 'content-type-uri-1'
+            }
+          ]
+        })
+      ]);
 
       expect(getExportRecordForContentTypeSpy).toHaveBeenCalledTimes(2);
       expect(getExportRecordForContentTypeSpy.mock.calls).toMatchSnapshot();
@@ -373,6 +390,7 @@ describe('content-type export command', (): void => {
         })
       );
       expect(result).toEqual(expect.arrayContaining(['repo2']));
+      expect(result).toMatchSnapshot();
     });
 
     it('should return empty array', async () => {

--- a/src/commands/content-type/export.ts
+++ b/src/commands/content-type/export.ts
@@ -133,7 +133,7 @@ type ExportsMap = {
   filename: string;
 };
 
-const getReposNamesForContentType = (
+export const getReposNamesForContentType = (
   repositories: ContentRepository[] = [],
   contentType: ContentType
 ): string[] | [] => {

--- a/src/commands/content-type/export.ts
+++ b/src/commands/content-type/export.ts
@@ -62,14 +62,14 @@ export const builder = (yargs: Argv): void => {
 const equals = (a: ContentType, b: ContentType): boolean =>
   a.contentTypeUri === b.contentTypeUri && isEqual(a.settings, b.settings);
 
-interface ContentTypeExtended extends ContentType {
+interface ContentTypeWithRepositories extends ContentType {
   repositories?: string[];
 }
 
 interface ExportRecord {
   readonly filename: string;
   readonly status: ExportResult;
-  readonly contentType: ContentTypeExtended;
+  readonly contentType: ContentTypeWithRepositories;
 }
 
 export const filterContentTypesByUri = (listToFilter: ContentType[], contentTypeUriList: string[]): ContentType[] => {
@@ -109,7 +109,7 @@ export const getReposNamesForContentType = (
 };
 
 export const getExportRecordForContentType = (
-  contentType: ContentTypeExtended,
+  contentType: ContentTypeWithRepositories,
   outputDir: string,
   previouslyExportedContentTypes: { [filename: string]: ContentType },
   repositories?: ContentRepository[]

--- a/src/commands/content-type/export.ts
+++ b/src/commands/content-type/export.ts
@@ -15,7 +15,7 @@ import {
 } from '../../services/export.service';
 import { loadJsonFromDirectory } from '../../services/import.service';
 import { validateNoDuplicateContentTypeUris } from './import';
-import { isEqual } from 'lodash';
+import { isEqual, compact } from 'lodash';
 import { ExportBuilderOptions } from '../../interfaces/export-builder-options.interface';
 import { ensureDirectoryExists } from '../../common/import/directory-utils';
 import { FileLog } from '../../common/file-log';
@@ -95,15 +95,17 @@ export const getReposNamesForContentType = (
   repositories: ContentRepository[] = [],
   contentType: ContentType
 ): string[] => {
-  return repositories
-    .filter(
-      repo =>
-        repo.contentTypes &&
-        repo.contentTypes.find(
-          el => el.hubContentTypeId === contentType.id && el.contentTypeUri === contentType.contentTypeUri
-        )
-    )
-    .map(repo => repo.name || '');
+  return compact(
+    repositories
+      .filter(
+        repo =>
+          repo.contentTypes &&
+          repo.contentTypes.find(
+            el => el.hubContentTypeId === contentType.id && el.contentTypeUri === contentType.contentTypeUri
+          )
+      )
+      .map(repo => repo.name || '')
+  );
 };
 
 export const getExportRecordForContentType = (

--- a/src/commands/content-type/import.spec.ts
+++ b/src/commands/content-type/import.spec.ts
@@ -656,7 +656,7 @@ describe('content-type import command', (): void => {
       expect(contentRepository.related.contentTypes.assign).toHaveBeenCalledWith(contentType.id);
     });
 
-    it('should throw an error if content type has an unknown repository', async () => {
+    it('should log a list of unknown repositories if content type has an unknown repository', async () => {
       const contentType = new ContentTypeWithRepositoryAssignments({
         id: 'id',
         contentTypeUri: 'http://example.com/content-type.json',
@@ -669,9 +669,15 @@ describe('content-type import command', (): void => {
         contentTypes: []
       });
 
-      await expect(
-        synchronizeContentTypeRepositories(contentType, createContentRepositoriesMap([contentRepository]))
-      ).rejects.toThrowErrorMatchingSnapshot();
+      contentRepository.related.contentTypes.assign = jest.fn().mockResolvedValue(contentRepository);
+
+      const result = await synchronizeContentTypeRepositories(
+        contentType,
+        createContentRepositoriesMap([contentRepository])
+      );
+
+      expect(result).toEqual(false);
+      expect(contentRepository.related.contentTypes.assign).not.toHaveBeenCalled();
     });
 
     it('should not assign content type to a repository if its already assigned', async () => {

--- a/src/commands/content-type/import.spec.ts
+++ b/src/commands/content-type/import.spec.ts
@@ -71,7 +71,7 @@ describe('content-type import command', (): void => {
       });
 
       expect(spyOption).toHaveBeenCalledWith('skipAssign', {
-        describe: 'Skip assignment content types to the repositories',
+        describe: 'Skip assigning content types to repositories.',
         type: 'boolean',
         default: false
       });

--- a/src/commands/content-type/import.spec.ts
+++ b/src/commands/content-type/import.spec.ts
@@ -69,6 +69,12 @@ describe('content-type import command', (): void => {
         describe: 'Path to a log file to write to.',
         coerce: createLog
       });
+
+      expect(spyOption).toHaveBeenCalledWith('skipAssign', {
+        describe: 'Skip assignment content types to the repositories',
+        type: 'boolean',
+        default: false
+      });
     });
   });
 
@@ -871,7 +877,8 @@ describe('content-type import command', (): void => {
         expect.any(Object),
         expect.any(Object),
         false,
-        expect.any(Object)
+        expect.any(FileLog),
+        undefined
       );
     });
 
@@ -909,7 +916,8 @@ describe('content-type import command', (): void => {
         expect.any(Object),
         expect.any(Object),
         true,
-        expect.any(Object)
+        expect.any(FileLog),
+        undefined
       );
     });
 

--- a/src/commands/content-type/import.ts
+++ b/src/commands/content-type/import.ts
@@ -46,7 +46,7 @@ export const builder = (yargs: Argv): void => {
   });
 
   yargs.option('skipAssign', {
-    describe: 'Skip assignment content types to the repositories',
+    describe: 'Skip assigning content types to repositories.',
     type: 'boolean',
     default: false
   });
@@ -303,9 +303,9 @@ export const processContentTypes = async (
   log.appendLine(table(data, streamTableOptions));
 
   if (!skipAssign && notFoundRepositories.length) {
-    log.appendLine('\nFollowing Repositories were not found in destination Hub:');
+    log.appendLine('\nThe following Repositories were not found in destination Hub:');
 
-    uniq(notFoundRepositories).map(name => log.appendLine(name));
+    uniq(notFoundRepositories).map(name => log.appendLine(`  ${name}`));
   } else if (skipAssign) {
     log.appendLine(
       '\nContent types were not automatically registered to the repositories because of --skipAssign argument.'

--- a/src/commands/content-type/import.ts
+++ b/src/commands/content-type/import.ts
@@ -306,6 +306,10 @@ export const processContentTypes = async (
     log.appendLine('\nFollowing Repositories were not found in destination Hub:');
 
     uniq(notFoundRepositories).map(name => log.appendLine(name));
+  } else if (skipAssign) {
+    log.appendLine(
+      '\nContent types were not automatically registered to the repositories because of --skipAssign argument.'
+    );
   }
 
   log.appendLine();

--- a/src/services/export.service.ts
+++ b/src/services/export.service.ts
@@ -16,9 +16,9 @@ export const uniqueFilenamePath = (dir: string, file = '', extension: string, ex
   let uniqueFilename = '';
   do {
     if (counter == 0) {
-      uniqueFilename = dir + path.sep + file + '.' + extension;
+      uniqueFilename = dir + path.sep + encodeURIComponent(file) + '.' + extension;
     } else {
-      uniqueFilename = dir + path.sep + file + '-' + counter + '.' + extension;
+      uniqueFilename = dir + path.sep + encodeURIComponent(file) + '-' + counter + '.' + extension;
     }
     counter++;
   } while (exportFilenames.find(filename => uniqueFilename.toLowerCase() === filename.toLowerCase()));

--- a/src/services/export.service.ts
+++ b/src/services/export.service.ts
@@ -4,6 +4,7 @@ import { URL } from 'url';
 import DataPresenter from '../view/data-presenter';
 import { asyncQuestion } from '../common/question-helpers';
 import { FileLog } from '../common/file-log';
+import sanitize from 'sanitize-filename';
 
 export type ExportResult = 'CREATED' | 'UPDATED' | 'UP-TO-DATE';
 
@@ -12,13 +13,15 @@ export const uniqueFilenamePath = (dir: string, file = '', extension: string, ex
     dir = dir.slice(0, -1);
   }
 
+  file = sanitize(file, { replacement: '_' });
+
   let counter = 0;
   let uniqueFilename = '';
   do {
     if (counter == 0) {
-      uniqueFilename = dir + path.sep + encodeURIComponent(file) + '.' + extension;
+      uniqueFilename = dir + path.sep + file + '.' + extension;
     } else {
-      uniqueFilename = dir + path.sep + encodeURIComponent(file) + '-' + counter + '.' + extension;
+      uniqueFilename = dir + path.sep + file + '-' + counter + '.' + extension;
     }
     counter++;
   } while (exportFilenames.find(filename => uniqueFilename.toLowerCase() === filename.toLowerCase()));

--- a/src/services/import.service.ts
+++ b/src/services/import.service.ts
@@ -24,7 +24,7 @@ export const loadJsonFromDirectory = <T extends HalResource>(
   const loadedFiles: { [filename: string]: T } = {};
   files.forEach(filename => {
     try {
-      loadedFiles[filename] = new resourceType(JSON.parse(fs.readFileSync(filename, 'utf-8')));
+      loadedFiles[decodeURIComponent(filename)] = new resourceType(JSON.parse(fs.readFileSync(filename, 'utf-8')));
     } catch (e) {
       throw new Error(`Non-JSON file found: ${filename}, aborting...`);
     }

--- a/src/services/import.service.ts
+++ b/src/services/import.service.ts
@@ -24,7 +24,7 @@ export const loadJsonFromDirectory = <T extends HalResource>(
   const loadedFiles: { [filename: string]: T } = {};
   files.forEach(filename => {
     try {
-      loadedFiles[decodeURIComponent(filename)] = new resourceType(JSON.parse(fs.readFileSync(filename, 'utf-8')));
+      loadedFiles[filename] = new resourceType(JSON.parse(fs.readFileSync(filename, 'utf-8')));
     } catch (e) {
       throw new Error(`Non-JSON file found: ${filename}, aborting...`);
     }


### PR DESCRIPTION
This PR contains:

- fix of export content type schemas in case when schema urls contain special characters as **:**, **!**, **?** etc. 
Special characters (especially **:** ) caused an issue on creating files on export schemas command on windows. 

- added list or repositories to a content type export command to use this list on import command to assign content types to repositories 