### PR TITLE
feat(log): log errors in a more consistent fashion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1275,8 +1275,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -1346,7 +1345,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1753,8 +1751,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "2.0.0",
@@ -3517,8 +3514,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.2.9",
@@ -4580,7 +4576,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
       "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -4940,7 +4935,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4949,8 +4943,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.5",
@@ -6327,7 +6320,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -6643,7 +6635,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -6806,8 +6797,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "2.0.1",
@@ -7409,7 +7399,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
       "integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
-      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -8719,8 +8708,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",

--- a/src/commands/content-item/archive.ts
+++ b/src/commands/content-item/archive.ts
@@ -1,7 +1,7 @@
 import { Arguments, Argv } from 'yargs';
 import { ConfigurationParameters } from '../configure';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
-import { ArchiveLog } from '../../common/archive/archive-log';
+import { LogErrorLevel, ArchiveLog } from '../../common/archive/archive-log';
 import paginator from '../../common/dc-management-sdk-js/paginator';
 import { confirmArchive } from '../../common/archive/archive-helpers';
 import ArchiveOptions from '../../common/archive/archive-options';
@@ -265,12 +265,16 @@ export const processItems = async ({
       log.addComment(e.toString());
 
       if (ignoreError) {
-        console.log(
-          `Failed to archive ${contentItems[i].label} (${contentItems[i].id}), continuing. Error: \n${e.toString()}`
+        log.addError(
+          LogErrorLevel.WARNING,
+          `Failed to archive ${contentItems[i].label} (${contentItems[i].id}), continuing.`,
+          e
         );
       } else {
-        console.log(
-          `Failed to archive ${contentItems[i].label} (${contentItems[i].id}), aborting. Error: \n${e.toString()}`
+        log.addError(
+          LogErrorLevel.ERROR,
+          `Failed to archive ${contentItems[i].label} (${contentItems[i].id}), aborting.`,
+          e
         );
         break;
       }

--- a/src/commands/content-item/archive.ts
+++ b/src/commands/content-item/archive.ts
@@ -265,17 +265,9 @@ export const processItems = async ({
       log.addComment(e.toString());
 
       if (ignoreError) {
-        log.addError(
-          LogErrorLevel.WARNING,
-          `Failed to archive ${contentItems[i].label} (${contentItems[i].id}), continuing.`,
-          e
-        );
+        log.warn(`Failed to archive ${contentItems[i].label} (${contentItems[i].id}), continuing.`, e);
       } else {
-        log.addError(
-          LogErrorLevel.ERROR,
-          `Failed to archive ${contentItems[i].label} (${contentItems[i].id}), aborting.`,
-          e
-        );
+        log.error(`Failed to archive ${contentItems[i].label} (${contentItems[i].id}), aborting.`, e);
         break;
       }
     }

--- a/src/commands/content-item/archive.ts
+++ b/src/commands/content-item/archive.ts
@@ -1,7 +1,7 @@
 import { Arguments, Argv } from 'yargs';
 import { ConfigurationParameters } from '../configure';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
-import { LogErrorLevel, ArchiveLog } from '../../common/archive/archive-log';
+import { ArchiveLog } from '../../common/archive/archive-log';
 import paginator from '../../common/dc-management-sdk-js/paginator';
 import { confirmArchive } from '../../common/archive/archive-helpers';
 import ArchiveOptions from '../../common/archive/archive-options';

--- a/src/commands/content-item/export.ts
+++ b/src/commands/content-item/export.ts
@@ -142,11 +142,7 @@ const getContentItems = async (
       Array.prototype.push.apply(repoItems, allItems);
       newItems = allItems.filter(item => item.folderId == null);
     } catch (e) {
-      log.addError(
-        LogErrorLevel.WARNING,
-        `Coult not get items from repository ${repository.name} (${repository.id})`,
-        e
-      );
+      log.warn(`Could not get items from repository ${repository.name} (${repository.id})`, e);
       continue;
     }
 
@@ -183,7 +179,7 @@ const getContentItems = async (
           try {
             newItems = (await paginator(folder.related.contentItems.list)).filter(item => item.status === 'ACTIVE');
           } catch (e) {
-            log.addError(LogErrorLevel.WARNING, `Could not get items from folder ${folder.name} (${folder.id})`, e);
+            log.warn(`Could not get items from folder ${folder.name} (${folder.id})`, e);
             return;
           }
         }
@@ -193,7 +189,7 @@ const getContentItems = async (
           const subfolders = await paginator(folder.related.folders.list);
           Array.prototype.push.apply(nextFolders, subfolders);
         } catch (e) {
-          log.addError(LogErrorLevel.WARNING, `Could not get subfolders from folder ${folder.name} (${folder.id})`, e);
+          log.warn(`Could not get subfolders from folder ${folder.name} (${folder.id})`, e);
         }
       }
     );
@@ -327,14 +323,11 @@ export const handler = async (argv: Arguments<ExportItemBuilderOptions & Configu
     try {
       const errors = await validator.validate(item.body);
       if (errors.length > 0) {
-        log.addError(
-          LogErrorLevel.WARNING,
-          `${item.label} does not validate under the available schema. It may not import correctly.`
-        );
+        log.warn(`${item.label} does not validate under the available schema. It may not import correctly.`);
         log.appendLine(JSON.stringify(errors, null, 2));
       }
     } catch (e) {
-      log.addError(LogErrorLevel.WARNING, `Could not validate ${item.label} as there is a problem with the schema:`, e);
+      log.warn(`Could not validate ${item.label} as there is a problem with the schema:`, e);
     }
 
     let resolvedPath: string;

--- a/src/commands/content-item/export.ts
+++ b/src/commands/content-item/export.ts
@@ -193,11 +193,7 @@ const getContentItems = async (
           const subfolders = await paginator(folder.related.folders.list);
           Array.prototype.push.apply(nextFolders, subfolders);
         } catch (e) {
-          log.addError(
-            LogErrorLevel.WARNING,
-            `Could not get subfolders from folder ${folder.name} (${folder.id})`,
-            e
-          );
+          log.addError(LogErrorLevel.WARNING, `Could not get subfolders from folder ${folder.name} (${folder.id})`, e);
         }
       }
     );
@@ -338,11 +334,7 @@ export const handler = async (argv: Arguments<ExportItemBuilderOptions & Configu
         log.appendLine(JSON.stringify(errors, null, 2));
       }
     } catch (e) {
-      log.addError(
-        LogErrorLevel.WARNING,
-        `Could not validate ${item.label} as there is a problem with the schema:`,
-        e
-      );
+      log.addError(LogErrorLevel.WARNING, `Could not validate ${item.label} as there is a problem with the schema:`, e);
     }
 
     let resolvedPath: string;

--- a/src/commands/content-item/export.ts
+++ b/src/commands/content-item/export.ts
@@ -16,7 +16,6 @@ import { ContentDependancyTree, RepositoryContentItem } from '../../common/conte
 import { ContentMapping } from '../../common/content-item/content-mapping';
 import { getDefaultLogPath } from '../../common/log-helpers';
 import { AmplienceSchemaValidator, defaultSchemaLookup } from '../../common/content-item/amplience-schema-validator';
-import { LogErrorLevel } from '../../common/archive/archive-log';
 
 interface PublishedContentItem {
   lastPublishedVersion?: number;

--- a/src/commands/content-item/import-revert.spec.ts
+++ b/src/commands/content-item/import-revert.spec.ts
@@ -57,7 +57,7 @@ describe('revert tests', function() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (readline as any).setResponses([]);
 
-    await createLog('temp/revert/createOnly.txt', 'CREATE id1\nCREATE id2\nCREATE id3');
+    await createLog('temp/revert/createOnly.txt', 'CREATE id1\nCREATE id2\nCREATE id3\nSUCCESS');
 
     // Create content to import
 
@@ -90,7 +90,7 @@ describe('revert tests', function() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (readline as any).setResponses([]);
 
-    await createLog('temp/revert/createImport.txt', 'UPDATE id1 1 2\nUPDATE id2 3 4\nCREATE id3');
+    await createLog('temp/revert/createImport.txt', 'UPDATE id1 1 2\nUPDATE id2 3 4\nCREATE id3\nSUCCESS');
 
     // Create content to import
 
@@ -127,7 +127,7 @@ describe('revert tests', function() {
 
     await createLog(
       'temp/revert/createWarn.txt',
-      'UPDATE id1 1 2\nUPDATE id2 3 4\nCREATE id3\nUPDATE id4 3 4\nCREATE id5'
+      'UPDATE id1 1 2\nUPDATE id2 3 4\nCREATE id3\nUPDATE id4 3 4\nCREATE id5\nSUCCESS'
     );
 
     // Create content to import
@@ -191,7 +191,7 @@ describe('revert tests', function() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (readline as any).setResponses(['n']);
 
-    await createLog('temp/revert/revertAbort.txt', 'UPDATE id1 1 2\nUPDATE id2 3 4\nCREATE id3');
+    await createLog('temp/revert/revertAbort.txt', 'UPDATE id1 1 2\nUPDATE id2 3 4\nCREATE id3\nSUCCESS');
 
     // Create content to import
 
@@ -236,7 +236,7 @@ describe('revert tests', function() {
 
     await createLog(
       'temp/revert/revertSkip.txt',
-      '// Title\n// Comment\nUPDATE id1 1 2\nUPDATE id2 3 4\nCREATE id3\nCREATE id4\nUPDATE id5 3 4\nCREATE id6\nUPDATE id7 23 24\nUPDATE id8 1 1\nUPDATE id9 0 1 invalid'
+      '// Title\n// Comment\nUPDATE id1 1 2\nUPDATE id2 3 4\nCREATE id3\nCREATE id4\nUPDATE id5 3 4\nCREATE id6\nUPDATE id7 23 24\nUPDATE id8 1 1\nUPDATE id9 0 1 invalid\nSUCCESS'
     );
 
     // Create content to import
@@ -310,7 +310,7 @@ describe('revert tests', function() {
 
     await createLog(
       'temp/revert/revertSkip.txt',
-      'UPDATE id1 1 2\nUPDATE id2 3 4\nCREATE id3\nCREATE id4\nUPDATE id5 3 4\nCREATE id6\nUPDATE id7 23 24'
+      'UPDATE id1 1 2\nUPDATE id2 3 4\nCREATE id3\nCREATE id4\nUPDATE id5 3 4\nCREATE id6\nUPDATE id7 23 24\nSUCCESS'
     );
 
     // Create content to import
@@ -349,7 +349,7 @@ describe('revert tests', function() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (readline as any).setResponses([]);
 
-    await createLog('temp/revert/revertSkip2.txt', 'UPDATE id1 1 2');
+    await createLog('temp/revert/revertSkip2.txt', 'UPDATE id1 1 2\nSUCCESS');
 
     // Create content to import
 

--- a/src/commands/content-item/import.spec.ts
+++ b/src/commands/content-item/import.spec.ts
@@ -14,6 +14,7 @@ import readline from 'readline';
 import rmdir from 'rimraf';
 import { ensureDirectoryExists } from '../../common/import/directory-utils';
 import { MockContent, ItemTemplate } from '../../common/dc-management-sdk-js/mock-content';
+import { FileLog } from '../../common/file-log';
 
 jest.mock('readline');
 jest.mock('./import-revert');
@@ -914,6 +915,8 @@ describe('content-item import command', () => {
 
       mockContent.metrics.reset();
 
+      const log = new FileLog();
+
       const argv = {
         ...yargArgs,
         ...config,
@@ -921,7 +924,8 @@ describe('content-item import command', () => {
         skipIncomplete: true, // Make it easier to detect that "yes" was said to the dependancy question
 
         dir: 'temp/import/force/',
-        mapFile: 'temp/import/force.json'
+        mapFile: 'temp/import/force.json',
+        logFile: log
       };
       await handler(argv);
 
@@ -938,6 +942,9 @@ describe('content-item import command', () => {
       expect(mockContent.metrics.itemsCreated).toEqual(4);
       expect(mockContent.metrics.itemsUpdated).toEqual(2);
       expect(mockContent.metrics.typesCreated).toEqual(1);
+
+      // Warns for each condition, except for overwrite.
+      expect(log.getData('WARNING').length).toEqual(4);
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((readline as any).responsesLeft()).toEqual(0); // All responses consumed.

--- a/src/commands/content-item/import.ts
+++ b/src/commands/content-item/import.ts
@@ -434,6 +434,8 @@ const prepareContentForImport = async (
         return null;
       }
 
+      log.addError(LogErrorLevel.WARNING, `Creating ${existing.length} missing content types.`);
+
       // Create the content types
 
       for (let i = 0; i < existing.length; i++) {
@@ -496,6 +498,8 @@ const prepareContentForImport = async (
       return null;
     }
 
+    log.addError(LogErrorLevel.WARNING, `Creating ${missingRepoAssignments.length} missing repo assignments.`);
+
     try {
       await Promise.all(
         missingRepoAssignments.map(([repo, type]) => repo.related.contentTypes.assign(type.id as string))
@@ -535,7 +539,10 @@ const prepareContentForImport = async (
     tree.removeContent(affectedContentItems);
 
     if (tree.all.length === 0) {
-      log.addError(LogErrorLevel.ERROR, 'No content remains after removing those with missing content type schemas. Aborting.');
+      log.addError(
+        LogErrorLevel.ERROR,
+        'No content remains after removing those with missing content type schemas. Aborting.'
+      );
       return null;
     }
 
@@ -547,6 +554,11 @@ const prepareContentForImport = async (
     if (!ignore) {
       return null;
     }
+
+    log.addError(
+      LogErrorLevel.WARNING,
+      `Skipping ${missingRepoAssignments.length} content items due to missing schemas.`
+    );
   }
 
   // Do all the content items that we depend on exist either in the mapping or in the items we're importing?
@@ -621,6 +633,11 @@ const prepareContentForImport = async (
     if (!ignore) {
       return null;
     }
+
+    log.addError(
+      LogErrorLevel.WARNING,
+      `${invalidContentItems.length} content items ${action} due to missing references.`
+    );
   }
 
   log.appendLine(
@@ -927,6 +944,8 @@ export const handler = async (
           closeLog();
           return false;
         }
+
+        log.addError(LogErrorLevel.WARNING, `${missingRepos.length} repositories skipped.`);
       }
     }
 

--- a/src/commands/content-item/import.ts
+++ b/src/commands/content-item/import.ts
@@ -31,7 +31,6 @@ import { asyncQuestion } from '../../common/archive/archive-helpers';
 import { AmplienceSchemaValidator, defaultSchemaLookup } from '../../common/content-item/amplience-schema-validator';
 import { getDefaultLogPath } from '../../common/log-helpers';
 import { PublishQueue } from '../../common/import/publish-queue';
-import { LogErrorLevel } from '../../common/archive/archive-log';
 
 export function getDefaultMappingPath(name: string, platform: string = process.platform): string {
   return join(

--- a/src/commands/content-item/import.ts
+++ b/src/commands/content-item/import.ts
@@ -333,7 +333,7 @@ const prepareContentForImport = async (
         }
       }
     } catch (e) {
-      log.addError(LogErrorLevel.ERROR, `Could not get base folders for repository ${repo.label}: `, e);
+      log.error(`Could not get base folders for repository ${repo.label}: `, e);
       return null;
     }
 
@@ -403,7 +403,7 @@ const prepareContentForImport = async (
     types = await paginator(hub.related.contentTypes.list);
     schemas = await paginator(hub.related.contentTypeSchema.list);
   } catch (e) {
-    log.addError(LogErrorLevel.ERROR, 'Could not load content types:', e);
+    log.error('Could not load content types:', e);
     return null;
   }
 
@@ -434,7 +434,7 @@ const prepareContentForImport = async (
         return null;
       }
 
-      log.addError(LogErrorLevel.WARNING, `Creating ${existing.length} missing content types.`);
+      log.warn(`Creating ${existing.length} missing content types.`);
 
       // Create the content types
 
@@ -498,14 +498,14 @@ const prepareContentForImport = async (
       return null;
     }
 
-    log.addError(LogErrorLevel.WARNING, `Creating ${missingRepoAssignments.length} missing repo assignments.`);
+    log.warn(`Creating ${missingRepoAssignments.length} missing repo assignments.`);
 
     try {
       await Promise.all(
         missingRepoAssignments.map(([repo, type]) => repo.related.contentTypes.assign(type.id as string))
       );
     } catch (e) {
-      log.addError(LogErrorLevel.ERROR, 'Failed creating repo assignments:', e);
+      log.error('Failed creating repo assignments:', e);
       return null;
     }
   }
@@ -539,10 +539,7 @@ const prepareContentForImport = async (
     tree.removeContent(affectedContentItems);
 
     if (tree.all.length === 0) {
-      log.addError(
-        LogErrorLevel.ERROR,
-        'No content remains after removing those with missing content type schemas. Aborting.'
-      );
+      log.error('No content remains after removing those with missing content type schemas. Aborting.');
       return null;
     }
 
@@ -555,10 +552,7 @@ const prepareContentForImport = async (
       return null;
     }
 
-    log.addError(
-      LogErrorLevel.WARNING,
-      `Skipping ${missingRepoAssignments.length} content items due to missing schemas.`
-    );
+    log.warn(`Skipping ${missingRepoAssignments.length} content items due to missing schemas.`);
   }
 
   // Do all the content items that we depend on exist either in the mapping or in the items we're importing?
@@ -634,10 +628,7 @@ const prepareContentForImport = async (
       return null;
     }
 
-    log.addError(
-      LogErrorLevel.WARNING,
-      `${invalidContentItems.length} content items ${action} due to missing references.`
-    );
+    log.warn(`${invalidContentItems.length} content items ${action} due to missing references.`);
   }
 
   log.appendLine(
@@ -697,7 +688,7 @@ const importTree = async (
         newItem = result.newItem;
         oldVersion = result.oldVersion;
       } catch (e) {
-        log.addError(LogErrorLevel.ERROR, `Failed creating ${content.label}:`, e);
+        log.error(`Failed creating ${content.label}:`, e);
         abort(e);
         return false;
       }
@@ -772,7 +763,7 @@ const importTree = async (
         newItem = result.newItem;
         oldVersion = result.oldVersion;
       } catch (e) {
-        log.addError(LogErrorLevel.ERROR, `Failed creating ${content.label}:`, e);
+        log.error(`Failed creating ${content.label}:`, e);
         abort(e);
         return false;
       }
@@ -849,7 +840,7 @@ export const handler = async (
   try {
     hub = await client.hubs.get(argv.hubId);
   } catch (e) {
-    log.addError(LogErrorLevel.ERROR, `Couldn't get hub:`, e);
+    log.error(`Couldn't get hub:`, e);
     closeLog();
     return false;
   }
@@ -883,7 +874,7 @@ export const handler = async (
       repo = await bFolder.related.contentRepository();
       folder = bFolder;
     } catch (e) {
-      log.addError(LogErrorLevel.ERROR, `Couldn't get base folder:`, e);
+      log.error(`Couldn't get base folder:`, e);
       closeLog();
       return false;
     }
@@ -893,7 +884,7 @@ export const handler = async (
     try {
       repo = await client.contentRepositories.get(baseRepo);
     } catch (e) {
-      log.addError(LogErrorLevel.ERROR, `Couldn't get base repository:`, e);
+      log.error(`Couldn't get base repository:`, e);
       closeLog();
       return false;
     }
@@ -904,7 +895,7 @@ export const handler = async (
     try {
       repos = await paginator(hub.related.contentRepositories.list);
     } catch (e) {
-      log.addError(LogErrorLevel.ERROR, `Couldn't get repositories:`, e);
+      log.error(`Couldn't get repositories:`, e);
       closeLog();
       return false;
     }
@@ -945,12 +936,12 @@ export const handler = async (
           return false;
         }
 
-        log.addError(LogErrorLevel.WARNING, `${missingRepos.length} repositories skipped.`);
+        log.warn(`${missingRepos.length} repositories skipped.`);
       }
     }
 
     if (importRepos.length == 0) {
-      log.addError(LogErrorLevel.ERROR, 'Could not find any matching repositories to import into, aborting.');
+      log.error('Could not find any matching repositories to import into, aborting.');
       closeLog();
       return false;
     }

--- a/src/commands/content-item/unarchive.ts
+++ b/src/commands/content-item/unarchive.ts
@@ -1,7 +1,7 @@
 import { Arguments, Argv } from 'yargs';
 import { ConfigurationParameters } from '../configure';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
-import { LogErrorLevel, ArchiveLog } from '../../common/archive/archive-log';
+import { ArchiveLog } from '../../common/archive/archive-log';
 import paginator from '../../common/dc-management-sdk-js/paginator';
 import { confirmArchive } from '../../common/archive/archive-helpers';
 import UnarchiveOptions from '../../common/archive/unarchive-options';

--- a/src/commands/content-item/unarchive.ts
+++ b/src/commands/content-item/unarchive.ts
@@ -265,17 +265,9 @@ export const processItems = async ({
       log.addComment(e.toString());
 
       if (ignoreError) {
-        log.addError(
-          LogErrorLevel.WARNING,
-          `Failed to unarchive ${contentItems[i].label} (${contentItems[i].id}), continuing.`,
-          e
-        );
+        log.warn(`Failed to unarchive ${contentItems[i].label} (${contentItems[i].id}), continuing.`, e);
       } else {
-        log.addError(
-          LogErrorLevel.ERROR,
-          `Failed to unarchive ${contentItems[i].label} (${contentItems[i].id}), aborting.`,
-          e
-        );
+        log.error(`Failed to unarchive ${contentItems[i].label} (${contentItems[i].id}), aborting.`, e);
         break;
       }
     }

--- a/src/commands/content-item/unarchive.ts
+++ b/src/commands/content-item/unarchive.ts
@@ -1,7 +1,7 @@
 import { Arguments, Argv } from 'yargs';
 import { ConfigurationParameters } from '../configure';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
-import { ArchiveLog } from '../../common/archive/archive-log';
+import { LogErrorLevel, ArchiveLog } from '../../common/archive/archive-log';
 import paginator from '../../common/dc-management-sdk-js/paginator';
 import { confirmArchive } from '../../common/archive/archive-helpers';
 import UnarchiveOptions from '../../common/archive/unarchive-options';
@@ -265,12 +265,16 @@ export const processItems = async ({
       log.addComment(e.toString());
 
       if (ignoreError) {
-        console.log(
-          `Failed to unarchive ${contentItems[i].label} (${contentItems[i].id}), continuing. Error: \n${e.toString()}`
+        log.addError(
+          LogErrorLevel.WARNING,
+          `Failed to unarchive ${contentItems[i].label} (${contentItems[i].id}), continuing.`,
+          e
         );
       } else {
-        console.log(
-          `Failed to unarchive ${contentItems[i].label} (${contentItems[i].id}), aborting. Error: \n${e.toString()}`
+        log.addError(
+          LogErrorLevel.ERROR,
+          `Failed to unarchive ${contentItems[i].label} (${contentItems[i].id}), aborting.`,
+          e
         );
         break;
       }

--- a/src/commands/content-type-schema/archive.ts
+++ b/src/commands/content-type-schema/archive.ts
@@ -2,7 +2,7 @@ import { Arguments, Argv } from 'yargs';
 import { ConfigurationParameters } from '../configure';
 import { ContentTypeSchema } from 'dc-management-sdk-js';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
-import { LogErrorLevel, ArchiveLog } from '../../common/archive/archive-log';
+import { ArchiveLog } from '../../common/archive/archive-log';
 import paginator from '../../common/dc-management-sdk-js/paginator';
 import { equalsOrRegex } from '../../common/filter/filter';
 import { confirmArchive } from '../../common/archive/archive-helpers';

--- a/src/commands/content-type-schema/archive.ts
+++ b/src/commands/content-type-schema/archive.ts
@@ -2,7 +2,7 @@ import { Arguments, Argv } from 'yargs';
 import { ConfigurationParameters } from '../configure';
 import { ContentTypeSchema } from 'dc-management-sdk-js';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
-import { ArchiveLog } from '../../common/archive/archive-log';
+import { LogErrorLevel, ArchiveLog } from '../../common/archive/archive-log';
 import paginator from '../../common/dc-management-sdk-js/paginator';
 import { equalsOrRegex } from '../../common/filter/filter';
 import { confirmArchive } from '../../common/archive/archive-helpers';
@@ -147,9 +147,9 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
       log.addComment(e.toString());
 
       if (ignoreError) {
-        console.log(`Failed to archive ${schemas[i].schemaId}, continuing. Error: \n${e.toString()}`);
+        log.addError(LogErrorLevel.WARNING, `Failed to archive ${schemas[i].schemaId}, continuing.`, e);
       } else {
-        console.log(`Failed to archive ${schemas[i].schemaId}, aborting. Error: \n${e.toString()}`);
+        log.addError(LogErrorLevel.ERROR, `Failed to archive ${schemas[i].schemaId}, aborting.`, e);
         break;
       }
     }

--- a/src/commands/content-type-schema/archive.ts
+++ b/src/commands/content-type-schema/archive.ts
@@ -147,9 +147,9 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
       log.addComment(e.toString());
 
       if (ignoreError) {
-        log.addError(LogErrorLevel.WARNING, `Failed to archive ${schemas[i].schemaId}, continuing.`, e);
+        log.warn(`Failed to archive ${schemas[i].schemaId}, continuing.`, e);
       } else {
-        log.addError(LogErrorLevel.ERROR, `Failed to archive ${schemas[i].schemaId}, aborting.`, e);
+        log.error(`Failed to archive ${schemas[i].schemaId}, aborting.`, e);
         break;
       }
     }

--- a/src/commands/content-type-schema/unarchive.ts
+++ b/src/commands/content-type-schema/unarchive.ts
@@ -2,7 +2,7 @@ import { Arguments, Argv } from 'yargs';
 import { ConfigurationParameters } from '../configure';
 import { ContentTypeSchema } from 'dc-management-sdk-js';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
-import { ArchiveLog } from '../../common/archive/archive-log';
+import { LogErrorLevel, ArchiveLog } from '../../common/archive/archive-log';
 import { equalsOrRegex } from '../../common/filter/filter';
 import paginator from '../../common/dc-management-sdk-js/paginator';
 import { confirmArchive } from '../../common/archive/archive-helpers';
@@ -147,9 +147,9 @@ export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationPa
       log.addComment(e.toString());
 
       if (ignoreError) {
-        console.log(`Failed to unarchive ${schemas[i].schemaId}, continuing. Error: \n${e.toString()}`);
+        log.addError(LogErrorLevel.WARNING, `Failed to unarchive ${schemas[i].schemaId}, continuing.`, e);
       } else {
-        console.log(`Failed to unarchive ${schemas[i].schemaId}, aborting. Error: \n${e.toString()}`);
+        log.addError(LogErrorLevel.ERROR, `Failed to unarchive ${schemas[i].schemaId}, aborting.`, e);
         break;
       }
     }

--- a/src/commands/content-type-schema/unarchive.ts
+++ b/src/commands/content-type-schema/unarchive.ts
@@ -147,9 +147,9 @@ export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationPa
       log.addComment(e.toString());
 
       if (ignoreError) {
-        log.addError(LogErrorLevel.WARNING, `Failed to unarchive ${schemas[i].schemaId}, continuing.`, e);
+        log.warn(`Failed to unarchive ${schemas[i].schemaId}, continuing.`, e);
       } else {
-        log.addError(LogErrorLevel.ERROR, `Failed to unarchive ${schemas[i].schemaId}, aborting.`, e);
+        log.error(`Failed to unarchive ${schemas[i].schemaId}, aborting.`, e);
         break;
       }
     }

--- a/src/commands/content-type-schema/unarchive.ts
+++ b/src/commands/content-type-schema/unarchive.ts
@@ -2,7 +2,7 @@ import { Arguments, Argv } from 'yargs';
 import { ConfigurationParameters } from '../configure';
 import { ContentTypeSchema } from 'dc-management-sdk-js';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
-import { LogErrorLevel, ArchiveLog } from '../../common/archive/archive-log';
+import { ArchiveLog } from '../../common/archive/archive-log';
 import { equalsOrRegex } from '../../common/filter/filter';
 import paginator from '../../common/dc-management-sdk-js/paginator';
 import { confirmArchive } from '../../common/archive/archive-helpers';

--- a/src/commands/content-type/archive.ts
+++ b/src/commands/content-type/archive.ts
@@ -152,9 +152,9 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
       log.addComment(e.toString());
 
       if (ignoreError) {
-        log.addError(LogErrorLevel.WARNING, `Failed to archive ${label}, continuing.`, e);
+        log.warn(`Failed to archive ${label}, continuing.`, e);
       } else {
-        log.addError(LogErrorLevel.ERROR, `Failed to archive ${label}, aborting.`, e);
+        log.error(`Failed to archive ${label}, aborting.`, e);
         break;
       }
     }

--- a/src/commands/content-type/archive.ts
+++ b/src/commands/content-type/archive.ts
@@ -2,7 +2,7 @@ import { Arguments, Argv } from 'yargs';
 import { ConfigurationParameters } from '../configure';
 import { ContentType } from 'dc-management-sdk-js';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
-import { LogErrorLevel, ArchiveLog } from '../../common/archive/archive-log';
+import { ArchiveLog } from '../../common/archive/archive-log';
 import paginator from '../../common/dc-management-sdk-js/paginator';
 import { equalsOrRegex } from '../../common/filter/filter';
 

--- a/src/commands/content-type/archive.ts
+++ b/src/commands/content-type/archive.ts
@@ -2,7 +2,7 @@ import { Arguments, Argv } from 'yargs';
 import { ConfigurationParameters } from '../configure';
 import { ContentType } from 'dc-management-sdk-js';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
-import { ArchiveLog } from '../../common/archive/archive-log';
+import { LogErrorLevel, ArchiveLog } from '../../common/archive/archive-log';
 import paginator from '../../common/dc-management-sdk-js/paginator';
 import { equalsOrRegex } from '../../common/filter/filter';
 
@@ -152,9 +152,9 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
       log.addComment(e.toString());
 
       if (ignoreError) {
-        console.log(`Failed to archive ${label}, continuing. Error: \n${e.toString()}`);
+        log.addError(LogErrorLevel.WARNING, `Failed to archive ${label}, continuing.`, e);
       } else {
-        console.log(`Failed to archive ${label}, aborting. Error: \n${e.toString()}`);
+        log.addError(LogErrorLevel.ERROR, `Failed to archive ${label}, aborting.`, e);
         break;
       }
     }

--- a/src/commands/content-type/unarchive.ts
+++ b/src/commands/content-type/unarchive.ts
@@ -149,9 +149,9 @@ export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationPa
       log.addComment(e.toString());
 
       if (ignoreError) {
-        log.addError(LogErrorLevel.WARNING, `Failed to unarchive ${label}, continuing.`, e);
+        log.warn(`Failed to unarchive ${label}, continuing.`, e);
       } else {
-        log.addError(LogErrorLevel.ERROR, `Failed to unarchive ${label}, aborting.`, e);
+        log.error(`Failed to unarchive ${label}, aborting.`, e);
         break;
       }
     }

--- a/src/commands/content-type/unarchive.ts
+++ b/src/commands/content-type/unarchive.ts
@@ -2,7 +2,7 @@ import { Arguments, Argv } from 'yargs';
 import { ConfigurationParameters } from '../configure';
 import { ContentType } from 'dc-management-sdk-js';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
-import { ArchiveLog } from '../../common/archive/archive-log';
+import { LogErrorLevel, ArchiveLog } from '../../common/archive/archive-log';
 import { equalsOrRegex } from '../../common/filter/filter';
 import paginator from '../../common/dc-management-sdk-js/paginator';
 import { confirmArchive } from '../../common/archive/archive-helpers';
@@ -149,9 +149,9 @@ export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationPa
       log.addComment(e.toString());
 
       if (ignoreError) {
-        console.log(`Failed to unarchive ${label}, continuing. Error: \n${e.toString()}`);
+        log.addError(LogErrorLevel.WARNING, `Failed to unarchive ${label}, continuing.`, e);
       } else {
-        console.log(`Failed to unarchive ${label}, aborting. Error: \n${e.toString()}`);
+        log.addError(LogErrorLevel.ERROR, `Failed to unarchive ${label}, aborting.`, e);
         break;
       }
     }

--- a/src/commands/content-type/unarchive.ts
+++ b/src/commands/content-type/unarchive.ts
@@ -2,7 +2,7 @@ import { Arguments, Argv } from 'yargs';
 import { ConfigurationParameters } from '../configure';
 import { ContentType } from 'dc-management-sdk-js';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
-import { LogErrorLevel, ArchiveLog } from '../../common/archive/archive-log';
+import { ArchiveLog } from '../../common/archive/archive-log';
 import { equalsOrRegex } from '../../common/filter/filter';
 import paginator from '../../common/dc-management-sdk-js/paginator';
 import { confirmArchive } from '../../common/archive/archive-helpers';

--- a/src/common/archive/archive-log.spec.ts
+++ b/src/common/archive/archive-log.spec.ts
@@ -1,0 +1,51 @@
+import { ArchiveLog, LogErrorLevel } from './archive-log';
+import { writeFile, unlink } from 'fs';
+import { promisify } from 'util';
+import * as directoryUtils from '../import/directory-utils';
+import { ensureDirectoryExists } from '../import/directory-utils';
+
+describe('archive-log', () => {
+  describe('archive-log tests', () => {
+    beforeEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('should return false when writing to file fails', async () => {
+      const log = new ArchiveLog('Failing Log');
+      log.addAction('ACTION', '1');
+
+      jest.spyOn(directoryUtils, 'ensureDirectoryExists').mockImplementation(() => Promise.reject());
+
+      const result = await log.writeToFile('failure.log');
+
+      expect(result).toBeFalsy();
+    });
+
+    it('should recover the exit code when loading from file', async () => {
+      await ensureDirectoryExists('temp/');
+
+      // Code -1 is when the file is closed without an error type.
+
+      const resultCodes = ['SUCCESS', 'WARNING', 'FAILURE'];
+      for (let i = -1; i <= LogErrorLevel.ERROR; i++) {
+        const errorType = i == -1 ? 0 : i;
+
+        const errorStr = LogErrorLevel[errorType];
+        const closingStr = resultCodes[errorType];
+
+        const path = `temp/exit-${errorStr}.log`;
+
+        await promisify(writeFile)(path, `// File Title\nACTION 1\n${closingStr}`);
+
+        const log = new ArchiveLog();
+        await log.loadFromFile(path);
+
+        expect(log.title).toEqual('File Title');
+        expect(log.getData('ACTION')).toEqual(['1']);
+        expect(log.errorLevel).toEqual(i == -1 ? LogErrorLevel.NONE : i);
+
+        await promisify(unlink)(path);
+      }
+    });
+  });
+});

--- a/src/common/archive/archive-log.ts
+++ b/src/common/archive/archive-log.ts
@@ -8,7 +8,14 @@ export interface ArchiveLogItem {
   data: string;
 }
 
+export enum LogErrorLevel {
+  NONE = 0,
+  WARNING,
+  ERROR
+}
+
 export class ArchiveLog {
+  errorLevel: LogErrorLevel = LogErrorLevel.NONE;
   items: ArchiveLogItem[] = [];
 
   constructor(public title?: string) {}
@@ -17,7 +24,7 @@ export class ArchiveLog {
     const log = await promisify(readFile)(path, 'utf8');
     const logLines = log.split('\n');
     this.items = [];
-    logLines.forEach(line => {
+    logLines.forEach((line, index) => {
       if (line.startsWith('//')) {
         // The first comment is the title, all ones after it should be recorded as comment items.
         const message = line.substring(2).trimLeft();
@@ -28,12 +35,39 @@ export class ArchiveLog {
         }
         return;
       }
-      const lineSplit = line.split(' ');
-      if (lineSplit.length >= 2) {
-        this.addAction(lineSplit[0], lineSplit.slice(1).join(' '));
+
+      if (index === logLines.length - 1) {
+        this.errorLevel = this.parseResultCode(line);
+      } else {
+        const lineSplit = line.split(' ');
+        if (lineSplit.length >= 2) {
+          this.addAction(lineSplit[0], lineSplit.slice(1).join(' '));
+        }
       }
     });
     return this;
+  }
+
+  private getResultCode(): string {
+    switch (this.errorLevel) {
+      case LogErrorLevel.NONE:
+        return 'SUCCESS';
+      case LogErrorLevel.ERROR:
+        return 'FAILURE';
+      default:
+        return LogErrorLevel[this.errorLevel];
+    }
+  }
+
+  private parseResultCode(code: string): LogErrorLevel {
+    switch (code) {
+      case 'SUCCESS':
+        return LogErrorLevel.NONE;
+      case 'FAILURE':
+        return LogErrorLevel.ERROR;
+      default:
+        return LogErrorLevel[code as keyof typeof LogErrorLevel] || LogErrorLevel.NONE;
+    }
   }
 
   async writeToFile(path: string): Promise<boolean> {
@@ -47,6 +81,8 @@ export class ArchiveLog {
         }
       });
 
+      log += this.getResultCode();
+
       const dir = dirname(path);
       if (!(await promisify(exists)(dir))) {
         await promisify(mkdir)(dir);
@@ -57,6 +93,23 @@ export class ArchiveLog {
     } catch {
       console.log('Could not write log.');
       return false;
+    }
+  }
+
+  addError(level: LogErrorLevel, message: string, error?: Error): void {
+    if (level > this.errorLevel) {
+      this.errorLevel = level;
+    }
+
+    this.addAction(LogErrorLevel[level], '');
+    this.addComment(LogErrorLevel[level] + ': ' + message);
+
+    console.error(LogErrorLevel[level] + ': ' + message);
+
+    if (error) {
+      this.addComment(error.toString());
+
+      console.error(error.toString());
     }
   }
 

--- a/src/common/archive/archive-log.ts
+++ b/src/common/archive/archive-log.ts
@@ -1,6 +1,7 @@
-import { readFile, writeFile, exists, mkdir } from 'fs';
+import { readFile, writeFile } from 'fs';
 import { dirname } from 'path';
 import { promisify } from 'util';
+import { ensureDirectoryExists } from '../import/directory-utils';
 
 export interface ArchiveLogItem {
   comment: boolean;
@@ -84,9 +85,8 @@ export class ArchiveLog {
       log += this.getResultCode();
 
       const dir = dirname(path);
-      if (!(await promisify(exists)(dir))) {
-        await promisify(mkdir)(dir);
-      }
+      await ensureDirectoryExists(dir);
+
       await promisify(writeFile)(path, log);
       console.log(`Log written to "${path}".`);
       return true;
@@ -104,12 +104,14 @@ export class ArchiveLog {
     this.addAction(LogErrorLevel[level], '');
     this.addComment(LogErrorLevel[level] + ': ' + message);
 
-    console.error(LogErrorLevel[level] + ': ' + message);
+    const errorLog = level == LogErrorLevel.ERROR ? console.error : console.warn;
+
+    errorLog(LogErrorLevel[level] + ': ' + message);
 
     if (error) {
       this.addComment(error.toString());
 
-      console.error(error.toString());
+      errorLog(error.toString());
     }
   }
 

--- a/src/common/archive/archive-log.ts
+++ b/src/common/archive/archive-log.ts
@@ -96,7 +96,7 @@ export class ArchiveLog {
     }
   }
 
-  addError(level: LogErrorLevel, message: string, error?: Error): void {
+  private addError(level: LogErrorLevel, message: string, error?: Error): void {
     if (level > this.errorLevel) {
       this.errorLevel = level;
     }
@@ -113,6 +113,14 @@ export class ArchiveLog {
 
       errorLog(error.toString());
     }
+  }
+
+  warn(message: string, error?: Error): void {
+    this.addError(LogErrorLevel.WARNING, message, error);
+  }
+
+  error(message: string, error?: Error): void {
+    this.addError(LogErrorLevel.ERROR, message, error);
   }
 
   addComment(comment: string): void {

--- a/src/common/file-log.spec.ts
+++ b/src/common/file-log.spec.ts
@@ -35,7 +35,7 @@ describe('file-log', () => {
       expect(await promisify(readFile)('temp/FileWithDate-1234.log', { encoding: 'utf-8' })).toMatchInlineSnapshot(`
         "// temp/FileWithDate-1234.log
         // Test Message
-        "
+        SUCCESS"
       `);
 
       await promisify(unlink)('temp/FileWithDate-1234.log');


### PR DESCRIPTION
This PR changes the reporting of errors and warnings into the log to be more consistent, and machine readable.

When an error occurs, there is now an `ERROR` or `WARNING` action inserted into the logs.

When any error or warning occurs, the overall error level of the log is increased to match the error. This is printed at the end of the file as `SUCCESS` if there are no warnings or errors, `FAILURE` if there are errors, or the highest error level otherwise.

The errors logs themselves have been made more consistent - logs with `Error` instances will now print them on the next line all of the time, rather than inconsistently as part of the string template.

This shouldn't be a breaking change. The final return code is on the last line of the log, which was previously empty. (the log ended with a new line). If the `ArchiveLog` attempts to parse a log without an exit code, it should default to `SUCCESS`.