### PR TITLE
feat(hub): clean hub command

### DIFF
--- a/src/__snapshots__/cli.spec.ts.snap
+++ b/src/__snapshots__/cli.spec.ts.snap
@@ -10,6 +10,7 @@ Commands:
   dc-cli content-type-schema  Content Type Schema
   dc-cli content-type         Content Type
   dc-cli event                Event
+  dc-cli hub                  Hub
   dc-cli settings             Settings
 
 Options:

--- a/src/commands/content-item/archive.ts
+++ b/src/commands/content-item/archive.ts
@@ -268,7 +268,7 @@ export const processItems = async ({
       }
       await contentItems[i].related.archive();
 
-      log.addAction('ARCHIVE', `${args}\n`);
+      log.addAction('ARCHIVE', `${args}`);
       successCount++;
     } catch (e) {
       log.addComment(`ARCHIVE FAILED: ${contentItems[i].id}`);

--- a/src/commands/content-item/archive.ts
+++ b/src/commands/content-item/archive.ts
@@ -251,7 +251,7 @@ export const processItems = async ({
   }
 
   const timestamp = Date.now().toString();
-  const log = typeof logFile === 'object' ? logFile : new ArchiveLog(`Content Items Archive Log - ${timestamp}\n`);
+  const log = logFile instanceof FileLog ? logFile : new ArchiveLog(`Content Items Archive Log - ${timestamp}\n`);
 
   let successCount = 0;
 

--- a/src/commands/content-item/copy.spec.ts
+++ b/src/commands/content-item/copy.spec.ts
@@ -13,7 +13,7 @@ import { Arguments } from 'yargs';
 import { ExportItemBuilderOptions } from '../../interfaces/export-item-builder-options.interface';
 import { ConfigurationParameters } from '../configure';
 import { ImportItemBuilderOptions } from '../../interfaces/import-item-builder-options.interface';
-import { getDefaultLogPath } from '../../common/log-helpers';
+import { createLog, getDefaultLogPath } from '../../common/log-helpers';
 import * as copyConfig from '../../common/content-item/copy-config';
 import { FileLog } from '../../common/file-log';
 
@@ -157,7 +157,8 @@ describe('content-item copy command', () => {
       expect(spyOption).toHaveBeenCalledWith('logFile', {
         type: 'string',
         default: LOG_FILENAME,
-        describe: 'Path to a log file to write to.'
+        describe: 'Path to a log file to write to.',
+        coerce: createLog
       });
     });
   });
