### PR TITLE
feat(content-item): add tree command, improved circular dependency import

### DIFF
--- a/src/commands/configure.spec.ts
+++ b/src/commands/configure.spec.ts
@@ -30,7 +30,7 @@ describe('configure command', function() {
     jest.spyOn(fs, 'mkdirSync').mockReturnValueOnce(undefined);
     jest.spyOn(fs, 'writeFileSync').mockReturnValueOnce(undefined);
 
-    handler({ ...yargArgs, ...configFixture });
+    handler({ ...yargArgs, ...configFixture, config: CONFIG_FILENAME() });
 
     expect(fs.existsSync).toHaveBeenCalledWith(expect.stringMatching(/\.amplience$/));
     expect(fs.mkdirSync).toHaveBeenCalledWith(expect.stringMatching(/\.amplience$/), { recursive: true });
@@ -48,12 +48,30 @@ describe('configure command', function() {
     jest.spyOn(fs, 'mkdirSync');
     jest.spyOn(fs, 'writeFileSync').mockReturnValueOnce(undefined);
 
-    handler({ ...yargArgs, ...configFixture });
+    handler({ ...yargArgs, ...configFixture, config: CONFIG_FILENAME() });
 
     expect(fs.existsSync).toHaveBeenCalledWith(expect.stringMatching(/\.amplience$/));
     expect(fs.mkdirSync).not.toHaveBeenCalled();
     expect(fs.writeFileSync).toHaveBeenCalledWith(
       expect.stringMatching(new RegExp('.amplience/dc-cli-config.json$')),
+      JSON.stringify(configFixture)
+    );
+  });
+
+  it('should write a config file and use the specified file', () => {
+    jest
+      .spyOn(fs, 'existsSync')
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(false);
+    jest.spyOn(fs, 'mkdirSync').mockReturnValueOnce(undefined);
+    jest.spyOn(fs, 'writeFileSync').mockReturnValueOnce(undefined);
+
+    handler({ ...yargArgs, ...configFixture, config: 'subdirectory/custom-config.json' });
+
+    expect(fs.existsSync).toHaveBeenCalledWith(expect.stringMatching(/subdirectory$/));
+    expect(fs.mkdirSync).toHaveBeenCalledWith(expect.stringMatching(/subdirectory$/), { recursive: true });
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      expect.stringMatching(new RegExp('subdirectory/custom-config.json$')),
       JSON.stringify(configFixture)
     );
   });
@@ -69,7 +87,7 @@ describe('configure command', function() {
     jest.spyOn(fs, 'writeFileSync').mockReturnValueOnce(undefined);
 
     expect(() => {
-      handler({ ...yargArgs, ...configFixture });
+      handler({ ...yargArgs, ...configFixture, config: CONFIG_FILENAME() });
     }).toThrowError(/^Unable to create dir ".*". Reason: .*/);
 
     expect(fs.existsSync).toHaveBeenCalledWith(expect.stringMatching(/\.amplience$/));
@@ -88,7 +106,7 @@ describe('configure command', function() {
     });
 
     expect(() => {
-      handler({ ...yargArgs, ...configFixture });
+      handler({ ...yargArgs, ...configFixture, config: CONFIG_FILENAME() });
     }).toThrowError(/^Unable to write config file ".*". Reason: .*/);
 
     expect(fs.existsSync).toHaveBeenCalledWith(expect.stringMatching(/\.amplience$/));
@@ -104,7 +122,7 @@ describe('configure command', function() {
     jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(JSON.stringify(configFixture));
     jest.spyOn(fs, 'writeFileSync');
 
-    handler({ ...yargArgs, ...configFixture });
+    handler({ ...yargArgs, ...configFixture, config: CONFIG_FILENAME() });
 
     expect(fs.writeFileSync).not.toHaveBeenCalled();
   });

--- a/src/commands/configure.ts
+++ b/src/commands/configure.ts
@@ -17,6 +17,10 @@ export type ConfigurationParameters = {
   hubId: string;
 };
 
+type ConfigArgument = {
+  config: string;
+};
+
 export const configureCommandOptions: CommandOptions = {
   clientId: { type: 'string', demandOption: true },
   clientSecret: { type: 'string', demandOption: true },
@@ -43,14 +47,14 @@ const writeConfigFile = (configFile: string, parameters: ConfigurationParameters
 export const readConfigFile = (configFile: string): object =>
   fs.existsSync(configFile) ? JSON.parse(fs.readFileSync(configFile, 'utf-8')) : {};
 
-export const handler = (argv: Arguments<ConfigurationParameters>): void => {
+export const handler = (argv: Arguments<ConfigurationParameters & ConfigArgument>): void => {
   const { clientId, clientSecret, hubId } = argv;
-  const storedConfig = readConfigFile(CONFIG_FILENAME());
+  const storedConfig = readConfigFile(argv.config);
 
   if (isEqual(storedConfig, { clientId, clientSecret, hubId })) {
     console.log('Config file up-to-date.  Please use `--help` for command usage.');
     return;
   }
-  writeConfigFile(CONFIG_FILENAME(), { clientId, clientSecret, hubId });
+  writeConfigFile(argv.config, { clientId, clientSecret, hubId });
   console.log('Config file updated.');
 };

--- a/src/commands/content-item/__mocks__/dependant-content-helper.ts
+++ b/src/commands/content-item/__mocks__/dependant-content-helper.ts
@@ -3,7 +3,8 @@ import { ContentDependancy } from '../../../common/content-item/content-dependan
 function dependancy(id: string): ContentDependancy {
   return {
     _meta: {
-      schema: 'http://bigcontent.io/cms/schema/v1/core#/definitions/content-link'
+      schema: 'http://bigcontent.io/cms/schema/v1/core#/definitions/content-link',
+      name: 'content-link'
     },
     contentType: 'https://dev-solutions.s3.amazonaws.com/DynamicContentTypes/Accelerators/blog.json',
     id: id

--- a/src/commands/content-item/__snapshots__/tree.spec.ts.snap
+++ b/src/commands/content-item/__snapshots__/tree.spec.ts.snap
@@ -1,0 +1,90 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`content-item tree command handler tests should detect and print circular dependencies with a double line indicator 1`] = `
+"=== LEVEL 2 (1) ===
+item6 
+└─ item5 
+
+=== LEVEL 1 (3) ===
+item3 
+
+item7 
+
+=== CIRCULAR (3) ===
+item1 ═════════════════╗
+├─ item2               ║
+│  └─ item4            ║
+│     └─ *** (item1) ══╝
+└─ (item3) 
+
+Finished. Circular Dependencies printed: 1"
+`;
+
+exports[`content-item tree command handler tests should detect intertwined circular dependencies with multiple lines with different position 1`] = `
+"test
+test
+=== CIRCULAR (6) ===
+item5 ══════════════╗
+└─ item6            ║
+   └─ *** (item5) ══╝
+
+item1 ══════════════════════╗
+└─ item2 ═════════════════╗ ║
+   └─ item3               ║ ║
+      ├─ *** (item2) ═════╝ ║
+      └─ item4              ║
+         ├─ *** (item1) ════╝
+         └─ (item5) 
+
+Finished. Circular Dependencies printed: 2"
+`;
+
+exports[`content-item tree command handler tests should print a single content item by itself 1`] = `
+"=== LEVEL 1 (1) ===
+item1 
+
+Finished. Circular Dependencies printed: 0"
+`;
+
+exports[`content-item tree command handler tests should print a tree of content items 1`] = `
+"=== LEVEL 4 (1) ===
+item1 
+├─ item2 
+│  ├─ item4 
+│  └─ item6 
+│     └─ item5 
+└─ item3 
+
+=== LEVEL 3 (1) ===
+=== LEVEL 2 (1) ===
+=== LEVEL 1 (3) ===
+Finished. Circular Dependencies printed: 0"
+`;
+
+exports[`content-item tree command handler tests should print an error when invalid json is found 1`] = `
+"=== LEVEL 1 (1) ===
+item1 
+
+Finished. Circular Dependencies printed: 0"
+`;
+
+exports[`content-item tree command handler tests should print an error when invalid json is found 2`] = `"Couldn't read content item at '/Users/rhys/Documents/amplience/dc-cli/temp/tree/invalud/repo1/badfile.json': SyntaxError: Unexpected token o in JSON at position 1"`;
+
+exports[`content-item tree command handler tests should print multiple disjoint trees of content items 1`] = `
+"=== LEVEL 3 (1) ===
+item1 
+├─ item2 
+│  └─ item4 
+└─ item3 
+
+=== LEVEL 2 (2) ===
+item6 
+└─ item5 
+
+=== LEVEL 1 (4) ===
+item7 
+
+Finished. Circular Dependencies printed: 0"
+`;
+
+exports[`content-item tree command handler tests should print nothing if no content is present 1`] = `"Finished. Circular Dependencies printed: 0"`;

--- a/src/commands/content-item/__snapshots__/tree.spec.ts.snap
+++ b/src/commands/content-item/__snapshots__/tree.spec.ts.snap
@@ -21,9 +21,7 @@ Finished. Circular Dependencies printed: 1"
 `;
 
 exports[`content-item tree command handler tests should detect intertwined circular dependencies with multiple lines with different position 1`] = `
-"test
-test
-=== CIRCULAR (6) ===
+"=== CIRCULAR (6) ===
 item5 ══════════════╗
 └─ item6            ║
    └─ *** (item5) ══╝

--- a/src/commands/content-item/__snapshots__/tree.spec.ts.snap
+++ b/src/commands/content-item/__snapshots__/tree.spec.ts.snap
@@ -66,8 +66,6 @@ item1
 Finished. Circular Dependencies printed: 0"
 `;
 
-exports[`content-item tree command handler tests should print an error when invalid json is found 2`] = `"Couldn't read content item at '/Users/rhys/Documents/amplience/dc-cli/temp/tree/invalud/repo1/badfile.json': SyntaxError: Unexpected token o in JSON at position 1"`;
-
 exports[`content-item tree command handler tests should print multiple disjoint trees of content items 1`] = `
 "=== LEVEL 3 (1) ===
 item1 

--- a/src/commands/content-item/import.ts
+++ b/src/commands/content-item/import.ts
@@ -26,6 +26,7 @@ import {
   ItemContentDependancies,
   ContentDependancyInfo
 } from '../../common/content-item/content-dependancy-tree';
+import { Body } from '../../common/content-item/body';
 
 import { AmplienceSchemaValidator, defaultSchemaLookup } from '../../common/content-item/amplience-schema-validator';
 import { createLog, getDefaultLogPath } from '../../common/log-helpers';
@@ -684,11 +685,12 @@ const rewriteDependancy = (dep: ContentDependancyInfo, mapping: ContentMapping, 
 
   if (dep.dependancy._meta.schema === '_hierarchy') {
     dep.owner.content.body._meta.hierarchy.parentId = id;
-  } else {
+  } else if (dep.parent) {
+    const parent = dep.parent as Body;
     if (id == null) {
-      delete dep.parent[dep.index];
+      delete parent[dep.index];
     } else {
-      dep.parent[dep.index] = dep.dependancy;
+      parent[dep.index] = dep.dependancy;
       dep.dependancy.id = id;
     }
   }

--- a/src/commands/content-item/import.ts
+++ b/src/commands/content-item/import.ts
@@ -675,12 +675,22 @@ const prepareContentForImport = async (
   return tree;
 };
 
-const rewriteDependancy = (dep: ContentDependancyInfo, mapping: ContentMapping): void => {
-  const id = mapping.getContentItem(dep.dependancy.id) || dep.dependancy.id;
+const rewriteDependancy = (dep: ContentDependancyInfo, mapping: ContentMapping, allowNull: boolean): void => {
+  let id = mapping.getContentItem(dep.dependancy.id);
+
+  if (id == null && !allowNull) {
+    id = dep.dependancy.id;
+  }
+
   if (dep.dependancy._meta.schema === '_hierarchy') {
     dep.owner.content.body._meta.hierarchy.parentId = id;
   } else {
-    dep.dependancy.id = id;
+    if (id == null) {
+      delete dep.parent[dep.index];
+    } else {
+      dep.parent[dep.index] = dep.dependancy;
+      dep.dependancy.id = id;
+    }
   }
 };
 
@@ -706,7 +716,7 @@ const importTree = async (
 
       // Replace any dependancies with the existing mapping.
       item.dependancies.forEach(dep => {
-        rewriteDependancy(dep, mapping);
+        rewriteDependancy(dep, mapping, false);
       });
 
       const originalId = content.id;
@@ -781,7 +791,7 @@ const importTree = async (
       const content = item.owner.content;
 
       item.dependancies.forEach(dep => {
-        rewriteDependancy(dep, mapping);
+        rewriteDependancy(dep, mapping, true);
       });
 
       const originalId = content.id;
@@ -815,6 +825,7 @@ const importTree = async (
 
         newDependants[i] = newItem;
         mapping.registerContentItem(originalId as string, newItem.id as string);
+        mapping.registerContentItem(newItem.id as string, newItem.id as string);
       } else {
         if (itemShouldPublish(content) && (newItem.version != oldVersion || argv.republish)) {
           publishable.push({ item: newItem, node: item });

--- a/src/commands/content-item/import.ts
+++ b/src/commands/content-item/import.ts
@@ -791,7 +791,7 @@ const importTree = async (
       const content = item.owner.content;
 
       item.dependancies.forEach(dep => {
-        rewriteDependancy(dep, mapping, true);
+        rewriteDependancy(dep, mapping, pass === 0);
       });
 
       const originalId = content.id;

--- a/src/commands/content-item/tree.spec.ts
+++ b/src/commands/content-item/tree.spec.ts
@@ -1,0 +1,309 @@
+// Copy tests are rather simple since they most of the work is done by import/export.
+// Unique features are revert, throwing when parameters are wrong/missing,
+// and forwarding input parameters to both import and export.
+
+import { builder, command, handler, firstSecondThird, fillWhitespace, LOG_FILENAME } from './tree';
+import Yargs from 'yargs/yargs';
+
+import { writeFile } from 'fs';
+import { join } from 'path';
+import { promisify } from 'util';
+
+import { ensureDirectoryExists } from '../../common/import/directory-utils';
+import rmdir from 'rimraf';
+import { getDefaultLogPath } from '../../common/log-helpers';
+
+import { ItemTemplate } from '../../common/dc-management-sdk-js/mock-content';
+import { dependsOn } from '../../commands/content-item/__mocks__/dependant-content-helper';
+import { ContentItem, Status } from 'dc-management-sdk-js';
+
+jest.mock('../../services/dynamic-content-client-factory');
+jest.mock('../../common/log-helpers');
+
+const consoleLogSpy = jest.spyOn(console, 'log');
+const consoleErrorSpy = jest.spyOn(console, 'error');
+
+function rimraf(dir: string): Promise<Error> {
+  return new Promise((resolve): void => {
+    rmdir(dir, resolve);
+  });
+}
+
+describe('content-item tree command', () => {
+  afterEach((): void => {
+    jest.resetAllMocks();
+  });
+
+  it('should command should defined', function() {
+    expect(command).toEqual('tree <dir>');
+  });
+
+  describe('builder tests', function() {
+    it('should configure yargs', function() {
+      const argv = Yargs(process.argv.slice(2));
+      const spyPositional = jest.spyOn(argv, 'positional').mockReturnThis();
+
+      builder(argv);
+
+      expect(spyPositional).toHaveBeenCalledWith('dir', {
+        type: 'string',
+        describe: 'Path to the content items to build a tree from. Should be in the same format as an export.'
+      });
+    });
+  });
+
+  describe('firstSecondThird tests', function() {
+    it('should return 0 for the first item in a list, above size 1', () => {
+      expect(firstSecondThird(0, 2)).toEqual(0);
+      expect(firstSecondThird(0, 3)).toEqual(0);
+      expect(firstSecondThird(0, 4)).toEqual(0);
+    });
+
+    it('should return 2 for the last item in a list', () => {
+      expect(firstSecondThird(0, 1)).toEqual(2);
+      expect(firstSecondThird(1, 2)).toEqual(2);
+      expect(firstSecondThird(2, 3)).toEqual(2);
+      expect(firstSecondThird(3, 4)).toEqual(2);
+    });
+
+    it('should return 1 for any middle item in a list, above size 2', () => {
+      expect(firstSecondThird(1, 3)).toEqual(1);
+      expect(firstSecondThird(1, 4)).toEqual(1);
+      expect(firstSecondThird(2, 4)).toEqual(1);
+    });
+  });
+
+  describe('fillWhitespace tests', function() {
+    it('should fill space characters only after the original string with the given character up to the length', () => {
+      expect(fillWhitespace('    ', '    ', '-', 4)).toEqual('    ');
+      expect(fillWhitespace('    ', '    ', '-', 8)).toEqual('    ----');
+    });
+
+    it('should inherit non-space characters from the current string', () => {
+      expect(fillWhitespace('    ', '    char', '-', 4)).toEqual('    char');
+      expect(fillWhitespace('    ', '    char', '-', 8)).toEqual('    char');
+      expect(fillWhitespace('    ', '    c a ', '-', 8)).toEqual('    c-a-');
+      expect(fillWhitespace('    ', '     h r', '-', 8)).toEqual('    -h-r');
+      expect(fillWhitespace('    ', '        ', '-', 8)).toEqual('    ----');
+    });
+  });
+
+  describe('handler tests', function() {
+    const yargArgs = {
+      $0: 'test',
+      _: ['test'],
+      json: true
+    };
+    const config = {
+      clientId: 'client-id',
+      clientSecret: 'client-id',
+      hubId: 'hub-id'
+    };
+
+    beforeAll(async () => {
+      await rimraf('temp/tree/');
+    });
+
+    beforeEach(() => {
+      jest.resetAllMocks();
+    });
+
+    const itemFromTemplate = (template: ItemTemplate): ContentItem => {
+      const item = new ContentItem({
+        label: template.label,
+        status: template.status || Status.ACTIVE,
+        id: template.id || template.label,
+        folderId: null,
+        version: template.version,
+        lastPublishedVersion: template.lastPublishedVersion,
+        locale: template.locale,
+        body: {
+          ...template.body,
+          _meta: {
+            schema: template.typeSchemaUri
+          }
+        },
+
+        // Not meant to be here, but used later for sorting by repository
+        repoId: template.repoId
+      });
+
+      return item;
+    };
+
+    const createContent = async (basePath: string, template: ItemTemplate): Promise<void> => {
+      await promisify(writeFile)(
+        join(basePath, template.label + '.json'),
+        JSON.stringify(itemFromTemplate(template).toJSON())
+      );
+    };
+
+    it('should use getDefaultLogPath for LOG_FILENAME with process.platform as default', function() {
+      LOG_FILENAME();
+
+      expect(getDefaultLogPath).toHaveBeenCalledWith('item', 'tree', process.platform);
+    });
+
+    it('should print nothing if no content is present', async () => {
+      await ensureDirectoryExists('temp/tree/empty');
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/tree/empty'
+      };
+
+      await handler(argv);
+
+      expect(consoleLogSpy.mock.calls.map(args => args[0]).join('\n')).toMatchSnapshot();
+    });
+
+    it('should print a single content item by itself', async () => {
+      const basePath = 'temp/tree/single/repo1';
+      await ensureDirectoryExists(basePath);
+
+      await promisify(writeFile)(join(basePath, 'dummyFile.txt'), 'ignored');
+
+      await createContent(basePath, {
+        label: 'item1',
+        id: 'id1',
+        repoId: 'repo1',
+        body: {},
+        typeSchemaUri: 'http://type.com'
+      });
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/tree/single'
+      };
+
+      await handler(argv);
+
+      expect(consoleLogSpy.mock.calls.map(args => args[0]).join('\n')).toMatchSnapshot();
+    });
+
+    it('should print a tree of content items', async () => {
+      const basePath = 'temp/tree/multiple/repo1';
+      await ensureDirectoryExists(basePath);
+
+      const shared = { typeSchemaUri: 'http://type.com', repoId: 'repo1' };
+
+      await createContent(basePath, { label: 'item1', id: 'id1', body: dependsOn(['id2', 'id3']), ...shared });
+      await createContent(basePath, { label: 'item2', id: 'id2', body: dependsOn(['id4', 'id6']), ...shared });
+      await createContent(basePath, { label: 'item3', id: 'id3', body: {}, ...shared });
+      await createContent(basePath, { label: 'item4', id: 'id4', body: {}, ...shared });
+      await createContent(basePath, { label: 'item5', id: 'id5', body: {}, ...shared });
+      await createContent(basePath, { label: 'item6', id: 'id6', body: dependsOn(['id5']), ...shared });
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/tree/multiple'
+      };
+
+      await handler(argv);
+
+      expect(consoleLogSpy.mock.calls.map(args => args[0]).join('\n')).toMatchSnapshot();
+    });
+
+    it('should print multiple disjoint trees of content items', async () => {
+      const basePath = 'temp/tree/disjoint/repo1';
+      await ensureDirectoryExists(basePath);
+
+      const shared = { typeSchemaUri: 'http://type.com', repoId: 'repo1' };
+
+      await createContent(basePath, { label: 'item1', id: 'id1', body: dependsOn(['id2', 'id3']), ...shared });
+      await createContent(basePath, { label: 'item2', id: 'id2', body: dependsOn(['id4']), ...shared });
+      await createContent(basePath, { label: 'item3', id: 'id3', body: {}, ...shared });
+      await createContent(basePath, { label: 'item4', id: 'id4', body: {}, ...shared });
+
+      await createContent(basePath, { label: 'item5', id: 'id5', body: {}, ...shared });
+      await createContent(basePath, { label: 'item6', id: 'id6', body: dependsOn(['id5']), ...shared });
+
+      await createContent(basePath, { label: 'item7', id: 'id7', body: {}, ...shared });
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/tree/disjoint'
+      };
+
+      await handler(argv);
+
+      expect(consoleLogSpy.mock.calls.map(args => args[0]).join('\n')).toMatchSnapshot();
+    });
+
+    it('should detect and print circular dependencies with a double line indicator', async () => {
+      const basePath = 'temp/tree/disjoint/repo1';
+      await ensureDirectoryExists(basePath);
+
+      const shared = { typeSchemaUri: 'http://type.com', repoId: 'repo1' };
+
+      await createContent(basePath, { label: 'item1', id: 'id1', body: dependsOn(['id2', 'id3']), ...shared });
+      await createContent(basePath, { label: 'item2', id: 'id2', body: dependsOn(['id4']), ...shared });
+      await createContent(basePath, { label: 'item3', id: 'id3', body: {}, ...shared });
+      await createContent(basePath, { label: 'item4', id: 'id4', body: dependsOn(['id1']), ...shared });
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/tree/disjoint'
+      };
+
+      await handler(argv);
+
+      expect(consoleLogSpy.mock.calls.map(args => args[0]).join('\n')).toMatchSnapshot();
+    });
+
+    it('should detect intertwined circular dependencies with multiple lines with different position', async () => {
+      const basePath = 'temp/tree/intertwine/repo1';
+      await ensureDirectoryExists(basePath);
+
+      const shared = { typeSchemaUri: 'http://type.com', repoId: 'repo1' };
+
+      await createContent(basePath, { label: 'item1', id: 'id1', body: dependsOn(['id2']), ...shared });
+      await createContent(basePath, { label: 'item2', id: 'id2', body: dependsOn(['id3']), ...shared });
+      await createContent(basePath, { label: 'item3', id: 'id3', body: dependsOn(['id2', 'id4']), ...shared });
+      await createContent(basePath, { label: 'item4', id: 'id4', body: dependsOn(['id1', 'id5']), ...shared });
+
+      await createContent(basePath, { label: 'item5', id: 'id5', body: dependsOn(['id6']), ...shared });
+      await createContent(basePath, { label: 'item6', id: 'id6', body: dependsOn(['id5']), ...shared });
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/tree/intertwine'
+      };
+
+      await handler(argv);
+
+      expect(consoleLogSpy.mock.calls.map(args => args[0]).join('\n')).toMatchSnapshot();
+    });
+
+    it('should print an error when invalid json is found', async () => {
+      const basePath = 'temp/tree/invalud/repo1';
+      await ensureDirectoryExists(basePath);
+
+      await createContent(basePath, {
+        label: 'item1',
+        id: 'id1',
+        repoId: 'repo1',
+        body: {},
+        typeSchemaUri: 'http://type.com'
+      });
+      await promisify(writeFile)(join(basePath, 'badfile.json'), 'not json');
+
+      const argv = {
+        ...yargArgs,
+        ...config,
+        dir: 'temp/tree/invalud'
+      };
+
+      await handler(argv);
+
+      expect(consoleLogSpy.mock.calls.map(args => args[0]).join('\n')).toMatchSnapshot();
+      expect(consoleErrorSpy.mock.calls.map(args => args[0]).join('\n')).toMatchSnapshot();
+    });
+  });
+});

--- a/src/commands/content-item/tree.spec.ts
+++ b/src/commands/content-item/tree.spec.ts
@@ -303,7 +303,7 @@ describe('content-item tree command', () => {
       await handler(argv);
 
       expect(consoleLogSpy.mock.calls.map(args => args[0]).join('\n')).toMatchSnapshot();
-      expect(consoleErrorSpy.mock.calls.map(args => args[0]).join('\n')).toMatchSnapshot();
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/commands/content-item/tree.ts
+++ b/src/commands/content-item/tree.ts
@@ -1,0 +1,185 @@
+import { getDefaultLogPath } from '../../common/log-helpers';
+import { Argv, Arguments } from 'yargs';
+import { join, extname, resolve } from 'path';
+import { ConfigurationParameters } from '../configure';
+import { lstat, readdir, readFile } from 'fs';
+import { promisify } from 'util';
+
+import { ContentItem, ContentRepository } from 'dc-management-sdk-js';
+import {
+  ContentDependancyTree,
+  ItemContentDependancies,
+  RepositoryContentItem
+} from '../../common/content-item/content-dependancy-tree';
+import { ContentMapping } from '../../common/content-item/content-mapping';
+
+export function getTempFolder(name: string, platform: string = process.platform): string {
+  return join(process.env[platform == 'win32' ? 'USERPROFILE' : 'HOME'] || __dirname, '.amplience', `copy-${name}/`);
+}
+
+export const command = 'tree <dir>';
+
+export const desc = 'Print a content dependency tree from content in the given folder.';
+
+export const LOG_FILENAME = (platform: string = process.platform): string =>
+  getDefaultLogPath('item', 'tree', platform);
+
+export const builder = (yargs: Argv): void => {
+  yargs.positional('dir', {
+    type: 'string',
+    describe: 'Path to the content items to build a tree from.. Should be in the same format as an export.'
+  });
+};
+
+interface TreeOptions {
+  dir: string;
+}
+
+const traverseRecursive = async (path: string, action: (path: string) => Promise<void>): Promise<void> => {
+  const dir = await promisify(readdir)(path);
+
+  await Promise.all(
+    dir.map(async (contained: string) => {
+      contained = join(path, contained);
+      const stat = await promisify(lstat)(contained);
+      return await (stat.isDirectory() ? traverseRecursive(contained, action) : action(contained));
+    })
+  );
+};
+
+const prepareContentForTree = async (
+  repos: { basePath: string; repo: ContentRepository }[],
+  argv: Arguments<TreeOptions & ConfigurationParameters>
+): Promise<ContentDependancyTree | null> => {
+  const contentItems: RepositoryContentItem[] = [];
+  const schemaNames = new Set<string>();
+
+  for (let i = 0; i < repos.length; i++) {
+    const repo = repos[i].repo;
+
+    await traverseRecursive(resolve(repos[i].basePath), async path => {
+      // Is this valid content? Must have extension .json to be considered, for a start.
+      if (extname(path) !== '.json') {
+        return;
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let contentJSON: any;
+      try {
+        const contentText = await promisify(readFile)(path, { encoding: 'utf8' });
+        contentJSON = JSON.parse(contentText);
+      } catch (e) {
+        console.error(`Couldn't read content item at '${path}': ${e.toString()}`);
+        return;
+      }
+
+      // Get the folder id via the mapping.
+
+      // Only filter relevant information - for example status and previous content repo are not useful.
+      const filteredContent = {
+        id: contentJSON.id,
+        label: contentJSON.label,
+        locale: contentJSON.locale,
+        body: contentJSON.body,
+        deliveryId: contentJSON.deliveryId == contentJSON.Id || argv.excludeKeys ? undefined : contentJSON.deliveryId,
+        folderId: null,
+        publish: contentJSON.lastPublishedVersion != null
+      };
+
+      if (argv.excludeKeys) {
+        delete filteredContent.body._meta.deliveryKey;
+      }
+
+      schemaNames.add(contentJSON.body._meta.schema);
+
+      contentItems.push({ repo: repo, content: new ContentItem(filteredContent) });
+    });
+  }
+
+  return new ContentDependancyTree(contentItems, new ContentMapping());
+};
+
+export const handler = async (argv: Arguments<TreeOptions & ConfigurationParameters>): Promise<void> => {
+  const dir = argv.dir;
+
+  const baseDirContents = await promisify(readdir)(dir);
+  const importRepos: { basePath: string; repo: ContentRepository }[] = [];
+  for (let i = 0; i < baseDirContents.length; i++) {
+    const name = baseDirContents[i];
+    const path = join(dir, name);
+    const status = await promisify(lstat)(path);
+    if (status.isDirectory()) {
+      importRepos.push({ basePath: path, repo: new ContentRepository() });
+    }
+  }
+
+  const tree = await prepareContentForTree(importRepos, argv);
+
+  // Print the items in the tree.
+  // Keep a set of all items that have already been printed.
+  // Starting at the highest level, print all dependencies on the tree.
+
+  if (tree == null) return;
+
+  const evaluated = new Set<ItemContentDependancies>();
+  const firstSecondThird = (index: number, total: number): number => {
+    return index === 0 ? 0 : index == total - 1 ? 2 : 1;
+  };
+
+  const fstPipes = ['├', '├', '└'];
+
+  const printDependency = (
+    item: ItemContentDependancies,
+    depth: number,
+    evalThis: ItemContentDependancies[],
+    fst: number,
+    prefix: string
+  ): boolean => {
+    const pipe = depth < 0 ? '' : fstPipes[fst] + '─ ';
+
+    if (evalThis.indexOf(item) !== -1) {
+      console.log(`${prefix}${pipe}*** (${item.owner.content.label})`);
+      return false;
+    } else if (evaluated.has(item)) {
+      if (depth > 0) {
+        console.log(`${prefix}${pipe}(${item.owner.content.label})`);
+      }
+      return false;
+    } else {
+      console.log(`${prefix}${pipe}${item.owner.content.label}`);
+    }
+
+    evalThis.push(item);
+    evaluated.add(item);
+
+    item.dependancies.forEach((dep, index) => {
+      if (dep.resolved) {
+        const subFst = firstSecondThird(index, item.dependancies.length);
+        const subPrefix = depth == -1 ? '' : fst === 2 ? '   ' : '│  ';
+        printDependency(dep.resolved, depth + 1, [...evalThis], subFst, prefix + subPrefix);
+      }
+    });
+    return true;
+  };
+
+  for (let i = tree.levels.length - 1; i >= 0; i--) {
+    const level = tree.levels[i];
+    console.log(`=== LEVEL ${i + 1} (${level.items.length}) ===`);
+
+    level.items.forEach(item => {
+      printDependency(item, -1, [], 0, '');
+      console.log('');
+    });
+  }
+
+  console.log(`=== CIRCULAR (${tree.circularLinks.length}) ===`);
+  let topLevelPrints = 0;
+  tree.circularLinks.forEach(item => {
+    if (printDependency(item, -1, [], 0, '')) {
+      topLevelPrints++;
+      console.log('');
+    }
+  });
+
+  console.log(`Finished. Circular Dependencies printed: ${topLevelPrints}`);
+};

--- a/src/commands/content-item/tree.ts
+++ b/src/commands/content-item/tree.ts
@@ -36,13 +36,16 @@ export const traverseRecursive = async (path: string, action: (path: string) => 
 
   dir.sort();
 
-  await Promise.all(
-    dir.map(async (contained: string) => {
-      contained = join(path, contained);
-      const stat = await promisify(lstat)(contained);
-      return await (stat.isDirectory() ? traverseRecursive(contained, action) : action(contained));
-    })
-  );
+  for (let i = 0; i < dir.length; i++) {
+    let contained = dir[i];
+    contained = join(path, contained);
+    const stat = await promisify(lstat)(contained);
+    if (stat.isDirectory()) {
+      await traverseRecursive(contained, action);
+    } else {
+      await action(contained);
+    }
+  }
 };
 
 export const prepareContentForTree = async (

--- a/src/commands/content-item/tree.ts
+++ b/src/commands/content-item/tree.ts
@@ -49,8 +49,7 @@ export const traverseRecursive = async (path: string, action: (path: string) => 
 };
 
 export const prepareContentForTree = async (
-  repo: { basePath: string; repo: ContentRepository },
-  argv: Arguments<TreeOptions & ConfigurationParameters>
+  repo: { basePath: string; repo: ContentRepository }
 ): Promise<ContentDependancyTree> => {
   const contentItems: RepositoryContentItem[] = [];
   const schemaNames = new Set<string>();
@@ -93,7 +92,7 @@ const fstPipes = ['├', '├', '└'];
 const circularPipes = ['╗', '║', '╝'];
 const circularLine = '═';
 
-export const printDependency = (
+export const addDependency = (
   item: ItemContentDependancies,
   evaluated: Set<ItemContentDependancies>,
   lines: string[],
@@ -126,7 +125,7 @@ export const printDependency = (
   filteredItems.forEach((dep, index) => {
     const subFst = firstSecondThird(index, filteredItems.length);
     const subPrefix = depth == -1 ? '' : fst === 2 ? '   ' : '│  ';
-    printDependency(
+    addDependency(
       dep.resolved as ItemContentDependancies,
       evaluated,
       lines,
@@ -164,7 +163,7 @@ export const printTree = (item: ItemContentDependancies, evaluated: Set<ItemCont
   let lines: string[] = [];
   const circularLinks: CircularLink[] = [];
 
-  const result = printDependency(item, evaluated, lines, circularLinks, [], 0, '');
+  const result = addDependency(item, evaluated, lines, circularLinks, [], 0, '');
 
   if (!result) return false;
 
@@ -210,7 +209,7 @@ export const printTree = (item: ItemContentDependancies, evaluated: Set<ItemCont
 export const handler = async (argv: Arguments<TreeOptions & ConfigurationParameters>): Promise<void> => {
   const dir = argv.dir;
 
-  const tree = await prepareContentForTree({ basePath: dir, repo: new ContentRepository() }, argv);
+  const tree = await prepareContentForTree({ basePath: dir, repo: new ContentRepository() });
 
   // Print the items in the tree.
   // Keep a set of all items that have already been printed.

--- a/src/commands/content-item/tree.ts
+++ b/src/commands/content-item/tree.ts
@@ -79,7 +79,9 @@ export const prepareContentForTree = async (repo: {
   return new ContentDependancyTree(contentItems, new ContentMapping());
 };
 
-type CircularLink = [number, number];
+type LineIndexFrom = number;
+type LineIndexTo = number;
+type CircularLink = [LineIndexFrom, LineIndexTo];
 interface ParentReference {
   item: ItemContentDependancies;
   line: number;

--- a/src/common/content-item/content-dependancy-tree.ts
+++ b/src/common/content-item/content-dependancy-tree.ts
@@ -214,10 +214,6 @@ export class ContentDependancyTree {
     let isParent = false;
     const seenBefore = new Set<ItemContentDependancies>();
 
-    if (top.owner.content.label == 'item5') {
-      console.log('test');
-    }
-
     const traverse = (
       top: ItemContentDependancies,
       item: ItemContentDependancies | undefined,
@@ -267,10 +263,6 @@ export class ContentDependancyTree {
     };
 
     const hasCircular = traverse(top, top, 0, unresolved, seenBefore, false);
-
-    if (top.owner.content.label == 'item5') {
-      console.log('test');
-    }
 
     if (hasCircular) {
       if (intertwinedLoop) {

--- a/src/common/content-item/content-dependancy-tree.ts
+++ b/src/common/content-item/content-dependancy-tree.ts
@@ -13,7 +13,7 @@ export interface RepositoryContentItem {
 }
 
 export interface ContentDependancy {
-  _meta: { schema: DependancyContentTypeSchema };
+  _meta: { schema: DependancyContentTypeSchema; name: string };
   contentType: string;
   id: string | undefined;
 }
@@ -23,8 +23,7 @@ export interface ContentDependancyInfo {
   dependancy: ContentDependancy;
   owner: RepositoryContentItem;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  parent: any;
+  parent?: RecursiveSearchStep;
   index: string | number;
 }
 
@@ -149,7 +148,7 @@ export class ContentDependancyTree {
     item: RepositoryContentItem,
     body: RecursiveSearchStep,
     result: ContentDependancyInfo[],
-    parent: RecursiveSearchStep | null,
+    parent: RecursiveSearchStep | undefined,
     index: string | number
   ): void {
     if (Array.isArray(body)) {
@@ -282,20 +281,21 @@ export class ContentDependancyTree {
   private identifyContentDependancies(items: RepositoryContentItem[]): ItemContentDependancies[] {
     return items.map(item => {
       const result: ContentDependancyInfo[] = [];
-      this.searchObjectForContentDependancies(item, item.content.body, result, null, 0);
+      this.searchObjectForContentDependancies(item, item.content.body, result, undefined, 0);
 
       // Hierarchy parent is also a dependancy.
       if (item.content.body._meta.hierarchy && item.content.body._meta.hierarchy.parentId) {
         result.push({
           dependancy: {
             _meta: {
-              schema: '_hierarchy'
+              schema: '_hierarchy',
+              name: '_hierarchy'
             },
             id: item.content.body._meta.hierarchy.parentId,
             contentType: ''
           },
           owner: item,
-          parent: null,
+          parent: undefined,
           index: 0
         });
       }


### PR DESCRIPTION
(Previous feedback on my fork, at https://github.com/rs-amp/dc-cli/pull/1 )

This command allows you to print a dependency tree for any folder of content items on your system. The input directory should contain content items in the same format that the `export` command generates. It does not require repo/folder layouts, just that all dependent content is contained within the parent directory.

`dc-cli content-item tree <dir>`

This uses the same dependency tree class as the import task, which uses it to import the deepest content items first so that references can be properly resolved. Here, the "levels" of content items are maintained, and the highest level (most layers of dependencies) is printed first, followed by the lower levels that have not been printed yet.

Each item shows the items that it references or links via a tree structure:

```
=== LEVEL 3 (1) ===
item1 
├─ item2 
│  └─ item4 
└─ item3 

=== LEVEL 2 (2) ===
item6 
└─ item5 

=== LEVEL 1 (4) ===
item7
```

When items have been printed before, their name is shown in brackets and their children are not printed. This saves a lot of space on the tree for content items that are reused a lot.

Circular dependencies are a possibility within DC. Like the import task, they are separated from the rest of the tree into a list of "circular dependencies", now ordered by depth to our best ability.

```
=== CIRCULAR (3) ===
item1 ═════════════════╗
├─ item2               ║
│  └─ item4            ║
│     └─ *** (item1) ══╝
└─ (item3) 
```

Overlapping circular dependencies with ordering:
```
=== CIRCULAR (6) ===
item5 ══════════════╗
└─ item6            ║
   └─ *** (item5) ══╝

item1 ══════════════════════╗
└─ item2 ═════════════════╗ ║
   └─ item3               ║ ║
      ├─ *** (item2) ═════╝ ║
      └─ item4              ║
         ├─ *** (item1) ════╝
         └─ (item5) 
```

This is useful for examining the dependency structure of content that has been created, and identifying potential problems you might encounter when importing content items to a hub. Since circular dependencies are undesirable and sometimes hard to track manually, it's a useful way of identifying them for removal.

This PR also changes the behaviour of importing content with circular dependencies. The circular dependencies are now imported in order of depth first, and should correctly nullify content references that are not yet available. This will not fix _required_ circular dependencies, but it will fix imports for all circular dependencies that do not use required fields.

This PR is built on top of the `feature/clone` branch. It's in this repo for easier review.