### PR TITLE
fix: json-exporter can now handle both windows and unix paths, regardless of host os

### DIFF
--- a/src/common/json-resolver/json-resolver.spec.ts
+++ b/src/common/json-resolver/json-resolver.spec.ts
@@ -69,6 +69,12 @@ describe('content type schema helper', function() {
       expect(mockPathResolve).toHaveBeenCalledWith('/foo', './content-type-schema/schema.json');
     });
 
+    it('should load JSON from a local file (windows relative path) using a supplied relative dir', async function() {
+      const mockPathResolve = path.resolve as jest.Mock;
+      await successfulLocalFileInvocation('.\\content-type-schema\\schema.json', '\\foo');
+      expect(mockPathResolve).toHaveBeenCalledWith('\\foo', '.\\content-type-schema\\schema.json');
+    });
+
     it('should load JSON from a local file (with file url)', async function() {
       await successfulLocalFileInvocation('file://content-type-schema/schema.json');
     });

--- a/src/common/json-resolver/json-resolver.ts
+++ b/src/common/json-resolver/json-resolver.ts
@@ -19,7 +19,12 @@ export async function jsonResolver(jsonToResolve = '', relativeDir: string = __d
   let resolvedFilename: string | URL = jsonToResolve;
   if (jsonToResolve.match(/file:\/\//)) {
     resolvedFilename = new URL(jsonToResolve);
-  } else if (jsonToResolve.split(path.sep)[0].match(/^\.{1,2}$/)) {
+  } else if (
+    jsonToResolve
+      .replace(/\\/g, '/')
+      .split('/')[0]
+      .match(/^\.{1,2}$/)
+  ) {
     resolvedFilename = path.resolve(relativeDir, jsonToResolve);
   }
 


### PR DESCRIPTION
The JSON files as part of exports have their paths in unix format, but the user can provide windows style paths when running the `update` and `create` `content-type-schema` commands. This PR makes sure that both are properly handled when calculating relative paths.

Fixes `content-type-schema` import on Windows.