@@ -171,7 +172,8 @@ describe('content-item copy command', () => {
     const config = {
       clientId: 'client-id',
       clientSecret: 'client-id',
-      hubId: 'hub-id'
+      hubId: 'hub-id',
+      logFile: new FileLog()
     };
 
     beforeAll(async () => {
@@ -431,7 +433,7 @@ describe('content-item copy command', () => {
       expect(importCalls[0].skipIncomplete).toEqual(argv.skipIncomplete);
     });
 
-    it('should not close the log if provided as part of the arguments', async () => {
+    it('should not close the log if previously opened', async () => {
       const copyConfig = {
         srcHubId: 'hub2-id',
         srcClientId: 'acc2-id',
@@ -442,7 +444,7 @@ describe('content-item copy command', () => {
         dstSecret: 'acc2-secret'
       };
 
-      const log = new FileLog();
+      const log = new FileLog().open();
       const argv = {
         ...yargArgs,
         ...config,

--- a/src/commands/content-item/move.spec.ts
+++ b/src/commands/content-item/move.spec.ts
@@ -18,14 +18,18 @@ import { CopyItemBuilderOptions } from '../../interfaces/copy-item-builder-optio
 import { ItemTemplate, MockContent } from '../../common/dc-management-sdk-js/mock-content';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
 import { ensureDirectoryExists } from '../../common/import/directory-utils';
-import { getDefaultLogPath } from '../../common/log-helpers';
+import { getDefaultLogPath, createLog as createFileLog, createLog } from '../../common/log-helpers';
 import * as copyConfig from '../../common/content-item/copy-config';
 import { ImportItemBuilderOptions } from '../../interfaces/import-item-builder-options.interface';
+import { FileLog } from '../../common/file-log';
 
 jest.mock('../../services/dynamic-content-client-factory');
 jest.mock('./copy');
 jest.mock('./import-revert');
-jest.mock('../../common/log-helpers');
+jest.mock('../../common/log-helpers', () => ({
+  ...jest.requireActual('../../common/log-helpers'),
+  getDefaultLogPath: jest.fn()
+}));
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const copierAny = copier as any;
@@ -138,7 +142,8 @@ describe('content-item move command', () => {
       expect(spyOption).toHaveBeenCalledWith('logFile', {
         type: 'string',
         default: LOG_FILENAME,
-        describe: 'Path to a log file to write to.'
+        describe: 'Path to a log file to write to.',
+        coerce: createLog
       });
     });
   });
@@ -152,7 +157,8 @@ describe('content-item move command', () => {
     const config = {
       clientId: 'client-id',
       clientSecret: 'client-id',
-      hubId: 'hub-id'
+      hubId: 'hub-id',
+      logFile: new FileLog()
     };
 
     beforeAll(async () => {
@@ -417,9 +423,7 @@ describe('content-item move command', () => {
 
         dstHubId: 'hub2-id',
         dstClientId: 'acc2-id',
-        dstSecret: 'acc2-secret',
-
-        logFile: LOG_FILENAME()
+        dstSecret: 'acc2-secret'
       };
       await handler(argv);
 
@@ -466,7 +470,7 @@ describe('content-item move command', () => {
         validate: false,
         skipIncomplete: false,
 
-        logFile: 'temp/move/failLog.txt'
+        logFile: createFileLog('temp/move/failLog.txt')
       };
       await handler(argv);
 
@@ -489,9 +493,7 @@ describe('content-item move command', () => {
 
         dstHubId: 'hub2-id',
         dstClientId: 'acc2-id',
-        dstSecret: 'acc2-secret',
-
-        logFile: LOG_FILENAME()
+        dstSecret: 'acc2-secret'
       };
       await handler(argv);
 

--- a/src/commands/content-item/move.ts
+++ b/src/commands/content-item/move.ts
@@ -1,4 +1,4 @@
-import { getDefaultLogPath } from '../../common/log-helpers';
+import { createLog, getDefaultLogPath } from '../../common/log-helpers';
 import { Argv, Arguments } from 'yargs';
 import { CopyItemBuilderOptions } from '../../interfaces/copy-item-builder-options.interface';
 import { ConfigurationParameters } from '../configure';
@@ -132,7 +132,8 @@ export const builder = (yargs: Argv): void => {
     .option('logFile', {
       type: 'string',
       default: LOG_FILENAME,
-      describe: 'Path to a log file to write to.'
+      describe: 'Path to a log file to write to.',
+      coerce: createLog
     });
 };
 
@@ -204,7 +205,7 @@ export const handler = async (argv: Arguments<CopyItemBuilderOptions & Configura
       revertLog: argv.revertLog
     });
   } else {
-    const log = new FileLog(argv.logFile as string);
+    const log = argv.logFile.open();
     argv.logFile = log;
 
     const copyConfig = await loadCopyConfig(argv, log);
@@ -245,6 +246,6 @@ export const handler = async (argv: Arguments<CopyItemBuilderOptions & Configura
       }
     }
 
-    log.close();
+    await log.close();
   }
 };

--- a/src/commands/content-item/unarchive.spec.ts
+++ b/src/commands/content-item/unarchive.spec.ts
@@ -34,7 +34,6 @@ describe('content-item unarchive command', () => {
     clientSecret: 'client-id',
     hubId: 'hub-id'
   };
-  const unarchiveMockFunc = jest.fn();
 
   const mockValues = (
     unarchiveError = false
@@ -43,17 +42,70 @@ describe('content-item unarchive command', () => {
     mockGetList: () => void;
     mockItemsList: () => void;
     mockUnarchive: () => void;
+    mockItemUpdate: () => void;
     mockItemGetById: () => void;
     mockRepoGet: () => void;
     mockFolderGet: () => void;
+    contentItems: ContentItem[];
   } => {
     const mockGet = jest.fn();
     const mockGetList = jest.fn();
     const mockItemsList = jest.fn();
     const mockUnarchive = jest.fn();
+    const mockItemUpdate = jest.fn();
     const mockItemGetById = jest.fn();
     const mockRepoGet = jest.fn();
     const mockFolderGet = jest.fn();
+
+    const item = new ContentItem({
+      id: '1',
+      label: 'item1',
+      repoId: 'repo1',
+      folderId: 'folder1',
+      status: 'ARCHIVED',
+      body: {
+        _meta: {
+          schema: 'http://test.com'
+        }
+      },
+      client: {
+        performActionThatReturnsResource: mockUnarchive
+      },
+      _links: {
+        unarchive: {
+          href: 'https://api.amplience.net/v2/content/content-items/1/unarchive'
+        }
+      }
+    });
+
+    const contentItems = [
+      item,
+      new ContentItem({
+        id: '2',
+        label: 'item2',
+        repoId: 'repo1',
+        folderId: 'folder1',
+        status: 'ARCHIVED',
+        body: {
+          _meta: {
+            schema: 'http://test1.com'
+          }
+        },
+        client: {
+          performActionThatReturnsResource: mockUnarchive
+        },
+        _links: {
+          unarchive: {
+            href: 'https://api.amplience.net/v2/content/content-items/2/unarchive'
+          }
+        }
+      })
+    ];
+
+    contentItems[0].related.unarchive = mockUnarchive;
+    contentItems[0].related.update = mockItemUpdate;
+    contentItems[1].related.unarchive = mockUnarchive;
+    contentItems[1].related.update = mockItemUpdate;
 
     (dynamicContentClientFactory as jest.Mock).mockReturnValue({
       hubs: {
@@ -145,76 +197,11 @@ describe('content-item unarchive command', () => {
       })
     );
 
-    mockItemGetById.mockResolvedValue(
-      new ContentItem({
-        id: '1',
-        label: 'item1',
-        repoId: 'repo1',
-        folderId: 'folder1',
-        status: 'ACTIVE',
-        body: {
-          _meta: {
-            schema: 'http://test.com'
-          }
-        },
-        related: { unarchive: mockUnarchive },
-        client: {
-          performActionThatReturnsResource: mockUnarchive
-        },
-        _links: {
-          unarchive: {
-            href: 'https://api.amplience.net/v2/content/content-items/1/unarchive'
-          }
-        }
-      })
-    );
+    mockItemGetById.mockResolvedValue(item);
+    mockUnarchive.mockResolvedValue(item);
+    mockItemUpdate.mockResolvedValue(item);
 
-    mockItemsList.mockResolvedValue(
-      new MockPage(ContentItem, [
-        new ContentItem({
-          id: '1',
-          label: 'item1',
-          repoId: 'repo1',
-          folderId: 'folder1',
-          status: 'ACTIVE',
-          body: {
-            _meta: {
-              schema: 'http://test.com'
-            }
-          },
-          related: { unarchive: mockUnarchive },
-          client: {
-            performActionThatReturnsResource: mockUnarchive
-          },
-          _links: {
-            unarchive: {
-              href: 'https://api.amplience.net/v2/content/content-items/1/unarchive'
-            }
-          }
-        }),
-        new ContentItem({
-          id: '2',
-          label: 'item2',
-          repoId: 'repo1',
-          folderId: 'folder1',
-          status: 'ACTIVE',
-          body: {
-            _meta: {
-              schema: 'http://test1.com'
-            }
-          },
-          client: {
-            performActionThatReturnsResource: mockUnarchive
-          },
-          _links: {
-            unarchive: {
-              href: 'https://api.amplience.net/v2/content/content-items/2/unarchive'
-            }
-          },
-          related: { unarchive: mockUnarchive }
-        })
-      ])
-    );
+    mockItemsList.mockResolvedValue(new MockPage(ContentItem, contentItems));
 
     if (unarchiveError) {
       mockUnarchive.mockRejectedValue(new Error('Error'));
@@ -227,60 +214,13 @@ describe('content-item unarchive command', () => {
       mockGetList,
       mockItemsList,
       mockUnarchive,
+      mockItemUpdate,
       mockItemGetById,
       mockRepoGet,
-      mockFolderGet
+      mockFolderGet,
+      contentItems
     };
   };
-
-  const contentItems = [
-    new ContentItem({
-      id: '1',
-      label: 'item1',
-      repoId: 'repo1',
-      folderId: 'folder1',
-      status: 'ACTIVE',
-      body: {
-        _meta: {
-          schema: 'http://test.com'
-        }
-      },
-      related: { unarchive: unarchiveMockFunc },
-      client: {
-        performActionThatReturnsResource: unarchiveMockFunc
-      },
-      _links: {
-        unarchive: {
-          href: 'https://api.amplience.net/v2/content/content-items/1/unarchive'
-        }
-      }
-    }),
-    new ContentItem({
-      id: '2',
-      label: 'item2',
-      repoId: 'repo1',
-      folderId: 'folder1',
-      status: 'ACTIVE',
-      body: {
-        _meta: {
-          schema: 'http://test1.com'
-        }
-      },
-      client: {
-        performActionThatReturnsResource: unarchiveMockFunc
-      },
-      _links: {
-        unarchive: {
-          href: 'https://api.amplience.net/v2/content/content-items/2/unarchive'
-        }
-      },
-      related: { unarchive: unarchiveMockFunc }
-    })
-  ];
-
-  unarchiveMockFunc.mockResolvedValue({
-    message: 'Success'
-  });
 
   it('should command should defined', function() {
     expect(command).toEqual('unarchive [id]');
@@ -696,7 +636,7 @@ describe('content-item unarchive command', () => {
       (readline as any).setResponses(['y']);
 
       const logFileName = 'temp/content-item-unarchive.log';
-      const log = '// Type log test file\n' + 'ARCHIVE 1\n' + 'ARCHIVE 2\n' + 'ARCHIVE idMissing';
+      const log = '// Type log test file\n' + 'ARCHIVE 1\n' + 'ARCHIVE 2 delivery-key\n' + 'ARCHIVE idMissing';
 
       const dir = dirname(logFileName);
       if (!(await promisify(exists)(dir))) {
@@ -704,7 +644,7 @@ describe('content-item unarchive command', () => {
       }
       await promisify(writeFile)(logFileName, log);
 
-      const { mockGet, mockGetList, mockUnarchive, mockItemsList } = mockValues();
+      const { mockGet, mockGetList, mockUnarchive, mockItemsList, mockItemUpdate } = mockValues();
 
       const argv = {
         ...yargArgs,
@@ -719,6 +659,9 @@ describe('content-item unarchive command', () => {
       expect(mockGet).toHaveBeenCalled();
       expect(mockGetList).toHaveBeenCalled();
       expect(mockItemsList).toHaveBeenCalled();
+      expect(mockItemUpdate).toHaveBeenCalled();
+      const updateItem: ContentItem = (mockItemUpdate as jest.Mock).mock.calls[0][0];
+      expect(updateItem.body._meta.deliveryKey).toEqual('delivery-key');
       expect(mockUnarchive).toBeCalledTimes(2);
     });
 
@@ -882,6 +825,8 @@ describe('content-item unarchive command', () => {
 
   describe('filterContentItems tests', () => {
     it('should filter content items', async () => {
+      const { contentItems } = mockValues();
+
       const result = await filterContentItems({
         contentItems
       });
@@ -893,6 +838,8 @@ describe('content-item unarchive command', () => {
     });
 
     it('should filter content items by content type', async () => {
+      const { contentItems } = mockValues();
+
       const result = await filterContentItems({
         contentItems,
         contentType: '/test.com/'
@@ -905,6 +852,8 @@ describe('content-item unarchive command', () => {
     });
 
     it('should filter content items by content types', async () => {
+      const { contentItems } = mockValues();
+
       const result = await filterContentItems({
         contentItems,
         contentType: ['/test.com/', '/test1.com/']
@@ -917,6 +866,8 @@ describe('content-item unarchive command', () => {
     });
 
     it('should filter content items by name', async () => {
+      const { contentItems } = mockValues();
+
       const result = await filterContentItems({
         contentItems,
         name: ['/item1/']
@@ -932,6 +883,8 @@ describe('content-item unarchive command', () => {
 
   describe('processItems tests', () => {
     it('should unarchive content items', async () => {
+      const { contentItems, mockUnarchive } = mockValues();
+
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (readline as any).setResponses(['y']);
 
@@ -942,7 +895,7 @@ describe('content-item unarchive command', () => {
         logFile: './logFile.log'
       });
 
-      expect(unarchiveMockFunc).toBeCalledTimes(2);
+      expect(mockUnarchive).toBeCalledTimes(2);
 
       if (await promisify(exists)('./logFile.log')) {
         await promisify(unlink)('./logFile.log');

--- a/src/commands/content-item/unarchive.ts
+++ b/src/commands/content-item/unarchive.ts
@@ -89,17 +89,35 @@ export const filterContentItems = async ({
 
     if (revertLog != null) {
       const log = await new ArchiveLog().loadFromFile(revertLog);
-      const ids = log.getData('ARCHIVE');
-      const contentItemsFiltered = contentItems.filter(contentItem => ids.indexOf(contentItem.id || '') != -1);
-      if (contentItems.length != ids.length) {
+      const archived = log.getData('ARCHIVE');
+      const items = archived.map(args => args.split(' '));
+
+      // The archive actions may include delivery keys that were removed.
+      // Add these back to the content item, which will cause the unarchive to assign them later.
+      const contentItemsFiltered = contentItems
+        .map(contentItem => {
+          const entry = items.find(item => item[0] === contentItem.id || '');
+          if (entry) {
+            contentItem.body._meta.deliveryKey = entry[1];
+            return contentItem;
+          } else {
+            return null;
+          }
+        })
+        .filter(contentItem => !!contentItem);
+
+      if (contentItemsFiltered.length != archived.length) {
         missingContent = true;
       }
 
       return {
-        contentItems: contentItemsFiltered,
+        contentItems: contentItemsFiltered as ContentItem[],
         missingContent
       };
     }
+
+    // Delete the delivery keys, as the unarchive will attempt to reassign them if present.
+    contentItems.forEach(item => delete item.body._meta.deliveryKey);
 
     if (name != null) {
       const itemsArray: string[] = Array.isArray(name) ? name : [name];
@@ -181,14 +199,15 @@ export const getContentItems = async ({
     folderId != null
       ? await Promise.all(
           folders.map(async source => {
-            const items = await paginator(source.related.contentItems.list);
+            const items = await paginator(source.related.contentItems.list, { status: 'ARCHIVED' });
 
-            contentItems.push(...items.filter(item => item.status == 'ACTIVE'));
+            contentItems.push(...items.filter(item => item.status !== 'ACTIVE'));
           })
         )
       : await Promise.all(
           contentRepositories.map(async source => {
-            const items = await paginator(source.related.contentItems.list, { status: 'ACTIVE' });
+            const items = await paginator(source.related.contentItems.list, { status: 'ARCHIVED' });
+
             contentItems.push(...items);
           })
         );
@@ -256,7 +275,14 @@ export const processItems = async ({
 
   for (let i = 0; i < contentItems.length; i++) {
     try {
-      await contentItems[i].related.unarchive();
+      const deliveryKey = contentItems[i].body._meta.deliveryKey;
+      contentItems[i] = await contentItems[i].related.unarchive();
+
+      if (contentItems[i].body._meta.deliveryKey != deliveryKey) {
+        // Restore the delivery key if present. (only on ARCHIVE revert)
+        contentItems[i].body._meta.deliveryKey = deliveryKey;
+        await contentItems[i].related.update(contentItems[i]);
+      }
 
       log.addAction('UNARCHIVE', `${contentItems[i].id}\n`);
       successCount++;
@@ -284,7 +310,7 @@ export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationPa
   const { id, logFile, force, silent, ignoreError, hubId, revertLog, repoId, folderId, name, contentType } = argv;
   const client = dynamicContentClientFactory(argv);
 
-  const allContent = !id && !name && !contentType && !revertLog;
+  const allContent = !id && !name && !contentType && !revertLog && !folderId && !repoId;
 
   if (repoId && id) {
     console.log('ID of content item is specified, ignoring repository ID');

--- a/src/commands/content-item/unarchive.ts
+++ b/src/commands/content-item/unarchive.ts
@@ -201,7 +201,7 @@ export const getContentItems = async ({
           folders.map(async source => {
             const items = await paginator(source.related.contentItems.list, { status: 'ARCHIVED' });
 
-            contentItems.push(...items.filter(item => item.status !== 'ACTIVE'));
+            contentItems.push(...items);
           })
         )
       : await Promise.all(

--- a/src/commands/content-type-schema/archive.ts
+++ b/src/commands/content-type-schema/archive.ts
@@ -141,7 +141,7 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
     try {
       await schemas[i].related.archive();
 
-      log.addAction('ARCHIVE', `${schemas[i].schemaId}\n`);
+      log.addAction('ARCHIVE', `${schemas[i].schemaId}`);
       successCount++;
     } catch (e) {
       log.addComment(`ARCHIVE FAILED: ${schemas[i].schemaId}`);

--- a/src/commands/content-type-schema/archive.ts
+++ b/src/commands/content-type-schema/archive.ts
@@ -7,7 +7,7 @@ import paginator from '../../common/dc-management-sdk-js/paginator';
 import { equalsOrRegex } from '../../common/filter/filter';
 import { confirmArchive } from '../../common/archive/archive-helpers';
 import ArchiveOptions from '../../common/archive/archive-options';
-import { getDefaultLogPath } from '../../common/log-helpers';
+import { createLog, getDefaultLogPath } from '../../common/log-helpers';
 import { FileLog } from '../../common/file-log';
 
 export const command = 'archive [id]';
@@ -16,6 +16,8 @@ export const desc = 'Archive Content Type Schemas';
 
 export const LOG_FILENAME = (platform: string = process.platform): string =>
   getDefaultLogPath('schema', 'archive', platform);
+
+export const coerceLog = (logFile: string): FileLog => createLog(logFile, 'Content Type Schema Archive Log');
 
 export const builder = (yargs: Argv): void => {
   yargs
@@ -55,7 +57,8 @@ export const builder = (yargs: Argv): void => {
     .option('logFile', {
       type: 'string',
       default: LOG_FILENAME,
-      describe: 'Path to a log file to write to.'
+      describe: 'Path to a log file to write to.',
+      coerce: coerceLog
     });
 };
 
@@ -132,8 +135,7 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
     }
   }
 
-  const timestamp = Date.now().toString();
-  const log = logFile instanceof FileLog ? logFile : new ArchiveLog(`Content Type Schema Archive Log - ${timestamp}\n`);
+  const log = logFile.open();
 
   let successCount = 0;
 
@@ -156,9 +158,7 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
     }
   }
 
-  if (!silent && typeof logFile === 'string') {
-    await log.writeToFile(logFile.replace('<DATE>', timestamp));
-  }
+  await log.close(!silent);
 
   console.log(`Archived ${successCount} content type schemas.`);
 };

--- a/src/commands/content-type-schema/archive.ts
+++ b/src/commands/content-type-schema/archive.ts
@@ -8,6 +8,7 @@ import { equalsOrRegex } from '../../common/filter/filter';
 import { confirmArchive } from '../../common/archive/archive-helpers';
 import ArchiveOptions from '../../common/archive/archive-options';
 import { getDefaultLogPath } from '../../common/log-helpers';
+import { FileLog } from '../../common/file-log';
 
 export const command = 'archive [id]';
 
@@ -132,8 +133,7 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
   }
 
   const timestamp = Date.now().toString();
-  const log =
-    typeof logFile === 'object' ? logFile : new ArchiveLog(`Content Type Schema Archive Log - ${timestamp}\n`);
+  const log = logFile instanceof FileLog ? logFile : new ArchiveLog(`Content Type Schema Archive Log - ${timestamp}\n`);
 
   let successCount = 0;
 

--- a/src/commands/content-type-schema/archive.ts
+++ b/src/commands/content-type-schema/archive.ts
@@ -132,7 +132,8 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
   }
 
   const timestamp = Date.now().toString();
-  const log = new ArchiveLog(`Content Type Schema Archive Log - ${timestamp}\n`);
+  const log =
+    typeof logFile === 'object' ? logFile : new ArchiveLog(`Content Type Schema Archive Log - ${timestamp}\n`);
 
   let successCount = 0;
 
@@ -155,7 +156,7 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
     }
   }
 
-  if (!silent && logFile) {
+  if (!silent && typeof logFile === 'string') {
     await log.writeToFile(logFile.replace('<DATE>', timestamp));
   }
 

--- a/src/commands/content-type/archive.ts
+++ b/src/commands/content-type/archive.ts
@@ -9,6 +9,7 @@ import { equalsOrRegex } from '../../common/filter/filter';
 import { confirmArchive } from '../../common/archive/archive-helpers';
 import ArchiveOptions from '../../common/archive/archive-options';
 import { getDefaultLogPath } from '../../common/log-helpers';
+import { FileLog } from '../../common/file-log';
 
 export const command = 'archive [id]';
 
@@ -135,7 +136,7 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
 
   const timestamp = Date.now().toString();
 
-  const log = typeof logFile === 'object' ? logFile : new ArchiveLog(`Content Type Archive Log - ${timestamp}\n`);
+  const log = logFile instanceof FileLog ? logFile : new ArchiveLog(`Content Type Archive Log - ${timestamp}\n`);
 
   let successCount = 0;
 

--- a/src/commands/content-type/archive.ts
+++ b/src/commands/content-type/archive.ts
@@ -8,7 +8,7 @@ import { equalsOrRegex } from '../../common/filter/filter';
 
 import { confirmArchive } from '../../common/archive/archive-helpers';
 import ArchiveOptions from '../../common/archive/archive-options';
-import { getDefaultLogPath } from '../../common/log-helpers';
+import { createLog, getDefaultLogPath } from '../../common/log-helpers';
 import { FileLog } from '../../common/file-log';
 
 export const command = 'archive [id]';
@@ -17,6 +17,8 @@ export const desc = 'Archive Content Types';
 
 export const LOG_FILENAME = (platform: string = process.platform): string =>
   getDefaultLogPath('type', 'archive', platform);
+
+export const coerceLog = (logFile: string): FileLog => createLog(logFile, 'Content Type Archive Log');
 
 export const builder = (yargs: Argv): void => {
   yargs
@@ -56,7 +58,8 @@ export const builder = (yargs: Argv): void => {
     .option('logFile', {
       type: 'string',
       default: LOG_FILENAME,
-      describe: 'Path to a log file to write to.'
+      describe: 'Path to a log file to write to.',
+      coerce: coerceLog
     });
 };
 
@@ -134,9 +137,7 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
     }
   }
 
-  const timestamp = Date.now().toString();
-
-  const log = logFile instanceof FileLog ? logFile : new ArchiveLog(`Content Type Archive Log - ${timestamp}\n`);
+  const log = logFile.open();
 
   let successCount = 0;
 
@@ -161,9 +162,7 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
     }
   }
 
-  if (!silent && typeof logFile === 'string') {
-    await log.writeToFile(logFile.replace('<DATE>', timestamp));
-  }
+  await log.close(!silent);
 
   console.log(`Archived ${successCount} content types.`);
 };

--- a/src/commands/content-type/archive.ts
+++ b/src/commands/content-type/archive.ts
@@ -135,7 +135,7 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
 
   const timestamp = Date.now().toString();
 
-  const log = new ArchiveLog(`Content Type Archive Log - ${timestamp}\n`);
+  const log = typeof logFile === 'object' ? logFile : new ArchiveLog(`Content Type Archive Log - ${timestamp}\n`);
 
   let successCount = 0;
 
@@ -160,7 +160,7 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
     }
   }
 
-  if (!silent && logFile) {
+  if (!silent && typeof logFile === 'string') {
     await log.writeToFile(logFile.replace('<DATE>', timestamp));
   }
 

--- a/src/commands/event/archive.spec.ts
+++ b/src/commands/event/archive.spec.ts
@@ -1,4 +1,4 @@
-import { builder, command, handler, LOG_FILENAME, getEvents } from './archive';
+import { builder, command, handler, LOG_FILENAME, getEvents, coerceLog } from './archive';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
 import { Event, Edition, Hub } from 'dc-management-sdk-js';
 import Yargs from 'yargs/yargs';
@@ -6,6 +6,7 @@ import readline from 'readline';
 import MockPage from '../../common/dc-management-sdk-js/mock-page';
 import { promisify } from 'util';
 import { exists, readFile, unlink } from 'fs';
+import { FileLog } from '../../common/file-log';
 
 jest.mock('readline');
 
@@ -24,7 +25,8 @@ describe('event archive command', () => {
   const config = {
     clientId: 'client-id',
     clientSecret: 'client-id',
-    hubId: 'hub-id'
+    hubId: 'hub-id',
+    logFile: new FileLog()
   };
 
   it('should command should defined', function() {
@@ -65,8 +67,16 @@ describe('event archive command', () => {
       expect(spyOption).toHaveBeenCalledWith('logFile', {
         type: 'string',
         default: LOG_FILENAME,
-        describe: 'Path to a log file to write to.'
+        describe: 'Path to a log file to write to.',
+        coerce: coerceLog
       });
+    });
+
+    it('should generate a log with coerceLog with the appropriate title', function() {
+      const logFile = coerceLog('filename.log');
+
+      expect(logFile).toEqual(expect.any(FileLog));
+      expect(logFile.title).toMatch(/^Events Archive Log \- ./);
     });
   });
 
@@ -554,7 +564,7 @@ describe('event archive command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        logFile,
+        logFile: new FileLog(logFile),
         silent: false,
         id: '1'
       };
@@ -637,7 +647,7 @@ describe('event archive command', () => {
         ...yargArgs,
         ...config,
         silent: false,
-        logFile: 'temp/event-archive.log',
+        logFile: new FileLog('temp/event-archive.log'),
         id: '1'
       };
 

--- a/src/commands/event/archive.ts
+++ b/src/commands/event/archive.ts
@@ -205,7 +205,7 @@ export const processItems = async ({
     }
 
     const timestamp = Date.now().toString();
-    const log = typeof logFile === 'object' ? logFile : new ArchiveLog(`Events Archive Log - ${timestamp}\n`);
+    const log = logFile instanceof FileLog ? logFile : new ArchiveLog(`Events Archive Log - ${timestamp}\n`);
 
     let successCount = 0;
 

--- a/src/commands/event/archive.ts
+++ b/src/commands/event/archive.ts
@@ -8,6 +8,7 @@ import ArchiveOptions from '../../common/archive/archive-options';
 import { Edition, Event, DynamicContent } from 'dc-management-sdk-js';
 import { equalsOrRegex } from '../../common/filter/filter';
 import { getDefaultLogPath } from '../../common/log-helpers';
+import { FileLog } from '../../common/file-log';
 const maxAttempts = 30;
 
 export const command = 'archive [id]';
@@ -157,7 +158,7 @@ export const processItems = async ({
   }[];
   force?: boolean;
   silent?: boolean;
-  logFile?: string;
+  logFile?: string | FileLog;
   missingContent: boolean;
   ignoreError?: boolean;
 }): Promise<void> => {
@@ -204,7 +205,7 @@ export const processItems = async ({
     }
 
     const timestamp = Date.now().toString();
-    const log = new ArchiveLog(`Events Archive Log - ${timestamp}\n`);
+    const log = typeof logFile === 'object' ? logFile : new ArchiveLog(`Events Archive Log - ${timestamp}\n`);
 
     let successCount = 0;
 
@@ -245,7 +246,7 @@ export const processItems = async ({
       }
     }
 
-    if (!silent && logFile) {
+    if (!silent && typeof logFile === 'string') {
       await log.writeToFile(logFile.replace('<DATE>', timestamp));
     }
 

--- a/src/commands/hub.ts
+++ b/src/commands/hub.ts
@@ -1,0 +1,12 @@
+import { Argv } from 'yargs';
+import YargsCommandBuilderOptions from '../common/yargs/yargs-command-builder-options';
+
+export const command = 'hub';
+
+export const desc = 'Hub';
+
+export const builder = (yargs: Argv): Argv =>
+  yargs
+    .commandDir('hub', YargsCommandBuilderOptions)
+    .demandCommand()
+    .help();

--- a/src/commands/hub/clean.spec.ts
+++ b/src/commands/hub/clean.spec.ts
@@ -1,0 +1,227 @@
+import { builder, command, handler, LOG_FILENAME } from './clean';
+import { getDefaultLogPath } from '../../common/log-helpers';
+import Yargs from 'yargs/yargs';
+
+import * as content from './steps/content-clean-step';
+import * as schema from './steps/schema-clean-step';
+import * as type from './steps/type-clean-step';
+
+import rmdir from 'rimraf';
+import { ConfigurationParameters } from '../configure';
+import { Arguments } from 'yargs';
+import { FileLog } from '../../common/file-log';
+import { CleanHubBuilderOptions } from '../../interfaces/clean-hub-builder-options';
+
+jest.mock('readline');
+
+jest.mock('../../services/dynamic-content-client-factory');
+
+let success = [true, true, true, true];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function succeedOrFail(mock: any, succeed: () => boolean): jest.Mock {
+  mock.mockImplementation(() => Promise.resolve(succeed()));
+  return mock;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function mockStep(name: string, success: () => boolean): any {
+  return jest.fn().mockImplementation(() => ({
+    run: succeedOrFail(jest.fn(), success),
+    revert: succeedOrFail(jest.fn(), success),
+    getName: jest.fn().mockReturnValue(name)
+  }));
+}
+
+jest.mock('./steps/content-clean-step', () => ({ ContentCleanStep: mockStep('Clean Content', () => success[0]) }));
+jest.mock('./steps/type-clean-step', () => ({ TypeCleanStep: mockStep('Clean Content Types', () => success[1]) }));
+jest.mock('./steps/schema-clean-step', () => ({
+  SchemaCleanStep: mockStep('Clean Content Type Schemas', () => success[2])
+}));
+
+jest.mock('../../common/log-helpers', () => ({
+  ...jest.requireActual('../../common/log-helpers'),
+  getDefaultLogPath: jest.fn()
+}));
+
+function rimraf(dir: string): Promise<Error> {
+  return new Promise((resolve): void => {
+    rmdir(dir, resolve);
+  });
+}
+
+function getMocks(): jest.Mock[] {
+  return [content.ContentCleanStep as jest.Mock, type.TypeCleanStep as jest.Mock, schema.SchemaCleanStep as jest.Mock];
+}
+
+function clearMocks(): void {
+  const mocks = getMocks();
+
+  mocks.forEach(mock => {
+    mock.mock.results.forEach(obj => {
+      const instance = obj.value;
+      (instance.run as jest.Mock).mockClear();
+      (instance.revert as jest.Mock).mockClear();
+    });
+  });
+}
+
+describe('hub clean command', () => {
+  afterEach((): void => {
+    jest.restoreAllMocks();
+  });
+
+  it('should command should defined', function() {
+    expect(command).toEqual('clean');
+  });
+
+  it('should use getDefaultLogPath for LOG_FILENAME with process.platform as default', function() {
+    LOG_FILENAME();
+
+    expect(getDefaultLogPath).toHaveBeenCalledWith('hub', 'clean', process.platform);
+  });
+
+  describe('builder tests', function() {
+    it('should configure yargs', function() {
+      const argv = Yargs(process.argv.slice(2));
+      const spyPositional = jest.spyOn(argv, 'positional').mockReturnThis();
+      const spyOption = jest.spyOn(argv, 'option').mockReturnThis();
+
+      builder(argv);
+
+      expect(spyPositional).not.toHaveBeenCalled();
+
+      expect(spyOption).toHaveBeenCalledWith('f', {
+        type: 'boolean',
+        boolean: true,
+        describe:
+          'Overwrite content, create and assign content types, and ignore content with missing types/references without asking.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('logFile', {
+        type: 'string',
+        default: LOG_FILENAME,
+        describe: 'Path to a log file to write to.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('step', {
+        type: 'number',
+        describe: 'Start at a numbered step. 0: Schema, 1: Type, 2: Content'
+      });
+    });
+  });
+
+  describe('handler tests', function() {
+    const yargArgs = {
+      $0: 'test',
+      _: ['test']
+    };
+
+    const config = {
+      clientId: 'client-id',
+      clientSecret: 'client-id',
+      hubId: 'hub-id'
+    };
+
+    beforeAll(async () => {
+      await rimraf('temp/clean/');
+    });
+
+    afterAll(async () => {
+      await rimraf('temp/clean/');
+    });
+
+    it('should call all steps in order with given parameters', async () => {
+      clearMocks();
+      success = [true, true, true, true];
+
+      const argv: Arguments<CleanHubBuilderOptions & ConfigurationParameters> = {
+        ...yargArgs,
+        ...config,
+
+        logFile: 'temp/clean/steps/all.log',
+        force: true
+      };
+
+      await handler(argv);
+
+      argv.logFile = expect.any(FileLog);
+
+      const mocks = getMocks();
+
+      mocks.forEach(mock => {
+        const instance = mock.mock.results[0].value;
+
+        expect(instance.run).toHaveBeenCalledWith(argv);
+      });
+
+      const loadLog = new FileLog();
+      await loadLog.loadFromFile('temp/clean/steps/all.log');
+    });
+
+    it('should handle false returns from each of the steps by stopping the process', async () => {
+      for (let i = 0; i < 3; i++) {
+        clearMocks();
+        success = [i != 0, i != 1, i != 2];
+
+        const argv: Arguments<CleanHubBuilderOptions & ConfigurationParameters> = {
+          ...yargArgs,
+          ...config,
+
+          logFile: 'temp/clean/steps/fail' + i + '.log',
+          force: true
+        };
+
+        await handler(argv);
+
+        const mocks = getMocks();
+
+        mocks.forEach((mock, index) => {
+          const instance = mock.mock.results[0].value;
+
+          if (index > i) {
+            expect(instance.run).not.toHaveBeenCalled();
+          } else {
+            expect(instance.run).toHaveBeenCalledWith(argv);
+          }
+        });
+
+        const loadLog = new FileLog();
+        await loadLog.loadFromFile('temp/clean/steps/fail' + i + '.log');
+      }
+    });
+
+    it('should start from the step given as a parameter', async () => {
+      for (let i = 0; i < 3; i++) {
+        clearMocks();
+        success = [true, true, true];
+
+        const argv: Arguments<CleanHubBuilderOptions & ConfigurationParameters> = {
+          ...yargArgs,
+          ...config,
+
+          step: i,
+          logFile: 'temp/clean/steps/step' + i + '.log',
+          force: true
+        };
+
+        await handler(argv);
+
+        const mocks = getMocks();
+
+        mocks.forEach((mock, index) => {
+          const instance = mock.mock.results[0].value;
+
+          if (index < i) {
+            expect(instance.run).not.toHaveBeenCalled();
+          } else {
+            expect(instance.run).toHaveBeenCalledWith(argv);
+          }
+        });
+
+        const loadLog = new FileLog();
+        await loadLog.loadFromFile('temp/clean/steps/step' + i + '.log');
+      }
+    });
+  });
+});

--- a/src/commands/hub/clean.spec.ts
+++ b/src/commands/hub/clean.spec.ts
@@ -1,5 +1,5 @@
 import { builder, command, handler, LOG_FILENAME } from './clean';
-import { getDefaultLogPath } from '../../common/log-helpers';
+import { createLog, getDefaultLogPath } from '../../common/log-helpers';
 import Yargs from 'yargs/yargs';
 
 import * as content from './steps/content-clean-step';
@@ -101,7 +101,8 @@ describe('hub clean command', () => {
       expect(spyOption).toHaveBeenCalledWith('logFile', {
         type: 'string',
         default: LOG_FILENAME,
-        describe: 'Path to a log file to write to.'
+        describe: 'Path to a log file to write to.',
+        coerce: createLog
       });
 
       expect(spyOption).toHaveBeenCalledWith('step', {
@@ -139,7 +140,7 @@ describe('hub clean command', () => {
         ...yargArgs,
         ...config,
 
-        logFile: 'temp/clean/steps/all.log',
+        logFile: createLog('temp/clean/steps/all.log'),
         force: true
       };
 
@@ -168,7 +169,7 @@ describe('hub clean command', () => {
           ...yargArgs,
           ...config,
 
-          logFile: 'temp/clean/steps/fail' + i + '.log',
+          logFile: createLog('temp/clean/steps/fail' + i + '.log'),
           force: true
         };
 
@@ -201,7 +202,7 @@ describe('hub clean command', () => {
           ...config,
 
           step: i,
-          logFile: 'temp/clean/steps/step' + i + '.log',
+          logFile: createLog('temp/clean/steps/step' + i + '.log'),
           force: true
         };
 

--- a/src/commands/hub/clean.ts
+++ b/src/commands/hub/clean.ts
@@ -43,7 +43,7 @@ const steps = [new ContentCleanStep(), new TypeCleanStep(), new SchemaCleanStep(
 
 export const handler = async (argv: Arguments<CleanHubBuilderOptions & ConfigurationParameters>): Promise<void> => {
   const logFile = argv.logFile;
-  const log = typeof logFile === 'string' || logFile == null ? new FileLog(logFile) : logFile;
+  const log = logFile instanceof FileLog ? logFile : new FileLog(logFile);
 
   argv.logFile = log;
 
@@ -68,7 +68,7 @@ export const handler = async (argv: Arguments<CleanHubBuilderOptions & Configura
     }
   }
 
-  if (typeof logFile !== 'object') {
+  if (!(logFile instanceof FileLog)) {
     await log.close();
   }
 };

--- a/src/commands/hub/clean.ts
+++ b/src/commands/hub/clean.ts
@@ -1,0 +1,73 @@
+import { getDefaultLogPath } from '../../common/log-helpers';
+import { Argv, Arguments } from 'yargs';
+import { ConfigurationParameters } from '../configure';
+
+import { FileLog } from '../../common/file-log';
+
+import { CleanHubBuilderOptions } from '../../interfaces/clean-hub-builder-options';
+import { SchemaCleanStep } from './steps/schema-clean-step';
+import { TypeCleanStep } from './steps/type-clean-step';
+import { ContentCleanStep } from './steps/content-clean-step';
+
+export const command = 'clean';
+
+export const desc =
+  'Cleans an entire hub. This will archive all content items, types and schemas. Note that these are not fully deleted, but they can be resurrected by a future import.';
+
+export const LOG_FILENAME = (platform: string = process.platform): string =>
+  getDefaultLogPath('hub', 'clean', platform);
+
+export const builder = (yargs: Argv): void => {
+  yargs
+    .alias('f', 'force')
+    .option('f', {
+      type: 'boolean',
+      boolean: true,
+      describe:
+        'Overwrite content, create and assign content types, and ignore content with missing types/references without asking.'
+    })
+
+    .option('logFile', {
+      type: 'string',
+      default: LOG_FILENAME,
+      describe: 'Path to a log file to write to.'
+    })
+
+    .option('step', {
+      type: 'number',
+      describe: 'Start at a numbered step. 0: Schema, 1: Type, 2: Content'
+    });
+};
+
+const steps = [new ContentCleanStep(), new TypeCleanStep(), new SchemaCleanStep()];
+
+export const handler = async (argv: Arguments<CleanHubBuilderOptions & ConfigurationParameters>): Promise<void> => {
+  const logFile = argv.logFile;
+  const log = typeof logFile === 'string' || logFile == null ? new FileLog(logFile) : logFile;
+
+  argv.logFile = log;
+
+  // Steps system: Each step performs another part of the clean command.
+  // If a step fails, we can return to that step on a future attempt.
+
+  for (let i = argv.step || 0; i < steps.length; i++) {
+    const step = steps[i];
+
+    log.appendLine(`=== Running Step ${i} - ${step.getName()} ===`);
+
+    const success = await step.run(argv);
+
+    if (!success) {
+      log.appendLine(`Step ${i} (${step.getName()}) Failed. Terminating.`);
+      log.appendLine('');
+      log.appendLine('To continue the clean from this point, use the option:');
+      log.appendLine(`--step ${i}`);
+
+      break;
+    }
+  }
+
+  if (typeof logFile !== 'object') {
+    await log.close();
+  }
+};

--- a/src/commands/hub/clean.ts
+++ b/src/commands/hub/clean.ts
@@ -53,6 +53,7 @@ export const handler = async (argv: Arguments<CleanHubBuilderOptions & Configura
   for (let i = argv.step || 0; i < steps.length; i++) {
     const step = steps[i];
 
+    log.switchGroup(step.getName());
     log.appendLine(`=== Running Step ${i} - ${step.getName()} ===`);
 
     const success = await step.run(argv);

--- a/src/commands/hub/clean.ts
+++ b/src/commands/hub/clean.ts
@@ -1,8 +1,6 @@
-import { getDefaultLogPath } from '../../common/log-helpers';
+import { createLog, getDefaultLogPath } from '../../common/log-helpers';
 import { Argv, Arguments } from 'yargs';
 import { ConfigurationParameters } from '../configure';
-
-import { FileLog } from '../../common/file-log';
 
 import { CleanHubBuilderOptions } from '../../interfaces/clean-hub-builder-options';
 import { SchemaCleanStep } from './steps/schema-clean-step';
@@ -30,7 +28,8 @@ export const builder = (yargs: Argv): void => {
     .option('logFile', {
       type: 'string',
       default: LOG_FILENAME,
-      describe: 'Path to a log file to write to.'
+      describe: 'Path to a log file to write to.',
+      coerce: createLog
     })
 
     .option('step', {
@@ -42,8 +41,7 @@ export const builder = (yargs: Argv): void => {
 const steps = [new ContentCleanStep(), new TypeCleanStep(), new SchemaCleanStep()];
 
 export const handler = async (argv: Arguments<CleanHubBuilderOptions & ConfigurationParameters>): Promise<void> => {
-  const logFile = argv.logFile;
-  const log = logFile instanceof FileLog ? logFile : new FileLog(logFile);
+  const log = argv.logFile.open();
 
   argv.logFile = log;
 
@@ -68,7 +66,5 @@ export const handler = async (argv: Arguments<CleanHubBuilderOptions & Configura
     }
   }
 
-  if (!(logFile instanceof FileLog)) {
-    await log.close();
-  }
+  await log.close();
 };

--- a/src/commands/hub/clean.ts
+++ b/src/commands/hub/clean.ts
@@ -1,5 +1,5 @@
 import { createLog, getDefaultLogPath } from '../../common/log-helpers';
-import { Argv, Arguments, choices } from 'yargs';
+import { Argv, Arguments } from 'yargs';
 import { ConfigurationParameters } from '../configure';
 
 import { CleanHubBuilderOptions } from '../../interfaces/clean-hub-builder-options';

--- a/src/commands/hub/model/clean-hub-step.ts
+++ b/src/commands/hub/model/clean-hub-step.ts
@@ -1,0 +1,8 @@
+import { Arguments } from 'yargs';
+import { CleanHubBuilderOptions } from '../../../interfaces/clean-hub-builder-options';
+import { ConfigurationParameters } from '../../configure';
+
+export interface CleanHubStep {
+  getName(): string;
+  run(argv: Arguments<CleanHubBuilderOptions & ConfigurationParameters>): Promise<boolean>;
+}

--- a/src/commands/hub/model/clean-hub-step.ts
+++ b/src/commands/hub/model/clean-hub-step.ts
@@ -2,7 +2,14 @@ import { Arguments } from 'yargs';
 import { CleanHubBuilderOptions } from '../../../interfaces/clean-hub-builder-options';
 import { ConfigurationParameters } from '../../configure';
 
+export enum CleanHubStepId {
+  Content = 'content',
+  Type = 'type',
+  Schema = 'schema'
+}
+
 export interface CleanHubStep {
+  getId(): CleanHubStepId;
   getName(): string;
   run(argv: Arguments<CleanHubBuilderOptions & ConfigurationParameters>): Promise<boolean>;
 }

--- a/src/commands/hub/steps/content-clean-step.spec.ts
+++ b/src/commands/hub/steps/content-clean-step.spec.ts
@@ -1,0 +1,77 @@
+import { Arguments } from 'yargs';
+import { FileLog } from '../../../common/file-log';
+import { CleanHubBuilderOptions } from '../../../interfaces/clean-hub-builder-options';
+import { ConfigurationParameters } from '../../configure';
+import { join } from 'path';
+
+import * as archive from '../../content-item/archive';
+
+import { ContentCleanStep } from './content-clean-step';
+
+jest.mock('../../../services/dynamic-content-client-factory');
+jest.mock('../../content-item/archive');
+
+describe('content clean step', () => {
+  const yargArgs = {
+    $0: 'test',
+    _: ['test']
+  };
+
+  const config = {
+    clientId: 'client-id',
+    clientSecret: 'client-id',
+    hubId: 'hub-id'
+  };
+
+  function reset(): void {
+    jest.resetAllMocks();
+  }
+
+  beforeEach(async () => {
+    reset();
+  });
+
+  function generateState(
+    directory: string,
+    logName: string
+  ): Arguments<CleanHubBuilderOptions & ConfigurationParameters> {
+    return {
+      ...yargArgs,
+      ...config,
+
+      logFile: new FileLog(join(directory, logName + '.log'))
+    };
+  }
+
+  it('should have the name "Clean Content"', () => {
+    const step = new ContentCleanStep();
+    expect(step.getName()).toEqual('Clean Content');
+  });
+
+  it('should call the copy command with arguments from the state', async () => {
+    const argv = generateState('temp/clean-content/run/', 'run');
+
+    (archive.handler as jest.Mock).mockResolvedValue(true);
+
+    const step = new ContentCleanStep();
+    const result = await step.run(argv);
+
+    expect(archive.handler).toHaveBeenCalledWith({
+      ...argv
+    });
+
+    expect(result).toBeTruthy();
+  });
+
+  it('should return false when the copy command fails', async () => {
+    const argv = generateState('temp/clean-content/fail/', 'fail');
+
+    (archive.handler as jest.Mock).mockRejectedValue(false);
+
+    const step = new ContentCleanStep();
+    const result = await step.run(argv);
+
+    expect(archive.handler).toHaveBeenCalled();
+    expect(result).toBeFalsy();
+  });
+});

--- a/src/commands/hub/steps/content-clean-step.spec.ts
+++ b/src/commands/hub/steps/content-clean-step.spec.ts
@@ -7,6 +7,7 @@ import { join } from 'path';
 import * as archive from '../../content-item/archive';
 
 import { ContentCleanStep } from './content-clean-step';
+import { CleanHubStepId } from '../model/clean-hub-step';
 
 jest.mock('../../../services/dynamic-content-client-factory');
 jest.mock('../../content-item/archive');
@@ -42,6 +43,11 @@ describe('content clean step', () => {
       logFile: new FileLog(join(directory, logName + '.log'))
     };
   }
+
+  it('should have the id "content"', () => {
+    const step = new ContentCleanStep();
+    expect(step.getId()).toEqual(CleanHubStepId.Content);
+  });
 
   it('should have the name "Clean Content"', () => {
     const step = new ContentCleanStep();

--- a/src/commands/hub/steps/content-clean-step.ts
+++ b/src/commands/hub/steps/content-clean-step.ts
@@ -1,0 +1,25 @@
+import { Arguments } from 'yargs';
+import { FileLog } from '../../../common/file-log';
+import { CleanHubBuilderOptions } from '../../../interfaces/clean-hub-builder-options';
+import { ConfigurationParameters } from '../../configure';
+import { handler } from '../../content-item/archive';
+import { CleanHubStep } from '../model/clean-hub-step';
+
+export class ContentCleanStep implements CleanHubStep {
+  getName(): string {
+    return 'Clean Content';
+  }
+
+  async run(argv: Arguments<CleanHubBuilderOptions & ConfigurationParameters>): Promise<boolean> {
+    try {
+      await handler({
+        ...argv
+      });
+    } catch (e) {
+      (argv.logFile as FileLog).appendLine(`ERROR: Could not archive content. \n${e}`);
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/src/commands/hub/steps/content-clean-step.ts
+++ b/src/commands/hub/steps/content-clean-step.ts
@@ -3,9 +3,13 @@ import { FileLog } from '../../../common/file-log';
 import { CleanHubBuilderOptions } from '../../../interfaces/clean-hub-builder-options';
 import { ConfigurationParameters } from '../../configure';
 import { handler } from '../../content-item/archive';
-import { CleanHubStep } from '../model/clean-hub-step';
+import { CleanHubStep, CleanHubStepId } from '../model/clean-hub-step';
 
 export class ContentCleanStep implements CleanHubStep {
+  getId(): CleanHubStepId {
+    return CleanHubStepId.Content;
+  }
+
   getName(): string {
     return 'Clean Content';
   }

--- a/src/commands/hub/steps/schema-clean-step.spec.ts
+++ b/src/commands/hub/steps/schema-clean-step.spec.ts
@@ -1,0 +1,77 @@
+import { Arguments } from 'yargs';
+import { FileLog } from '../../../common/file-log';
+import { CleanHubBuilderOptions } from '../../../interfaces/clean-hub-builder-options';
+import { ConfigurationParameters } from '../../configure';
+import { join } from 'path';
+
+import * as archive from '../../content-type-schema/archive';
+
+import { SchemaCleanStep } from './schema-clean-step';
+
+jest.mock('../../../services/dynamic-content-client-factory');
+jest.mock('../../content-type-schema/archive');
+
+describe('schema clean step', () => {
+  const yargArgs = {
+    $0: 'test',
+    _: ['test']
+  };
+
+  const config = {
+    clientId: 'client-id',
+    clientSecret: 'client-id',
+    hubId: 'hub-id'
+  };
+
+  function reset(): void {
+    jest.resetAllMocks();
+  }
+
+  beforeEach(async () => {
+    reset();
+  });
+
+  function generateState(
+    directory: string,
+    logName: string
+  ): Arguments<CleanHubBuilderOptions & ConfigurationParameters> {
+    return {
+      ...yargArgs,
+      ...config,
+
+      logFile: new FileLog(join(directory, logName + '.log'))
+    };
+  }
+
+  it('should have the name "Clean Content Type Schemas"', () => {
+    const step = new SchemaCleanStep();
+    expect(step.getName()).toEqual('Clean Content Type Schemas');
+  });
+
+  it('should call the copy command with arguments from the state', async () => {
+    const argv = generateState('temp/clean-schema/run/', 'run');
+
+    (archive.handler as jest.Mock).mockResolvedValue(true);
+
+    const step = new SchemaCleanStep();
+    const result = await step.run(argv);
+
+    expect(archive.handler).toHaveBeenCalledWith({
+      ...argv
+    });
+
+    expect(result).toBeTruthy();
+  });
+
+  it('should return false when the copy command fails', async () => {
+    const argv = generateState('temp/clean-schema/fail/', 'fail');
+
+    (archive.handler as jest.Mock).mockRejectedValue(false);
+
+    const step = new SchemaCleanStep();
+    const result = await step.run(argv);
+
+    expect(archive.handler).toHaveBeenCalled();
+    expect(result).toBeFalsy();
+  });
+});

--- a/src/commands/hub/steps/schema-clean-step.spec.ts
+++ b/src/commands/hub/steps/schema-clean-step.spec.ts
@@ -7,6 +7,7 @@ import { join } from 'path';
 import * as archive from '../../content-type-schema/archive';
 
 import { SchemaCleanStep } from './schema-clean-step';
+import { CleanHubStepId } from '../model/clean-hub-step';
 
 jest.mock('../../../services/dynamic-content-client-factory');
 jest.mock('../../content-type-schema/archive');
@@ -42,6 +43,11 @@ describe('schema clean step', () => {
       logFile: new FileLog(join(directory, logName + '.log'))
     };
   }
+
+  it('should have the id "schema"', () => {
+    const step = new SchemaCleanStep();
+    expect(step.getId()).toEqual(CleanHubStepId.Schema);
+  });
 
   it('should have the name "Clean Content Type Schemas"', () => {
     const step = new SchemaCleanStep();

--- a/src/commands/hub/steps/schema-clean-step.ts
+++ b/src/commands/hub/steps/schema-clean-step.ts
@@ -1,0 +1,25 @@
+import { Arguments } from 'yargs';
+import { FileLog } from '../../../common/file-log';
+import { CleanHubBuilderOptions } from '../../../interfaces/clean-hub-builder-options';
+import { ConfigurationParameters } from '../../configure';
+import { handler } from '../../content-type-schema/archive';
+import { CleanHubStep } from '../model/clean-hub-step';
+
+export class SchemaCleanStep implements CleanHubStep {
+  getName(): string {
+    return 'Clean Content Type Schemas';
+  }
+
+  async run(argv: Arguments<CleanHubBuilderOptions & ConfigurationParameters>): Promise<boolean> {
+    try {
+      await handler({
+        ...argv
+      });
+    } catch (e) {
+      (argv.logFile as FileLog).appendLine(`ERROR: Could not archive schemas. \n${e}`);
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/src/commands/hub/steps/schema-clean-step.ts
+++ b/src/commands/hub/steps/schema-clean-step.ts
@@ -3,9 +3,13 @@ import { FileLog } from '../../../common/file-log';
 import { CleanHubBuilderOptions } from '../../../interfaces/clean-hub-builder-options';
 import { ConfigurationParameters } from '../../configure';
 import { handler } from '../../content-type-schema/archive';
-import { CleanHubStep } from '../model/clean-hub-step';
+import { CleanHubStep, CleanHubStepId } from '../model/clean-hub-step';
 
 export class SchemaCleanStep implements CleanHubStep {
+  getId(): CleanHubStepId {
+    return CleanHubStepId.Schema;
+  }
+
   getName(): string {
     return 'Clean Content Type Schemas';
   }

--- a/src/commands/hub/steps/type-clean-step.spec.ts
+++ b/src/commands/hub/steps/type-clean-step.spec.ts
@@ -1,0 +1,77 @@
+import { Arguments } from 'yargs';
+import { FileLog } from '../../../common/file-log';
+import { CleanHubBuilderOptions } from '../../../interfaces/clean-hub-builder-options';
+import { ConfigurationParameters } from '../../configure';
+import { join } from 'path';
+
+import * as archive from '../../content-type/archive';
+
+import { TypeCleanStep } from './type-clean-step';
+
+jest.mock('../../../services/dynamic-content-client-factory');
+jest.mock('../../content-type/archive');
+
+describe('type clean step', () => {
+  const yargArgs = {
+    $0: 'test',
+    _: ['test']
+  };
+
+  const config = {
+    clientId: 'client-id',
+    clientSecret: 'client-id',
+    hubId: 'hub-id'
+  };
+
+  function reset(): void {
+    jest.resetAllMocks();
+  }
+
+  beforeEach(async () => {
+    reset();
+  });
+
+  function generateState(
+    directory: string,
+    logName: string
+  ): Arguments<CleanHubBuilderOptions & ConfigurationParameters> {
+    return {
+      ...yargArgs,
+      ...config,
+
+      logFile: new FileLog(join(directory, logName + '.log'))
+    };
+  }
+
+  it('should have the name "Clean Content Types"', () => {
+    const step = new TypeCleanStep();
+    expect(step.getName()).toEqual('Clean Content Types');
+  });
+
+  it('should call the copy command with arguments from the state', async () => {
+    const argv = generateState('temp/clean-schema/run/', 'run');
+
+    (archive.handler as jest.Mock).mockResolvedValue(true);
+
+    const step = new TypeCleanStep();
+    const result = await step.run(argv);
+
+    expect(archive.handler).toHaveBeenCalledWith({
+      ...argv
+    });
+
+    expect(result).toBeTruthy();
+  });
+
+  it('should return false when the copy command fails', async () => {
+    const argv = generateState('temp/clean-schema/fail/', 'fail');
+
+    (archive.handler as jest.Mock).mockRejectedValue(false);
+
+    const step = new TypeCleanStep();
+    const result = await step.run(argv);
+
+    expect(archive.handler).toHaveBeenCalled();
+    expect(result).toBeFalsy();
+  });
+});

--- a/src/commands/hub/steps/type-clean-step.spec.ts
+++ b/src/commands/hub/steps/type-clean-step.spec.ts
@@ -7,6 +7,7 @@ import { join } from 'path';
 import * as archive from '../../content-type/archive';
 
 import { TypeCleanStep } from './type-clean-step';
+import { CleanHubStepId } from '../model/clean-hub-step';
 
 jest.mock('../../../services/dynamic-content-client-factory');
 jest.mock('../../content-type/archive');
@@ -42,6 +43,11 @@ describe('type clean step', () => {
       logFile: new FileLog(join(directory, logName + '.log'))
     };
   }
+
+  it('should have the id "type"', () => {
+    const step = new TypeCleanStep();
+    expect(step.getId()).toEqual(CleanHubStepId.Type);
+  });
 
   it('should have the name "Clean Content Types"', () => {
     const step = new TypeCleanStep();

--- a/src/commands/hub/steps/type-clean-step.ts
+++ b/src/commands/hub/steps/type-clean-step.ts
@@ -1,0 +1,25 @@
+import { Arguments } from 'yargs';
+import { FileLog } from '../../../common/file-log';
+import { CleanHubBuilderOptions } from '../../../interfaces/clean-hub-builder-options';
+import { ConfigurationParameters } from '../../configure';
+import { handler } from '../../content-type/archive';
+import { CleanHubStep } from '../model/clean-hub-step';
+
+export class TypeCleanStep implements CleanHubStep {
+  getName(): string {
+    return 'Clean Content Types';
+  }
+
+  async run(argv: Arguments<CleanHubBuilderOptions & ConfigurationParameters>): Promise<boolean> {
+    try {
+      await handler({
+        ...argv
+      });
+    } catch (e) {
+      (argv.logFile as FileLog).appendLine(`ERROR: Could not archive types. \n${e}`);
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/src/commands/hub/steps/type-clean-step.ts
+++ b/src/commands/hub/steps/type-clean-step.ts
@@ -3,9 +3,13 @@ import { FileLog } from '../../../common/file-log';
 import { CleanHubBuilderOptions } from '../../../interfaces/clean-hub-builder-options';
 import { ConfigurationParameters } from '../../configure';
 import { handler } from '../../content-type/archive';
-import { CleanHubStep } from '../model/clean-hub-step';
+import { CleanHubStep, CleanHubStepId } from '../model/clean-hub-step';
 
 export class TypeCleanStep implements CleanHubStep {
+  getId(): CleanHubStepId {
+    return CleanHubStepId.Type;
+  }
+
   getName(): string {
     return 'Clean Content Types';
   }

--- a/src/common/archive/archive-options.ts
+++ b/src/common/archive/archive-options.ts
@@ -8,7 +8,7 @@ export default interface ArchiveOptions {
   folderId?: string | string[];
   name?: string | string[];
   contentType?: string | string[];
-  logFile?: string | FileLog;
+  logFile: FileLog;
   force?: boolean;
   silent?: boolean;
   ignoreError?: boolean;

--- a/src/common/archive/archive-options.ts
+++ b/src/common/archive/archive-options.ts
@@ -1,3 +1,5 @@
+import { FileLog } from '../file-log';
+
 export default interface ArchiveOptions {
   id?: string;
   schemaId?: string | string[];
@@ -6,7 +8,7 @@ export default interface ArchiveOptions {
   folderId?: string | string[];
   name?: string | string[];
   contentType?: string | string[];
-  logFile?: string;
+  logFile?: string | FileLog;
   force?: boolean;
   silent?: boolean;
   ignoreError?: boolean;

--- a/src/common/content-item/content-dependancy-tree.spec.ts
+++ b/src/common/content-item/content-dependancy-tree.spec.ts
@@ -221,6 +221,25 @@ describe('content-dependancy-tree', () => {
       }
     });
 
+    it('should correctly handle content item bodies with null properties or array items', () => {
+      const bodyWithNullLeaves = dependsOn(['id1']);
+      bodyWithNullLeaves.links.push(null);
+      bodyWithNullLeaves.nullProperty = null;
+
+      const items = createItems([
+        { label: 'id1', body: dependsOn([]), repoId: 'repo1', typeSchemaUri: 'http://type.com' },
+        { label: 'id2', body: bodyWithNullLeaves, repoId: 'repo1', typeSchemaUri: 'http://type.com' }
+      ]);
+
+      const tree = new ContentDependancyTree(items, new ContentMapping());
+
+      expect(tree.levels.length).toEqual(2);
+      expect(tree.circularLinks.length).toEqual(0);
+      expect(tree.all.length).toEqual(2);
+      expect(tree.byId.size).toEqual(2);
+      expect(tree.requiredSchema.length).toEqual(1);
+    });
+
     it('should successfully remove content dependancies', () => {
       const items = defaultDependantItems();
 

--- a/src/common/content-item/content-dependancy-tree.ts
+++ b/src/common/content-item/content-dependancy-tree.ts
@@ -112,7 +112,7 @@ export class ContentDependancyTree {
       body.forEach(contained => {
         this.searchObjectForContentDependancies(item, contained, result);
       });
-    } else {
+    } else if (body != null) {
       const allPropertyNames = Object.getOwnPropertyNames(body);
       // Does this object match the pattern expected for a content item or reference?
       if (

--- a/src/common/content-item/copy-config.spec.ts
+++ b/src/common/content-item/copy-config.spec.ts
@@ -12,7 +12,8 @@ jest.mock('fs');
 const yargArgs = {
   $0: 'test',
   _: ['test'],
-  json: true
+  json: true,
+  logFile: new FileLog()
 };
 
 describe('copy-config', () => {
@@ -90,7 +91,7 @@ describe('copy-config', () => {
 
     it('should return a config object based on the arguments when no config file argument is given', async () => {
       const log = new FileLog();
-      const argv: Arguments<ConfigurationParameters> = {
+      const argv: Arguments<ConfigurationParameters & CopyItemBuilderOptions> = {
         ...yargArgs,
         hubId: 'test',
         clientId: 'test2',

--- a/src/common/file-log.ts
+++ b/src/common/file-log.ts
@@ -1,6 +1,7 @@
 import { ArchiveLog } from './archive/archive-log';
 
 export class FileLog extends ArchiveLog {
+  private openedCount = 0;
   closed: boolean;
 
   constructor(private filename?: string) {
@@ -18,11 +19,19 @@ export class FileLog extends ArchiveLog {
     this.addComment(text as string);
   }
 
-  public async close(): Promise<void> {
-    if (this.filename != null) {
-      await this.writeToFile(this.filename);
-    }
+  public open(): FileLog {
+    this.openedCount++;
 
-    this.closed = true;
+    return this;
+  }
+
+  public async close(writeIfClosed = true): Promise<void> {
+    if (--this.openedCount <= 0) {
+      if (this.filename != null && writeIfClosed) {
+        await this.writeToFile(this.filename);
+      }
+
+      this.closed = true;
+    }
   }
 }

--- a/src/common/log-helpers.spec.ts
+++ b/src/common/log-helpers.spec.ts
@@ -1,0 +1,58 @@
+import { createLog, getDefaultLogPath } from './log-helpers';
+import { join } from 'path';
+
+describe('log-helpers', () => {
+  describe('getDefaultLogPath tests', () => {
+    it('should build a log path out of the given type, action and platform', async () => {
+      process.env['USERPROFILE'] = '/win32path';
+      process.env['HOME'] = '/unixpath';
+
+      const pathWin = getDefaultLogPath('example1', 'action1', 'win32');
+      expect(pathWin).toMatchInlineSnapshot(`"/win32path/.amplience/logs/example1-action1-<DATE>.log"`);
+
+      const pathUnix = getDefaultLogPath('example2', 'action2', 'unix');
+      expect(pathUnix).toMatchInlineSnapshot(`"/unixpath/.amplience/logs/example2-action2-<DATE>.log"`);
+
+      const pathAuto = getDefaultLogPath('example3', 'action3');
+      if (process.platform === 'win32') {
+        expect(pathAuto).toMatchInlineSnapshot(`"/win32path/.amplience/logs/example3-action3-<DATE>.log"`);
+      } else {
+        expect(pathAuto).toMatchInlineSnapshot(`"/unixpath/.amplience/logs/example3-action3-<DATE>.log"`);
+      }
+
+      delete process.env['HOME'];
+
+      const pathUndefined = getDefaultLogPath('example2', 'action2', 'unix');
+      expect(pathUndefined).toEqual(join(__dirname, '/.amplience/logs/example2-action2-<DATE>.log'));
+    });
+  });
+
+  describe('createLog tests', () => {
+    it('should create a log instance with the given filename, without opening it', async () => {
+      const log = createLog('exampleFilename.txt');
+
+      // Undefined title matches the filename.
+      expect(log.title).toEqual('exampleFilename.txt');
+      expect(log['filename']).toEqual('exampleFilename.txt');
+      expect(log['openedCount']).toEqual(0);
+    });
+
+    it('should create a log instance with the given filename, without opening it', async () => {
+      const log = createLog('exampleFilename.txt');
+
+      // Undefined title matches the filename.
+      expect(log.title).toEqual('exampleFilename.txt');
+      expect(log['filename']).toEqual('exampleFilename.txt');
+      expect(log['openedCount']).toEqual(0);
+    });
+
+    it('should create a log instance with the given title, adding a timestamp afterwards', async () => {
+      const log = createLog('exampleFilename2.txt', 'title with timestamp');
+
+      // Followed by timestamp.
+      expect(log.title).toMatch(/^title with timestamp \- ./);
+      expect(log['filename']).toEqual('exampleFilename2.txt');
+      expect(log['openedCount']).toEqual(0);
+    });
+  });
+});

--- a/src/common/log-helpers.ts
+++ b/src/common/log-helpers.ts
@@ -1,4 +1,5 @@
 import { join } from 'path';
+import { FileLog } from './file-log';
 
 export function getDefaultLogPath(type: string, action: string, platform: string = process.platform): string {
   return join(
@@ -6,4 +7,16 @@ export function getDefaultLogPath(type: string, action: string, platform: string
     '.amplience',
     `logs/${type}-${action}-<DATE>.log`
   );
+}
+
+export function createLog(logFile: string, title?: string): FileLog {
+  const log = new FileLog(logFile);
+
+  if (title !== undefined) {
+    const timestamp = Date.now().toString();
+
+    log.title = `${title} - ${timestamp}\n`;
+  }
+
+  return log;
 }

--- a/src/interfaces/clean-hub-builder-options.ts
+++ b/src/interfaces/clean-hub-builder-options.ts
@@ -1,0 +1,7 @@
+import { FileLog } from '../common/file-log';
+
+export interface CleanHubBuilderOptions {
+  logFile?: string | FileLog;
+  force?: boolean;
+  step?: number;
+}

--- a/src/interfaces/clean-hub-builder-options.ts
+++ b/src/interfaces/clean-hub-builder-options.ts
@@ -1,7 +1,7 @@
 import { FileLog } from '../common/file-log';
 
 export interface CleanHubBuilderOptions {
-  logFile?: string | FileLog;
+  logFile: FileLog;
   force?: boolean;
   step?: number;
 }

--- a/src/interfaces/clean-hub-builder-options.ts
+++ b/src/interfaces/clean-hub-builder-options.ts
@@ -1,7 +1,8 @@
+import { CleanHubStepId } from '../commands/hub/model/clean-hub-step';
 import { FileLog } from '../common/file-log';
 
 export interface CleanHubBuilderOptions {
   logFile: FileLog;
   force?: boolean;
-  step?: number;
+  step?: CleanHubStepId;
 }

--- a/src/interfaces/copy-item-builder-options.interface.ts
+++ b/src/interfaces/copy-item-builder-options.interface.ts
@@ -20,7 +20,7 @@ export interface CopyItemBuilderOptions {
   validate?: boolean;
   skipIncomplete?: boolean;
   media?: boolean;
-  logFile?: string | FileLog;
+  logFile: FileLog;
   copyConfig?: string | CopyConfig;
 
   revertLog?: string;

--- a/src/interfaces/export-item-builder-options.interface.ts
+++ b/src/interfaces/export-item-builder-options.interface.ts
@@ -6,7 +6,7 @@ export interface ExportItemBuilderOptions {
   repoId?: string[] | string;
   schemaId?: string[] | string;
   name?: string[] | string;
-  logFile?: string | FileLog;
+  logFile?: FileLog;
   publish?: boolean;
 
   exportedIds?: string[];

--- a/src/interfaces/import-item-builder-options.interface.ts
+++ b/src/interfaces/import-item-builder-options.interface.ts
@@ -12,7 +12,7 @@ export interface ImportItemBuilderOptions {
   skipIncomplete?: boolean;
   excludeKeys?: boolean;
   media?: boolean;
-  logFile?: string | FileLog;
+  logFile?: FileLog;
 
   revertLog?: string;
 }


### PR DESCRIPTION
This PR adds a command for cleaning a whole hub. This runs all of the content/type/schema archive commands at once, which can be rather useful for automation. All of the commands are combined into a single log file, and could potentially be reverted from this single log file with a future change to the command.

Additional Changes:
- Content Item Archive now attempts to remove delivery keys before archiving. The removed delivery key will be stored with the ARCHIVE action, and can be restored when running UNARCHIVE with the revert log. The tests have been cleaned up and updated to support this new situation.
- The archive commands can now take a FileLog directly from their argv, which allows us to pass a FileLog in from the clean hub command.
- Fixed a bug with the content dependency tree where a null object would cause the traversal to fail.

NOTE: This PR contains the same log group changes as clone hub, as the groups can be used to revert at some point in the future.