### PR TITLE
fix: unit test logging

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -33,6 +33,6 @@ jobs:
       run: |
         npm ci
         npm run build --if-present
-        npm test -- --runInBand
+        npm test
       env:
         CI: true

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,5 +7,6 @@ module.exports = {
   preset: 'ts-jest',
   coveragePathIgnorePatterns: [
     '^.+\\.mocks\.ts?$'
-  ]
+  ],
+  setupFilesAfterEnv: ['<rootDir>/jest.global.js']
 };

--- a/jest.global.js
+++ b/jest.global.js
@@ -1,0 +1,11 @@
+const rmdir = require('rimraf');
+
+function rimraf(dir) {
+  return new Promise(resolve => {
+    rmdir(dir, resolve);
+  });
+}
+
+afterAll(async () => {
+  await rimraf(`temp_${process.env.JEST_WORKER_ID}/`);
+});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "commit": "npx git-cz",
     "lint": "prettier --check \"**/*.ts\" && eslint \"**/*.ts\"",
     "pretest": "npm run lint",
-    "test": "FORCE_COLOR=1 jest --silent --coverage --runInBand",
+    "test": "FORCE_COLOR=1 jest --silent --coverage",
     "fix": "prettier --write '**/*.ts'",
     "reset": "git clean -dfx && git reset --hard && npm ci",
     "prerelease": "npm run reset",

--- a/src/cli.spec.ts
+++ b/src/cli.spec.ts
@@ -2,19 +2,8 @@ import * as cli from './cli';
 import Yargs from 'yargs/yargs';
 import { configureCommandOptions } from './commands/configure';
 import YargsCommandBuilderOptions from './common/yargs/yargs-command-builder-options';
-import rmdir from 'rimraf';
 
 jest.mock('./commands/configure');
-
-function rimraf(dir: string): Promise<Error> {
-  return new Promise((resolve): void => {
-    rmdir(dir, resolve);
-  });
-}
-
-afterAll(() => {
-  rimraf('temp/');
-});
 
 describe('cli', (): void => {
   afterEach(() => {

--- a/src/commands/content-item/archive.spec.ts
+++ b/src/commands/content-item/archive.spec.ts
@@ -660,7 +660,7 @@ describe('content-item archive command', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (readline as any).setResponses(['y']);
 
-      const logFileName = 'temp/content-item-unarchive.log';
+      const logFileName = `temp_${process.env.JEST_WORKER_ID}/content-item-unarchive.log`;
       const log = '// Type log test file\n' + 'UNARCHIVE 1\n' + 'UNARCHIVE 2\n' + 'UNARCHIVE idMissing';
 
       const dir = dirname(logFileName);
@@ -708,11 +708,11 @@ describe('content-item archive command', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (readline as any).setResponses(['y']);
 
-      if (await promisify(exists)('temp/content-item-unarchive.log')) {
-        await promisify(unlink)('temp/content-item-unarchive.log');
+      if (await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/content-item-unarchive.log`)) {
+        await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/content-item-unarchive.log`);
       }
 
-      const logFileName = 'temp/content-item-unarchive.log';
+      const logFileName = `temp_${process.env.JEST_WORKER_ID}/content-item-unarchive.log`;
       const log = '// Type log test file\n' + 'UNARCHIVE 1\n' + 'UNARCHIVE 2\n' + 'UNARCHIVE idMissing';
 
       const dir = dirname(logFileName);
@@ -742,8 +742,8 @@ describe('content-item archive command', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (readline as any).setResponses(['y']);
 
-      if (await promisify(exists)('temp/content-item-archive.log')) {
-        await promisify(unlink)('temp/content-item-archive.log');
+      if (await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/content-item-archive.log`)) {
+        await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/content-item-archive.log`);
       }
 
       const { mockItemGetById, mockArchive, contentItems } = mockValues();
@@ -753,7 +753,7 @@ describe('content-item archive command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        logFile: createLog('temp/content-item-archive.log'),
+        logFile: createLog(`temp_${process.env.JEST_WORKER_ID}/content-item-archive.log`),
         id: '1'
       };
 
@@ -762,11 +762,11 @@ describe('content-item archive command', () => {
       expect(mockItemGetById).toHaveBeenCalled();
       expect(mockArchive).toBeCalled();
 
-      const logExists = await promisify(exists)('temp/content-item-archive.log');
+      const logExists = await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/content-item-archive.log`);
 
       expect(logExists).toBeTruthy();
 
-      const log = await promisify(readFile)('temp/content-item-archive.log', 'utf8');
+      const log = await promisify(readFile)(`temp_${process.env.JEST_WORKER_ID}/content-item-archive.log`, 'utf8');
 
       const logLines = log.split('\n');
       let total = 0;
@@ -784,7 +784,7 @@ describe('content-item archive command', () => {
       expect(total).toEqual(1);
       expect(deliveryKeys).toEqual(1);
 
-      await promisify(unlink)('temp/content-item-archive.log');
+      await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/content-item-archive.log`);
     });
   });
 

--- a/src/commands/content-item/copy.spec.ts
+++ b/src/commands/content-item/copy.spec.ts
@@ -183,7 +183,7 @@ describe('content-item copy command', () => {
     };
 
     beforeAll(async () => {
-      await rimraf('temp/copy/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/copy/`);
     });
 
     const clearArray = (array: object[]): void => {
@@ -321,7 +321,7 @@ describe('content-item copy command', () => {
         dstClientId: 'acc2-id',
         dstSecret: 'acc2-secret',
 
-        revertLog: openRevertLog('temp/copy/revertMissing.txt')
+        revertLog: openRevertLog(`temp_${process.env.JEST_WORKER_ID}/copy/revertMissing.txt`)
       };
       await handler(argv);
 

--- a/src/commands/content-item/export.spec.ts
+++ b/src/commands/content-item/export.spec.ts
@@ -123,7 +123,7 @@ describe('content-item export command', () => {
     };
 
     beforeAll(async () => {
-      await rimraf('temp/export/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/export/`);
     });
 
     it('should export all content when given only an output directory', async () => {
@@ -142,13 +142,13 @@ describe('content-item export command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/export/all/'
+        dir: `temp_${process.env.JEST_WORKER_ID}/export/all/`
       };
       await handler(argv);
 
-      await itemsExist('temp/export/all/', templates);
+      await itemsExist(`temp_${process.env.JEST_WORKER_ID}/export/all/`, templates);
 
-      await rimraf('temp/export/all/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/export/all/`);
     });
 
     it('should export content from a specific folder', async () => {
@@ -172,15 +172,15 @@ describe('content-item export command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/export/folder1',
+        dir: `temp_${process.env.JEST_WORKER_ID}/export/folder1`,
         folderId: 'folder1'
       };
       await handler(argv);
 
-      await itemsExist('temp/export/', exists);
-      await itemsDontExist('temp/export/', skips);
+      await itemsExist(`temp_${process.env.JEST_WORKER_ID}/export/`, exists);
+      await itemsDontExist(`temp_${process.env.JEST_WORKER_ID}/export/`, skips);
 
-      await rimraf('temp/export/folder1/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/export/folder1/`);
     });
 
     it('should export content from a multiple folders, with directory structure including both explicitly', async () => {
@@ -206,15 +206,15 @@ describe('content-item export command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/export/multi/',
+        dir: `temp_${process.env.JEST_WORKER_ID}/export/multi/`,
         folderId: ['folder1', 'folder3']
       };
       await handler(argv);
 
-      await itemsExist('temp/export/multi/', exists);
-      await itemsDontExist('temp/export/multi/', skips);
+      await itemsExist(`temp_${process.env.JEST_WORKER_ID}/export/multi/`, exists);
+      await itemsDontExist(`temp_${process.env.JEST_WORKER_ID}/export/multi/`, skips);
 
-      await rimraf('temp/export/multi/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/export/multi/`);
     });
 
     it('should export content from a single repo, ignoring others', async () => {
@@ -239,15 +239,15 @@ describe('content-item export command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/export/repo/',
+        dir: `temp_${process.env.JEST_WORKER_ID}/export/repo/`,
         repoId: 'repo1'
       };
       await handler(argv);
 
-      await itemsExist('temp/export/repo/', exists);
-      await itemsDontExist('temp/export/repo/', skips);
+      await itemsExist(`temp_${process.env.JEST_WORKER_ID}/export/repo/`, exists);
+      await itemsDontExist(`temp_${process.env.JEST_WORKER_ID}/export/repo/`, skips);
 
-      await rimraf('temp/export/repo/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/export/repo/`);
     });
 
     it('should export content from a multiple repos, ignoring others', async () => {
@@ -270,15 +270,15 @@ describe('content-item export command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/export/repomulti/',
+        dir: `temp_${process.env.JEST_WORKER_ID}/export/repomulti/`,
         repoId: ['repo1', 'repo2']
       };
       await handler(argv);
 
-      await itemsExist('temp/export/repomulti/', exists, ['repo1', 'repo2']);
-      await itemsDontExist('temp/export/repomulti/', skips, ['repo1', 'repo2']);
+      await itemsExist(`temp_${process.env.JEST_WORKER_ID}/export/repomulti/`, exists, ['repo1', 'repo2']);
+      await itemsDontExist(`temp_${process.env.JEST_WORKER_ID}/export/repomulti/`, skips, ['repo1', 'repo2']);
 
-      await rimraf('temp/export/repomulti/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/export/repomulti/`);
     });
 
     it('should only export content with a matching type id when specified', async () => {
@@ -303,16 +303,16 @@ describe('content-item export command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/export/typeSpecific/folder1',
+        dir: `temp_${process.env.JEST_WORKER_ID}/export/typeSpecific/folder1`,
         folderId: 'folder1',
         schemaId: '/typeMatch/'
       };
       await handler(argv);
 
-      await itemsExist('temp/export/typeSpecific/', exists);
-      await itemsDontExist('temp/export/typeSpecific/', skips);
+      await itemsExist(`temp_${process.env.JEST_WORKER_ID}/export/typeSpecific/`, exists);
+      await itemsDontExist(`temp_${process.env.JEST_WORKER_ID}/export/typeSpecific/`, skips);
 
-      await rimraf('temp/export/typeSpecific/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/export/typeSpecific/`);
     });
 
     it('should only export content with a matching name when specified', async () => {
@@ -339,16 +339,16 @@ describe('content-item export command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/export/nameSpecific/folder1',
+        dir: `temp_${process.env.JEST_WORKER_ID}/export/nameSpecific/folder1`,
         folderId: 'folder1',
         name: '/nameMatch/'
       };
       await handler(argv);
 
-      await itemsExist('temp/export/nameSpecific/', exists);
-      await itemsDontExist('temp/export/nameSpecific/', skips);
+      await itemsExist(`temp_${process.env.JEST_WORKER_ID}/export/nameSpecific/`, exists);
+      await itemsDontExist(`temp_${process.env.JEST_WORKER_ID}/export/nameSpecific/`, skips);
 
-      await rimraf('temp/export/nameSpecific/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/export/nameSpecific/`);
     });
 
     it('should respect all filters when specified at the same time', async () => {
@@ -396,7 +396,7 @@ describe('content-item export command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/export/allFilter/',
+        dir: `temp_${process.env.JEST_WORKER_ID}/export/allFilter/`,
         repoId: 'repo2',
         folderId: 'folder1', // folder1 in addition to repo2
         name: '/nameMatch/',
@@ -404,10 +404,10 @@ describe('content-item export command', () => {
       };
       await handler(argv);
 
-      await itemsExist('temp/export/allFilter/', exists, ['repo2']);
-      await itemsDontExist('temp/export/allFilter/', skips, ['repo2']);
+      await itemsExist(`temp_${process.env.JEST_WORKER_ID}/export/allFilter/`, exists, ['repo2']);
+      await itemsDontExist(`temp_${process.env.JEST_WORKER_ID}/export/allFilter/`, skips, ['repo2']);
 
-      await rimraf('temp/export/allFilter/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/export/allFilter/`);
     });
 
     it('should export content outwith the filter if it is depended on', async () => {
@@ -466,15 +466,15 @@ describe('content-item export command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/export/folder1',
+        dir: `temp_${process.env.JEST_WORKER_ID}/export/folder1`,
         folderId: 'folder1'
       };
       await handler(argv);
 
-      await itemsExist('temp/export/', exists);
-      await itemsDontExist('temp/export/', skips);
+      await itemsExist(`temp_${process.env.JEST_WORKER_ID}/export/`, exists);
+      await itemsDontExist(`temp_${process.env.JEST_WORKER_ID}/export/`, skips);
 
-      await rimraf('temp/export/folder1/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/export/folder1/`);
     });
 
     it('should export archived content if it is depended on, from multiple repos', async () => {
@@ -549,14 +549,14 @@ describe('content-item export command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/export/repoDeps'
+        dir: `temp_${process.env.JEST_WORKER_ID}/export/repoDeps`
       };
       await handler(argv);
 
-      await itemsExist('temp/export/repoDeps/', exists, ['repo1', 'repo2']);
-      await itemsDontExist('temp/export/repoDeps/', skips, ['repo1', 'repo2']);
+      await itemsExist(`temp_${process.env.JEST_WORKER_ID}/export/repoDeps/`, exists, ['repo1', 'repo2']);
+      await itemsDontExist(`temp_${process.env.JEST_WORKER_ID}/export/repoDeps/`, skips, ['repo1', 'repo2']);
 
-      await rimraf('temp/export/repoDeps/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/export/repoDeps/`);
     });
 
     it('should warn when schema validation fails, but not if it succeeds', async () => {
@@ -606,14 +606,14 @@ describe('content-item export command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/export/validation/',
+        dir: `temp_${process.env.JEST_WORKER_ID}/export/validation/`,
         repoId: 'repo1'
       };
       await handler(argv);
 
-      await itemsExist('temp/export/validation/', exists);
+      await itemsExist(`temp_${process.env.JEST_WORKER_ID}/export/validation/`, exists);
 
-      await rimraf('temp/export/validation/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/export/validation/`);
     });
 
     it("should skip repositories if items can't be listed from them", async () => {
@@ -636,13 +636,13 @@ describe('content-item export command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/export/failRepo/',
+        dir: `temp_${process.env.JEST_WORKER_ID}/export/failRepo/`,
         repoId: 'repo1'
       };
       await handler(argv);
-      await itemsDontExist('temp/export/failRepo/', templates);
+      await itemsDontExist(`temp_${process.env.JEST_WORKER_ID}/export/failRepo/`, templates);
 
-      await rimraf('temp/export/failRepo/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/export/failRepo/`);
     });
 
     it('should skip content items if they are fetched folder, but the content items endpoints fail', async () => {
@@ -666,14 +666,14 @@ describe('content-item export command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/export/failFolder/',
+        dir: `temp_${process.env.JEST_WORKER_ID}/export/failFolder/`,
         folderId: ['folder1', 'folder2']
       };
       await handler(argv);
 
-      await itemsDontExist('temp/export/failFolder/', templates);
+      await itemsDontExist(`temp_${process.env.JEST_WORKER_ID}/export/failFolder/`, templates);
 
-      await rimraf('temp/export/failFolder/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/export/failFolder/`);
     });
 
     it('should place content items that error when getting the directory name in the base directory', async () => {
@@ -698,17 +698,17 @@ describe('content-item export command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/export/failFolder/',
+        dir: `temp_${process.env.JEST_WORKER_ID}/export/failFolder/`,
         repoId: 'repo1'
       };
       await handler(argv);
 
       exists[0].folderPath = 'nested2'; // nested2 could not be tracked back to the base, so it was placed directly there.
 
-      await itemsExist('temp/export/failFolder/', exists);
-      await itemsDontExist('temp/export/failFolder/', skips);
+      await itemsExist(`temp_${process.env.JEST_WORKER_ID}/export/failFolder/`, exists);
+      await itemsDontExist(`temp_${process.env.JEST_WORKER_ID}/export/failFolder/`, skips);
 
-      await rimraf('temp/export/failFolder/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/export/failFolder/`);
     });
 
     it('should skip subfolders if the request for them fails', async () => {
@@ -734,15 +734,15 @@ describe('content-item export command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/export/failSubfolder/folder1',
+        dir: `temp_${process.env.JEST_WORKER_ID}/export/failSubfolder/folder1`,
         folderId: 'folder1'
       };
       await handler(argv);
 
-      await itemsExist('temp/export/failSubfolder/', exists);
-      await itemsDontExist('temp/export/failSubfolder/', skips);
+      await itemsExist(`temp_${process.env.JEST_WORKER_ID}/export/failSubfolder/`, exists);
+      await itemsDontExist(`temp_${process.env.JEST_WORKER_ID}/export/failSubfolder/`, skips);
 
-      await rimraf('temp/export/failSubfolder/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/export/failSubfolder/`);
     });
 
     it('should fetch the last published version of content when available and --publish is passed', async () => {
@@ -783,16 +783,16 @@ describe('content-item export command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/export/version/',
+        dir: `temp_${process.env.JEST_WORKER_ID}/export/version/`,
         publish: true
       };
       await handler(argv);
 
       expect(content.metrics.itemsVersionGet).toEqual(2);
 
-      await itemsExist('temp/export/version/', templates);
+      await itemsExist(`temp_${process.env.JEST_WORKER_ID}/export/version/`, templates);
 
-      await rimraf('temp/export/version/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/export/version/`);
     });
 
     it('should populate exportedIds with the ids of exported content items when present', async () => {
@@ -818,18 +818,18 @@ describe('content-item export command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/export/exportedIds',
+        dir: `temp_${process.env.JEST_WORKER_ID}/export/exportedIds`,
         folderId: 'exportedIds',
         exportedIds
       };
       await handler(argv);
 
-      await itemsExist('temp/export/', exists);
-      await itemsDontExist('temp/export/', skips);
+      await itemsExist(`temp_${process.env.JEST_WORKER_ID}/export/`, exists);
+      await itemsDontExist(`temp_${process.env.JEST_WORKER_ID}/export/`, skips);
 
       expect(exportedIds).toEqual(exists.map(item => item.id as string));
 
-      await rimraf('temp/export/exportedIds/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/export/exportedIds/`);
     });
   });
 });

--- a/src/commands/content-item/import-revert.spec.ts
+++ b/src/commands/content-item/import-revert.spec.ts
@@ -35,11 +35,11 @@ describe('revert tests', function() {
   };
 
   beforeAll(async () => {
-    await rimraf('temp/revert/');
+    await rimraf(`temp_${process.env.JEST_WORKER_ID}/revert/`);
   });
 
   afterAll(async () => {
-    await rimraf('temp/revert/');
+    await rimraf(`temp_${process.env.JEST_WORKER_ID}/revert/`);
   });
 
   async function createLog(logFileName: string, log: string): Promise<void> {
@@ -60,7 +60,10 @@ describe('revert tests', function() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (readline as any).setResponses([]);
 
-    await createLog('temp/revert/createOnly.txt', 'CREATE id1\nCREATE id2\nCREATE id3\nSUCCESS');
+    await createLog(
+      `temp_${process.env.JEST_WORKER_ID}/revert/createOnly.txt`,
+      'CREATE id1\nCREATE id2\nCREATE id3\nSUCCESS'
+    );
 
     // Create content to import
 
@@ -78,7 +81,7 @@ describe('revert tests', function() {
     const argv = {
       ...yargArgs,
       ...config,
-      revertLog: openRevertLog('temp/revert/createOnly.txt'),
+      revertLog: openRevertLog(`temp_${process.env.JEST_WORKER_ID}/revert/createOnly.txt`),
       dir: '.'
     };
     await revert(argv);
@@ -86,14 +89,17 @@ describe('revert tests', function() {
     // check items were archived appropriately
     expect(mockContent.metrics.itemsArchived).toEqual(3);
 
-    await rimraf('temp/revert/createOnly.txt');
+    await rimraf(`temp_${process.env.JEST_WORKER_ID}/revert/createOnly.txt`);
   });
 
   test('Reverting an import on top of existing content should revert to an older version of the content, and archive content that was created.', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (readline as any).setResponses([]);
 
-    await createLog('temp/revert/createImport.txt', 'UPDATE id1 1 2\nUPDATE id2 3 4\nCREATE id3\nSUCCESS');
+    await createLog(
+      `temp_${process.env.JEST_WORKER_ID}/revert/createImport.txt`,
+      'UPDATE id1 1 2\nUPDATE id2 3 4\nCREATE id3\nSUCCESS'
+    );
 
     // Create content to import
 
@@ -111,7 +117,7 @@ describe('revert tests', function() {
     const argv = {
       ...yargArgs,
       ...config,
-      revertLog: openRevertLog('temp/revert/createImport.txt'),
+      revertLog: openRevertLog(`temp_${process.env.JEST_WORKER_ID}/revert/createImport.txt`),
       dir: '.'
     };
     await revert(argv);
@@ -121,7 +127,7 @@ describe('revert tests', function() {
     // check items were archived appropriately
     expect(mockContent.metrics.itemsArchived).toEqual(1);
 
-    await rimraf('temp/revert/createImport.txt');
+    await rimraf(`temp_${process.env.JEST_WORKER_ID}/revert/createImport.txt`);
   });
 
   test('Attempting to revert an import of content that has since changed should warn the user and continue on prompt.', async () => {
@@ -129,7 +135,7 @@ describe('revert tests', function() {
     (readline as any).setResponses(['y']);
 
     await createLog(
-      'temp/revert/createWarn.txt',
+      `temp_${process.env.JEST_WORKER_ID}/revert/createWarn.txt`,
       'UPDATE id1 1 2\nUPDATE id2 3 4\nCREATE id3\nUPDATE id4 3 4\nCREATE id5\nSUCCESS'
     );
 
@@ -174,7 +180,7 @@ describe('revert tests', function() {
     const argv = {
       ...yargArgs,
       ...config,
-      revertLog: openRevertLog('temp/revert/createWarn.txt'),
+      revertLog: openRevertLog(`temp_${process.env.JEST_WORKER_ID}/revert/createWarn.txt`),
       dir: '.'
     };
     await revert(argv);
@@ -187,14 +193,17 @@ describe('revert tests', function() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((readline as any).responsesLeft()).toEqual(0);
 
-    await rimraf('temp/revert/createWarn.txt');
+    await rimraf(`temp_${process.env.JEST_WORKER_ID}/revert/createWarn.txt`);
   });
 
   test('User responding no to the content changed warning should abort the process.', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (readline as any).setResponses(['n']);
 
-    await createLog('temp/revert/revertAbort.txt', 'UPDATE id1 1 2\nUPDATE id2 3 4\nCREATE id3\nSUCCESS');
+    await createLog(
+      `temp_${process.env.JEST_WORKER_ID}/revert/revertAbort.txt`,
+      'UPDATE id1 1 2\nUPDATE id2 3 4\nCREATE id3\nSUCCESS'
+    );
 
     // Create content to import
 
@@ -215,7 +224,7 @@ describe('revert tests', function() {
     const argv = {
       ...yargArgs,
       ...config,
-      revertLog: openRevertLog('temp/revert/revertAbort.txt'),
+      revertLog: openRevertLog(`temp_${process.env.JEST_WORKER_ID}/revert/revertAbort.txt`),
       dir: '.'
     };
     const result = await revert(argv);
@@ -230,7 +239,7 @@ describe('revert tests', function() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((readline as any).responsesLeft()).toEqual(0);
 
-    await rimraf('temp/revert/revertAbort.txt');
+    await rimraf(`temp_${process.env.JEST_WORKER_ID}/revert/revertAbort.txt`);
   });
 
   test('Missing/invalid/non-updated items when reverting (or already in the desired state) should be silently skipped.', async () => {
@@ -238,7 +247,7 @@ describe('revert tests', function() {
     (readline as any).setResponses([]);
 
     await createLog(
-      'temp/revert/revertSkip.txt',
+      `temp_${process.env.JEST_WORKER_ID}/revert/revertSkip.txt`,
       '// Title\n// Comment\nUPDATE id1 1 2\nUPDATE id2 3 4\nCREATE id3\nCREATE id4\nUPDATE id5 3 4\nCREATE id6\nUPDATE id7 23 24\nUPDATE id8 1 1\nUPDATE id9 0 1 invalid\nSUCCESS'
     );
 
@@ -258,7 +267,7 @@ describe('revert tests', function() {
     const argv = {
       ...yargArgs,
       ...config,
-      revertLog: openRevertLog('temp/revert/revertSkip.txt'),
+      revertLog: openRevertLog(`temp_${process.env.JEST_WORKER_ID}/revert/revertSkip.txt`),
       dir: '.'
     };
     const result = await revert(argv);
@@ -270,14 +279,14 @@ describe('revert tests', function() {
     // check items were archived appropriately
     expect(mockContent.metrics.itemsArchived).toEqual(1);
 
-    await rimraf('temp/revert/revertSkip.txt');
+    await rimraf(`temp_${process.env.JEST_WORKER_ID}/revert/revertSkip.txt`);
   });
 
   test('Reverting an empty log should not do anything.', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (readline as any).setResponses([]);
 
-    await createLog('temp/revert/revertEmpty.txt', '// empty :)');
+    await createLog(`temp_${process.env.JEST_WORKER_ID}/revert/revertEmpty.txt`, '// empty :)');
 
     // Create content to import
 
@@ -295,7 +304,7 @@ describe('revert tests', function() {
     const argv = {
       ...yargArgs,
       ...config,
-      revertLog: openRevertLog('temp/revert/revertEmpty.txt'),
+      revertLog: openRevertLog(`temp_${process.env.JEST_WORKER_ID}/revert/revertEmpty.txt`),
       dir: '.'
     };
     await revert(argv);
@@ -304,7 +313,7 @@ describe('revert tests', function() {
     expect(mockContent.metrics.itemsArchived).toEqual(0);
     expect(mockContent.metrics.itemsUpdated).toEqual(0);
 
-    await rimraf('temp/revert/revertEmpty.txt');
+    await rimraf(`temp_${process.env.JEST_WORKER_ID}/revert/revertEmpty.txt`);
   });
 
   test('Failed requests should silently skip affected content.', async () => {
@@ -312,7 +321,7 @@ describe('revert tests', function() {
     (readline as any).setResponses([]);
 
     await createLog(
-      'temp/revert/revertSkip.txt',
+      `temp_${process.env.JEST_WORKER_ID}/revert/revertSkip.txt`,
       'UPDATE id1 1 2\nUPDATE id2 3 4\nCREATE id3\nCREATE id4\nUPDATE id5 3 4\nCREATE id6\nUPDATE id7 23 24\nSUCCESS'
     );
 
@@ -333,7 +342,7 @@ describe('revert tests', function() {
     const argv = {
       ...yargArgs,
       ...config,
-      revertLog: openRevertLog('temp/revert/revertSkip.txt'),
+      revertLog: openRevertLog(`temp_${process.env.JEST_WORKER_ID}/revert/revertSkip.txt`),
       dir: '.'
     };
     const result = await revert(argv);
@@ -345,14 +354,14 @@ describe('revert tests', function() {
     // check items were archived appropriately
     expect(mockContent.metrics.itemsArchived).toEqual(0);
 
-    await rimraf('temp/revert/revertSkip.txt');
+    await rimraf(`temp_${process.env.JEST_WORKER_ID}/revert/revertSkip.txt`);
   });
 
   test('When the version request does not fail but updating it to that version does, skip the item.', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (readline as any).setResponses([]);
 
-    await createLog('temp/revert/revertSkip2.txt', 'UPDATE id1 1 2\nSUCCESS');
+    await createLog(`temp_${process.env.JEST_WORKER_ID}/revert/revertSkip2.txt`, 'UPDATE id1 1 2\nSUCCESS');
 
     // Create content to import
 
@@ -369,7 +378,7 @@ describe('revert tests', function() {
     const argv = {
       ...yargArgs,
       ...config,
-      revertLog: openRevertLog('temp/revert/revertSkip2.txt'),
+      revertLog: openRevertLog(`temp_${process.env.JEST_WORKER_ID}/revert/revertSkip2.txt`),
       dir: '.'
     };
     const result = await revert(argv);
@@ -381,7 +390,7 @@ describe('revert tests', function() {
     // check items were archived appropriately
     expect(mockContent.metrics.itemsArchived).toEqual(0);
 
-    await rimraf('temp/revert/revertSkip2.txt');
+    await rimraf(`temp_${process.env.JEST_WORKER_ID}/revert/revertSkip2.txt`);
   });
 
   test('Missing log should exit early.', async () => {
@@ -415,7 +424,7 @@ describe('revert tests', function() {
       ...yargArgs,
       ...config,
       dir: '.',
-      revertLog: openRevertLog('temp/revert/missing.txt')
+      revertLog: openRevertLog(`temp_${process.env.JEST_WORKER_ID}/revert/missing.txt`)
     };
     const result2 = await revert(argv2);
 

--- a/src/commands/content-item/import.spec.ts
+++ b/src/commands/content-item/import.spec.ts
@@ -163,11 +163,11 @@ describe('content-item import command', () => {
     });
 
     beforeAll(async () => {
-      await rimraf('temp/import/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/`);
     });
 
     afterAll(async () => {
-      await rimraf('temp/import/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/`);
     });
 
     async function createContent(
@@ -235,7 +235,7 @@ describe('content-item import command', () => {
         { label: 'item4', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' }
       ];
 
-      await createContent('temp/import/repo/', templates, false);
+      await createContent(`temp_${process.env.JEST_WORKER_ID}/import/repo/`, templates, false);
 
       const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
       mockContent.createMockRepository('targetRepo');
@@ -244,8 +244,8 @@ describe('content-item import command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/import/repo/',
-        mapFile: 'temp/import/repo.json',
+        dir: `temp_${process.env.JEST_WORKER_ID}/import/repo/`,
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/import/repo.json`,
         baseRepo: 'targetRepo'
       };
       await handler(argv);
@@ -257,7 +257,7 @@ describe('content-item import command', () => {
       expect(matches.length).toEqual(templates.length);
       expect(mockContent.metrics.itemsLocaleSet).toEqual(1);
 
-      await rimraf('temp/import/repo/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/repo/`);
     });
 
     it('Importing into a baseFolder creates folder structure starting at the given folder (within the specified repository)', async () => {
@@ -270,7 +270,7 @@ describe('content-item import command', () => {
         { label: 'item4', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' }
       ];
 
-      await createContent('temp/import/folder/', templates, false);
+      await createContent(`temp_${process.env.JEST_WORKER_ID}/import/folder/`, templates, false);
 
       const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
       mockContent.createMockRepository('targetRepo');
@@ -280,8 +280,8 @@ describe('content-item import command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/import/folder/',
-        mapFile: 'temp/import/folder.json',
+        dir: `temp_${process.env.JEST_WORKER_ID}/import/folder/`,
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/import/folder.json`,
         baseFolder: 'targetFolder'
       };
       await handler(argv);
@@ -292,7 +292,7 @@ describe('content-item import command', () => {
 
       expect(matches.length).toEqual(templates.length);
 
-      await rimraf('temp/import/folder/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/folder/`);
     });
 
     it('Folder structure recreation should work with existing, matching folders present without creating more.', async () => {
@@ -308,7 +308,7 @@ describe('content-item import command', () => {
         { label: 'item7doesnt', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/doesnt/nested' }
       ];
 
-      await createContent('temp/import/folder2/', templates, false);
+      await createContent(`temp_${process.env.JEST_WORKER_ID}/import/folder2/`, templates, false);
 
       const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
       mockContent.createMockRepository('targetRepo');
@@ -332,8 +332,8 @@ describe('content-item import command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/import/folder2/',
-        mapFile: 'temp/import/folder2.json',
+        dir: `temp_${process.env.JEST_WORKER_ID}/import/folder2/`,
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/import/folder2.json`,
         baseFolder: 'targetFolder'
       };
       await handler(argv);
@@ -346,7 +346,7 @@ describe('content-item import command', () => {
 
       expect(matches.length).toEqual(templates.length);
 
-      await rimraf('temp/import/folder2/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/folder2/`);
     });
 
     // == INTERACTIVE PROMPT TESTS ==
@@ -368,7 +368,7 @@ describe('content-item import command', () => {
         { label: 'item4', repoId: 'repo2', typeSchemaUri: 'http://type3', folderPath: 'folderTest/special' }
       ];
 
-      await createContent('temp/import/all/', templates, true);
+      await createContent(`temp_${process.env.JEST_WORKER_ID}/import/all/`, templates, true);
 
       const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
       mockContent.createMockRepository('repo');
@@ -383,8 +383,8 @@ describe('content-item import command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/import/all/',
-        mapFile: 'temp/import/all.json'
+        dir: `temp_${process.env.JEST_WORKER_ID}/import/all/`,
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/import/all.json`
       };
       await handler(argv);
 
@@ -396,7 +396,7 @@ describe('content-item import command', () => {
 
       expect(matches.length).toEqual(templates.length);
 
-      await rimraf('temp/import/all/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/all/`);
     });
 
     it('Importing content with no base and a missing repository name will request that it be skipped (then skip it)', async () => {
@@ -420,7 +420,7 @@ describe('content-item import command', () => {
         { label: 'item8', repoId: 'repo2', typeSchemaUri: 'http://type3', folderPath: 'folderTest/special' }
       ];
 
-      await createContent('temp/import/repoMissing/', skipped.concat(added), true);
+      await createContent(`temp_${process.env.JEST_WORKER_ID}/import/repoMissing/`, skipped.concat(added), true);
 
       const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
       mockContent.createMockRepository('repo2');
@@ -434,8 +434,8 @@ describe('content-item import command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/import/repoMissing/',
-        mapFile: 'temp/import/repoMissing.json'
+        dir: `temp_${process.env.JEST_WORKER_ID}/import/repoMissing/`,
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/import/repoMissing.json`
       };
       await handler(argv);
 
@@ -450,7 +450,7 @@ describe('content-item import command', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((readline as any).responsesLeft()).toEqual(0); // All responses consumed.
 
-      await rimraf('temp/import/repoMissing/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/repoMissing/`);
     });
 
     it('Importing content with a missing content type (but not schema) will request that the content type be created (then create it)', async () => {
@@ -468,7 +468,7 @@ describe('content-item import command', () => {
         { label: 'item4', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' }
       ];
 
-      await createContent('temp/import/missingType/', templates, false);
+      await createContent(`temp_${process.env.JEST_WORKER_ID}/import/missingType/`, templates, false);
 
       const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
       mockContent.createMockRepository('targetRepo');
@@ -481,8 +481,8 @@ describe('content-item import command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/import/missingType/',
-        mapFile: 'temp/import/missingType.json',
+        dir: `temp_${process.env.JEST_WORKER_ID}/import/missingType/`,
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/import/missingType.json`,
         baseRepo: 'targetRepo'
       };
       await handler(argv);
@@ -500,7 +500,7 @@ describe('content-item import command', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((readline as any).responsesLeft()).toEqual(0); // All responses consumed.
 
-      await rimraf('temp/import/missingType/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/missingType/`);
     });
 
     it('Importing content with a missing content type schema will ask if the affected content should be skipped (then create unaffected content)', async () => {
@@ -526,7 +526,7 @@ describe('content-item import command', () => {
         { label: 'item8', repoId: 'repo', typeSchemaUri: 'http://type2', folderPath: 'folderTest/special' }
       ];
 
-      await createContent('temp/import/missingSchema/', skipped.concat(added), false);
+      await createContent(`temp_${process.env.JEST_WORKER_ID}/import/missingSchema/`, skipped.concat(added), false);
 
       const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
       mockContent.createMockRepository('targetRepo');
@@ -542,8 +542,8 @@ describe('content-item import command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/import/missingSchema/',
-        mapFile: 'temp/import/missingSchema.json',
+        dir: `temp_${process.env.JEST_WORKER_ID}/import/missingSchema/`,
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/import/missingSchema.json`,
         baseRepo: 'targetRepo'
       };
       await handler(argv);
@@ -557,7 +557,7 @@ describe('content-item import command', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((readline as any).responsesLeft()).toEqual(0); // All responses consumed.
 
-      await rimraf('temp/import/missingSchema/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/missingSchema/`);
     });
 
     function genContentTypeWithReference(
@@ -657,13 +657,13 @@ describe('content-item import command', () => {
         { id: 'new5', label: 'item5', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' }
       ];
 
-      await createContent('temp/import/ref/', templates, false);
+      await createContent(`temp_${process.env.JEST_WORKER_ID}/import/ref/`, templates, false);
 
       // Add an existing mapping for the two items in "oldTemplates".
       const existingMapping = { contentItems: [['ref1', 'new1'], ['ref2', 'new2']] };
-      await ensureDirectoryExists('temp/import/ref/');
-      await rimraf('temp/import/ref.json');
-      await promisify(writeFile)('temp/import/ref.json', JSON.stringify(existingMapping));
+      await ensureDirectoryExists(`temp_${process.env.JEST_WORKER_ID}/import/ref/`);
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/ref.json`);
+      await promisify(writeFile)(`temp_${process.env.JEST_WORKER_ID}/import/ref.json`, JSON.stringify(existingMapping));
 
       const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
       mockContent.createMockRepository('repo');
@@ -678,8 +678,8 @@ describe('content-item import command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/import/ref/',
-        mapFile: 'temp/import/ref.json',
+        dir: `temp_${process.env.JEST_WORKER_ID}/import/ref/`,
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/import/ref.json`,
         baseRepo: 'repo'
       };
       await handler(argv);
@@ -698,7 +698,7 @@ describe('content-item import command', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((readline as any).responsesLeft()).toEqual(0); // All responses consumed.
 
-      await rimraf('temp/import/ref/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/ref/`);
     });
 
     it('Importing content with missing cross references should ask if the user wants to continue (and skip all dependant items)', async () => {
@@ -735,11 +735,11 @@ describe('content-item import command', () => {
         }
       ];
 
-      await createContent('temp/import/refMissing/', templates.concat(skips), false);
+      await createContent(`temp_${process.env.JEST_WORKER_ID}/import/refMissing/`, templates.concat(skips), false);
 
       // Add an existing mapping for the two items in "oldTemplates".
-      await ensureDirectoryExists('temp/import/refMissing/');
-      await rimraf('temp/import/refMissing.json');
+      await ensureDirectoryExists(`temp_${process.env.JEST_WORKER_ID}/import/refMissing/`);
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/refMissing.json`);
 
       const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
       mockContent.createMockRepository('repo');
@@ -753,8 +753,8 @@ describe('content-item import command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/import/refMissing/',
-        mapFile: 'temp/import/refMissing.json',
+        dir: `temp_${process.env.JEST_WORKER_ID}/import/refMissing/`,
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/import/refMissing.json`,
         baseRepo: 'repo',
         skipIncomplete: true
       };
@@ -774,7 +774,7 @@ describe('content-item import command', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((readline as any).responsesLeft()).toEqual(0); // All responses consumed.
 
-      await rimraf('temp/import/refMissing/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/refMissing/`);
     });
 
     it('Importing content with an existing mapping should ask if the user wants to overwrite existing content items (then overwrite it)', async () => {
@@ -806,13 +806,16 @@ describe('content-item import command', () => {
 
       oldTemplates.forEach(template => (template.label += 'updated')); // Should update existing content with this new label.
 
-      await createContent('temp/import/mapping/', oldTemplates.concat(templates), false);
+      await createContent(`temp_${process.env.JEST_WORKER_ID}/import/mapping/`, oldTemplates.concat(templates), false);
 
       // Add an existing mapping for the two items in "oldTemplates".
       const existingMapping = { contentItems: [['old1', 'new1'], ['old2', 'new2']] };
-      await ensureDirectoryExists('temp/import/mapping/');
-      await rimraf('temp/import/mapping.json');
-      await promisify(writeFile)('temp/import/mapping.json', JSON.stringify(existingMapping));
+      await ensureDirectoryExists(`temp_${process.env.JEST_WORKER_ID}/import/mapping/`);
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/mapping.json`);
+      await promisify(writeFile)(
+        `temp_${process.env.JEST_WORKER_ID}/import/mapping.json`,
+        JSON.stringify(existingMapping)
+      );
 
       const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
       mockContent.createMockRepository('repo');
@@ -824,8 +827,8 @@ describe('content-item import command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/import/mapping/',
-        mapFile: 'temp/import/mapping.json',
+        dir: `temp_${process.env.JEST_WORKER_ID}/import/mapping/`,
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/import/mapping.json`,
         baseRepo: 'repo'
       };
       await handler(argv);
@@ -847,7 +850,7 @@ describe('content-item import command', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((readline as any).responsesLeft()).toEqual(0); // All responses consumed.
 
-      await rimraf('temp/import/mapping/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/mapping/`);
     });
 
     it('Importing with the `force` flag should not ever await a response, and should skip and automate changes where necessary', async () => {
@@ -910,13 +913,20 @@ describe('content-item import command', () => {
 
       oldTemplates.forEach(template => (template.label += 'updated')); // Should update existing content with this new label.
 
-      await createContent('temp/import/force/', skips.concat(oldTemplates.concat(templates)), true);
+      await createContent(
+        `temp_${process.env.JEST_WORKER_ID}/import/force/`,
+        skips.concat(oldTemplates.concat(templates)),
+        true
+      );
 
       // Add an existing mapping for the two items in "oldTemplates".
       const existingMapping = { contentItems: [['old1', 'new1'], ['old2', 'new2']] };
-      await ensureDirectoryExists('temp/import/force/');
-      await rimraf('temp/import/force.json');
-      await promisify(writeFile)('temp/import/force.json', JSON.stringify(existingMapping));
+      await ensureDirectoryExists(`temp_${process.env.JEST_WORKER_ID}/import/force/`);
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/force.json`);
+      await promisify(writeFile)(
+        `temp_${process.env.JEST_WORKER_ID}/import/force.json`,
+        JSON.stringify(existingMapping)
+      );
 
       const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
       mockContent.createMockRepository('repo');
@@ -939,8 +949,8 @@ describe('content-item import command', () => {
         force: true,
         skipIncomplete: true, // Make it easier to detect that "yes" was said to the dependancy question
 
-        dir: 'temp/import/force/',
-        mapFile: 'temp/import/force.json',
+        dir: `temp_${process.env.JEST_WORKER_ID}/import/force/`,
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/import/force.json`,
         logFile: log
       };
       await handler(argv);
@@ -965,14 +975,14 @@ describe('content-item import command', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((readline as any).responsesLeft()).toEqual(0); // All responses consumed.
 
-      await rimraf('temp/import/force/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/force/`);
     });
 
     it('should exit without prompt when importing with no base and no content', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (readline as any).setResponses([]);
 
-      await ensureDirectoryExists('temp/import/none/');
+      await ensureDirectoryExists(`temp_${process.env.JEST_WORKER_ID}/import/none/`);
 
       const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
       mockContent.createMockRepository('repo');
@@ -986,23 +996,23 @@ describe('content-item import command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/import/none/',
-        mapFile: 'temp/import/none.json'
+        dir: `temp_${process.env.JEST_WORKER_ID}/import/none/`,
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/import/none.json`
       };
       await handler(argv);
 
       expect(mockContent.items.length).toEqual(0); // Should have done nothing
 
-      await rimraf('temp/import/none/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/none/`);
     });
 
     it("should exit when importing repositories that don't exist on the target, and the prompt to continue is declined", async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (readline as any).setResponses(['n']);
 
-      await ensureDirectoryExists('temp/import/repoMissing/');
-      await ensureDirectoryExists('temp/import/repoMissing/repo');
-      await ensureDirectoryExists('temp/import/repoMissing/repoMissing');
+      await ensureDirectoryExists(`temp_${process.env.JEST_WORKER_ID}/import/repoMissing/`);
+      await ensureDirectoryExists(`temp_${process.env.JEST_WORKER_ID}/import/repoMissing/repo`);
+      await ensureDirectoryExists(`temp_${process.env.JEST_WORKER_ID}/import/repoMissing/repoMissing`);
 
       const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
       mockContent.createMockRepository('repo');
@@ -1016,22 +1026,22 @@ describe('content-item import command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/import/repoMissing/',
-        mapFile: 'temp/import/repoMissing.json'
+        dir: `temp_${process.env.JEST_WORKER_ID}/import/repoMissing/`,
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/import/repoMissing.json`
       };
 
       expect(await handler(argv)).toBeFalsy();
 
       expect(mockContent.items.length).toEqual(0); // Should have done nothing
 
-      await rimraf('temp/import/repoMissing/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/repoMissing/`);
     });
 
     it('should exit without prompt when the content service is unreachable (all variants)', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (readline as any).setResponses([]);
 
-      await ensureDirectoryExists('temp/import/netError/');
+      await ensureDirectoryExists(`temp_${process.env.JEST_WORKER_ID}/import/netError/`);
 
       const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
       mockContent.failHubGet = true;
@@ -1040,8 +1050,8 @@ describe('content-item import command', () => {
       const argv0 = {
         ...yargArgs,
         ...config,
-        dir: 'temp/import/netError/',
-        mapFile: 'temp/import/netError.json'
+        dir: `temp_${process.env.JEST_WORKER_ID}/import/netError/`,
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/import/netError.json`
       };
       expect(await handler(argv0)).toBeFalsy();
 
@@ -1053,8 +1063,8 @@ describe('content-item import command', () => {
         ...yargArgs,
         ...config,
         baseFolder: 'ignore',
-        dir: 'temp/import/netError/',
-        mapFile: 'temp/import/netError.json'
+        dir: `temp_${process.env.JEST_WORKER_ID}/import/netError/`,
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/import/netError.json`
       };
       expect(await handler(argv1)).toBeFalsy();
 
@@ -1062,20 +1072,20 @@ describe('content-item import command', () => {
         ...yargArgs,
         ...config,
         baseRepo: 'ignore',
-        dir: 'temp/import/netError/',
-        mapFile: 'temp/import/netError.json'
+        dir: `temp_${process.env.JEST_WORKER_ID}/import/netError/`,
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/import/netError.json`
       };
       expect(await handler(argv2)).toBeFalsy();
 
       const argv3 = {
         ...yargArgs,
         ...config,
-        dir: 'temp/import/netError/',
-        mapFile: 'temp/import/netError.json'
+        dir: `temp_${process.env.JEST_WORKER_ID}/import/netError/`,
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/import/netError.json`
       };
       expect(await handler(argv3)).toBeFalsy();
 
-      await rimraf('temp/import/netError/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/netError/`);
     });
 
     it('should call import-revert if passed a revertLog', async () => {
@@ -1086,7 +1096,7 @@ describe('content-item import command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/import/unused/',
+        dir: `temp_${process.env.JEST_WORKER_ID}/import/unused/`,
         revertLog: Promise.resolve(new FileLog())
       };
 
@@ -1121,7 +1131,7 @@ describe('content-item import command', () => {
         { label: 'item4', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' }
       ];
 
-      await createContent('temp/import/publish/', templates, false);
+      await createContent(`temp_${process.env.JEST_WORKER_ID}/import/publish/`, templates, false);
 
       const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
       mockContent.createMockRepository('targetRepo');
@@ -1130,8 +1140,8 @@ describe('content-item import command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/import/publish/',
-        mapFile: 'temp/import/publish.json',
+        dir: `temp_${process.env.JEST_WORKER_ID}/import/publish/`,
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/import/publish.json`,
         baseRepo: 'targetRepo',
         publish: true
       };
@@ -1143,7 +1153,7 @@ describe('content-item import command', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((publish as any).publishCalls.length).toEqual(2);
 
-      await rimraf('temp/import/publish/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/publish/`);
     });
 
     const circularDependancies: ItemTemplate[] = [
@@ -1175,7 +1185,7 @@ describe('content-item import command', () => {
 
       const templates = circularDependancies;
 
-      await createContent('temp/import/circular/', templates, false);
+      await createContent(`temp_${process.env.JEST_WORKER_ID}/import/circular/`, templates, false);
 
       const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
       mockContent.createMockRepository('targetRepo');
@@ -1184,8 +1194,8 @@ describe('content-item import command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/import/circular/',
-        mapFile: 'temp/import/circular.json',
+        dir: `temp_${process.env.JEST_WORKER_ID}/import/circular/`,
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/import/circular.json`,
         baseRepo: 'targetRepo',
         publish: true
       };
@@ -1203,13 +1213,13 @@ describe('content-item import command', () => {
 
       expect(matches.length).toEqual(templates.length);
 
-      await rimraf('temp/import/circular/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/circular/`);
     });
 
     it('should not import any content if passed --validate', async () => {
       const templates: ItemTemplate[] = [{ label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type' }];
 
-      await createContent('temp/import/validate/', templates, false);
+      await createContent(`temp_${process.env.JEST_WORKER_ID}/import/validate/`, templates, false);
 
       const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
       mockContent.createMockRepository('targetRepo');
@@ -1218,8 +1228,8 @@ describe('content-item import command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/import/validate/',
-        mapFile: 'temp/import/validate.json',
+        dir: `temp_${process.env.JEST_WORKER_ID}/import/validate/`,
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/import/validate.json`,
         baseRepo: 'targetRepo',
         validate: true
       };
@@ -1229,7 +1239,7 @@ describe('content-item import command', () => {
       expect(mockContent.metrics.itemsCreated).toEqual(0);
       expect(mockContent.metrics.itemsUpdated).toEqual(0);
 
-      await rimraf('temp/import/validate/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/validate/`);
     });
 
     it('should ask for imported dependancies to be nullified if they are missing, and then skipped if invalid', async () => {
@@ -1240,7 +1250,7 @@ describe('content-item import command', () => {
         { label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type', body: dependsOn(['idNotExist']) }
       ];
 
-      await createContent('temp/import/depNull/', templates, false);
+      await createContent(`temp_${process.env.JEST_WORKER_ID}/import/depNull/`, templates, false);
 
       const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
       mockContent.createMockRepository('targetRepo');
@@ -1249,8 +1259,8 @@ describe('content-item import command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/import/depNull/',
-        mapFile: 'temp/import/depNull.json',
+        dir: `temp_${process.env.JEST_WORKER_ID}/import/depNull/`,
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/import/depNull.json`,
         baseRepo: 'targetRepo'
       };
       await handler(argv);
@@ -1258,7 +1268,7 @@ describe('content-item import command', () => {
       expect(mockContent.metrics.itemsCreated).toEqual(0);
       expect(mockContent.metrics.itemsUpdated).toEqual(0);
 
-      await rimraf('temp/import/depNull/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/depNull/`);
     });
 
     it('should abort when failing to create content', async () => {
@@ -1267,7 +1277,7 @@ describe('content-item import command', () => {
 
       const templates: ItemTemplate[] = [{ label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type' }];
 
-      await createContent('temp/import/abort1/', templates, false);
+      await createContent(`temp_${process.env.JEST_WORKER_ID}/import/abort1/`, templates, false);
 
       const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
       mockContent.failRepoActions = 'create';
@@ -1277,8 +1287,8 @@ describe('content-item import command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/import/abort1/',
-        mapFile: 'temp/import/abort1.json',
+        dir: `temp_${process.env.JEST_WORKER_ID}/import/abort1/`,
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/import/abort1.json`,
         baseRepo: 'targetRepo',
         publish: true
       };
@@ -1288,7 +1298,7 @@ describe('content-item import command', () => {
 
       expect(mockContent.metrics.itemsCreated).toEqual(0);
 
-      await rimraf('temp/import/abort1/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/abort1/`);
     });
 
     it('should abort when failing to create content with a circular dependancy', async () => {
@@ -1297,7 +1307,7 @@ describe('content-item import command', () => {
 
       const templates = circularDependancies.slice(0, 3);
 
-      await createContent('temp/import/abort2/', templates, false);
+      await createContent(`temp_${process.env.JEST_WORKER_ID}/import/abort2/`, templates, false);
 
       const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
       mockContent.failRepoActions = 'create';
@@ -1307,8 +1317,8 @@ describe('content-item import command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/import/abort2/',
-        mapFile: 'temp/import/abort2.json',
+        dir: `temp_${process.env.JEST_WORKER_ID}/import/abort2/`,
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/import/abort2.json`,
         baseRepo: 'targetRepo',
         publish: true
       };
@@ -1318,13 +1328,13 @@ describe('content-item import command', () => {
 
       expect(mockContent.metrics.itemsCreated).toEqual(0);
 
-      await rimraf('temp/import/abort2/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/abort2/`);
     });
 
     it('should call the media rewriter when --media is passed', async () => {
       const templates: ItemTemplate[] = [{ label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type' }];
 
-      await createContent('temp/import/media1/', templates, false);
+      await createContent(`temp_${process.env.JEST_WORKER_ID}/import/media1/`, templates, false);
 
       const mockContent = new MockContent(dynamicContentClientFactory as jest.Mock);
       mockContent.createMockRepository('targetRepo');
@@ -1333,8 +1343,8 @@ describe('content-item import command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/import/media1/',
-        mapFile: 'temp/import/media1.json',
+        dir: `temp_${process.env.JEST_WORKER_ID}/import/media1/`,
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/import/media1.json`,
         baseRepo: 'targetRepo',
         media: true
       };
@@ -1346,7 +1356,7 @@ describe('content-item import command', () => {
       expect(mockContent.metrics.itemsCreated).toEqual(1);
       expect(mockContent.metrics.itemsUpdated).toEqual(0);
 
-      await rimraf('temp/import/media1/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/import/media1/`);
     });
   });
 });

--- a/src/commands/content-item/move.spec.ts
+++ b/src/commands/content-item/move.spec.ts
@@ -165,7 +165,7 @@ describe('content-item move command', () => {
     };
 
     beforeAll(async () => {
-      await rimraf('temp/move/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/move/`);
     });
 
     const clearArray = (array: object[]): void => {
@@ -261,7 +261,10 @@ describe('content-item move command', () => {
       copyCalls.splice(0, copyCalls.length);
       revertCalls.splice(0, revertCalls.length);
 
-      await createLog('temp/move/moveRevert.txt', 'MOVED id1\nMOVED id2\nMOVED id3\nMOVED id4');
+      await createLog(
+        `temp_${process.env.JEST_WORKER_ID}/move/moveRevert.txt`,
+        'MOVED id1\nMOVED id2\nMOVED id3\nMOVED id4'
+      );
 
       // Create content to revert
 
@@ -303,7 +306,7 @@ describe('content-item move command', () => {
         dstClientId: 'acc2-id',
         dstSecret: 'acc2-secret',
 
-        revertLog: openRevertLog('temp/move/moveRevert.txt')
+        revertLog: openRevertLog(`temp_${process.env.JEST_WORKER_ID}/move/moveRevert.txt`)
       };
       await handler(argv);
 
@@ -323,14 +326,14 @@ describe('content-item move command', () => {
         logFile: expect.any(FileLog)
       });
 
-      rimraf('temp/move/moveRevert.txt');
+      rimraf(`temp_${process.env.JEST_WORKER_ID}/move/moveRevert.txt`);
     });
 
     it('should revert uninterrupted when fetching an item fails', async () => {
       const copyCalls: Arguments<CopyItemBuilderOptions & ConfigurationParameters>[] = copierAny.calls;
 
       // NOTE: id3 doesn't exist, but that's OK
-      await createLog('temp/move/moveRevertFetch.txt', 'MOVED id1\nMOVED id2\nMOVED id3');
+      await createLog(`temp_${process.env.JEST_WORKER_ID}/move/moveRevertFetch.txt`, 'MOVED id1\nMOVED id2\nMOVED id3');
 
       // Create content to revert
       const templates: ItemTemplate[] = [
@@ -359,14 +362,14 @@ describe('content-item move command', () => {
         dstClientId: 'acc2-id',
         dstSecret: 'acc2-secret',
 
-        revertLog: openRevertLog('temp/move/moveRevertFetch.txt')
+        revertLog: openRevertLog(`temp_${process.env.JEST_WORKER_ID}/move/moveRevertFetch.txt`)
       };
       await handler(argv);
 
       expect(mockContent.metrics.itemsUnarchived).toEqual(0);
       expect(copyCalls.length).toEqual(0);
 
-      rimraf('temp/move/moveRevertFetch.txt');
+      rimraf(`temp_${process.env.JEST_WORKER_ID}/move/moveRevertFetch.txt`);
     });
 
     // should revert uninterrupted when unarchiving an item fails
@@ -392,7 +395,7 @@ describe('content-item move command', () => {
         dstClientId: 'acc2-id',
         dstSecret: 'acc2-secret',
 
-        revertLog: openRevertLog('temp/move/moveRevertMissing.txt')
+        revertLog: openRevertLog(`temp_${process.env.JEST_WORKER_ID}/move/moveRevertMissing.txt`)
       };
       await handler(argv);
 
@@ -472,7 +475,7 @@ describe('content-item move command', () => {
         validate: false,
         skipIncomplete: false,
 
-        logFile: createFileLog('temp/move/failLog.txt')
+        logFile: createFileLog(`temp_${process.env.JEST_WORKER_ID}/move/failLog.txt`)
       };
       await handler(argv);
 

--- a/src/commands/content-item/tree.spec.ts
+++ b/src/commands/content-item/tree.spec.ts
@@ -101,7 +101,7 @@ describe('content-item tree command', () => {
     };
 
     beforeAll(async () => {
-      await rimraf('temp/tree/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/tree/`);
     });
 
     beforeEach(() => {
@@ -145,12 +145,12 @@ describe('content-item tree command', () => {
     });
 
     it('should print nothing if no content is present', async () => {
-      await ensureDirectoryExists('temp/tree/empty');
+      await ensureDirectoryExists(`temp_${process.env.JEST_WORKER_ID}/tree/empty`);
 
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/tree/empty'
+        dir: `temp_${process.env.JEST_WORKER_ID}/tree/empty`
       };
 
       await handler(argv);
@@ -159,7 +159,7 @@ describe('content-item tree command', () => {
     });
 
     it('should print a single content item by itself', async () => {
-      const basePath = 'temp/tree/single/repo1';
+      const basePath = `temp_${process.env.JEST_WORKER_ID}/tree/single/repo1`;
       await ensureDirectoryExists(basePath);
 
       await promisify(writeFile)(join(basePath, 'dummyFile.txt'), 'ignored');
@@ -175,7 +175,7 @@ describe('content-item tree command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/tree/single'
+        dir: `temp_${process.env.JEST_WORKER_ID}/tree/single`
       };
 
       await handler(argv);
@@ -184,7 +184,7 @@ describe('content-item tree command', () => {
     });
 
     it('should print a tree of content items', async () => {
-      const basePath = 'temp/tree/multiple/repo1';
+      const basePath = `temp_${process.env.JEST_WORKER_ID}/tree/multiple/repo1`;
       await ensureDirectoryExists(basePath);
 
       const shared = { typeSchemaUri: 'http://type.com', repoId: 'repo1' };
@@ -199,7 +199,7 @@ describe('content-item tree command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/tree/multiple'
+        dir: `temp_${process.env.JEST_WORKER_ID}/tree/multiple`
       };
 
       await handler(argv);
@@ -208,7 +208,7 @@ describe('content-item tree command', () => {
     });
 
     it('should print multiple disjoint trees of content items', async () => {
-      const basePath = 'temp/tree/disjoint/repo1';
+      const basePath = `temp_${process.env.JEST_WORKER_ID}/tree/disjoint/repo1`;
       await ensureDirectoryExists(basePath);
 
       const shared = { typeSchemaUri: 'http://type.com', repoId: 'repo1' };
@@ -226,7 +226,7 @@ describe('content-item tree command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/tree/disjoint'
+        dir: `temp_${process.env.JEST_WORKER_ID}/tree/disjoint`
       };
 
       await handler(argv);
@@ -235,7 +235,7 @@ describe('content-item tree command', () => {
     });
 
     it('should detect and print circular dependencies with a double line indicator', async () => {
-      const basePath = 'temp/tree/disjoint/repo1';
+      const basePath = `temp_${process.env.JEST_WORKER_ID}/tree/disjoint/repo1`;
       await ensureDirectoryExists(basePath);
 
       const shared = { typeSchemaUri: 'http://type.com', repoId: 'repo1' };
@@ -248,7 +248,7 @@ describe('content-item tree command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/tree/disjoint'
+        dir: `temp_${process.env.JEST_WORKER_ID}/tree/disjoint`
       };
 
       await handler(argv);
@@ -257,7 +257,7 @@ describe('content-item tree command', () => {
     });
 
     it('should detect intertwined circular dependencies with multiple lines with different position', async () => {
-      const basePath = 'temp/tree/intertwine/repo1';
+      const basePath = `temp_${process.env.JEST_WORKER_ID}/tree/intertwine/repo1`;
       await ensureDirectoryExists(basePath);
 
       const shared = { typeSchemaUri: 'http://type.com', repoId: 'repo1' };
@@ -273,7 +273,7 @@ describe('content-item tree command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/tree/intertwine'
+        dir: `temp_${process.env.JEST_WORKER_ID}/tree/intertwine`
       };
 
       await handler(argv);
@@ -282,7 +282,7 @@ describe('content-item tree command', () => {
     });
 
     it('should print an error when invalid json is found', async () => {
-      const basePath = 'temp/tree/invalud/repo1';
+      const basePath = `temp_${process.env.JEST_WORKER_ID}/tree/invalud/repo1`;
       await ensureDirectoryExists(basePath);
 
       await createContent(basePath, {
@@ -297,7 +297,7 @@ describe('content-item tree command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        dir: 'temp/tree/invalud'
+        dir: `temp_${process.env.JEST_WORKER_ID}/tree/invalud`
       };
 
       await handler(argv);

--- a/src/commands/content-item/unarchive.spec.ts
+++ b/src/commands/content-item/unarchive.spec.ts
@@ -635,7 +635,7 @@ describe('content-item unarchive command', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (readline as any).setResponses(['y']);
 
-      const logFileName = 'temp/content-item-unarchive.log';
+      const logFileName = `temp_${process.env.JEST_WORKER_ID}/content-item-unarchive.log`;
       const log = '// Type log test file\n' + 'ARCHIVE 1\n' + 'ARCHIVE 2 delivery-key\n' + 'ARCHIVE idMissing';
 
       const dir = dirname(logFileName);
@@ -687,11 +687,11 @@ describe('content-item unarchive command', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (readline as any).setResponses(['y']);
 
-      if (await promisify(exists)('temp/content-item-archive.log')) {
-        await promisify(unlink)('temp/content-item-archive.log');
+      if (await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/content-item-archive.log`)) {
+        await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/content-item-archive.log`);
       }
 
-      const logFileName = 'temp/content-item-unarchive.log';
+      const logFileName = `temp_${process.env.JEST_WORKER_ID}/content-item-unarchive.log`;
       const log = '// Type log test file\n' + 'ARCHIVE 1\n' + 'ARCHIVE 2\n' + 'ARCHIVE idMissing';
 
       const dir = dirname(logFileName);
@@ -722,8 +722,8 @@ describe('content-item unarchive command', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (readline as any).setResponses(['y']);
 
-      if (await promisify(exists)('temp/content-item-unarchive.log')) {
-        await promisify(unlink)('temp/content-item-unarchive.log');
+      if (await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/content-item-unarchive.log`)) {
+        await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/content-item-unarchive.log`);
       }
 
       const { mockItemGetById, mockUnarchive } = mockValues();
@@ -731,7 +731,7 @@ describe('content-item unarchive command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        logFile: 'temp/content-item-unarchive.log',
+        logFile: `temp_${process.env.JEST_WORKER_ID}/content-item-unarchive.log`,
         id: '1'
       };
 
@@ -740,11 +740,11 @@ describe('content-item unarchive command', () => {
       expect(mockItemGetById).toHaveBeenCalled();
       expect(mockUnarchive).toBeCalled();
 
-      const logExists = await promisify(exists)('temp/content-item-unarchive.log');
+      const logExists = await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/content-item-unarchive.log`);
 
       expect(logExists).toBeTruthy();
 
-      const log = await promisify(readFile)('temp/content-item-unarchive.log', 'utf8');
+      const log = await promisify(readFile)(`temp_${process.env.JEST_WORKER_ID}/content-item-unarchive.log`, 'utf8');
 
       const logLines = log.split('\n');
       let total = 0;
@@ -756,7 +756,7 @@ describe('content-item unarchive command', () => {
 
       expect(total).toEqual(1);
 
-      await promisify(unlink)('temp/content-item-unarchive.log');
+      await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/content-item-unarchive.log`);
     });
   });
 

--- a/src/commands/content-type-schema/archive.spec.ts
+++ b/src/commands/content-type-schema/archive.spec.ts
@@ -379,7 +379,7 @@ describe('content-item-schema archive command', () => {
       const targets: (() => Promise<ContentTypeSchema>)[] = [];
       const skips: (() => Promise<ContentTypeSchema>)[] = [];
 
-      const logFileName = 'temp/schema-archive-revert.log';
+      const logFileName = `temp_${process.env.JEST_WORKER_ID}/schema-archive-revert.log`;
       const log =
         '// Schema log test file\n' +
         'UNARCHIVE http://schemas.com/schemaMatch1\n' +
@@ -427,8 +427,8 @@ describe('content-item-schema archive command', () => {
 
     it('should output archived content to a well formatted log file with specified path in --logFile', async () => {
       // First, ensure the log does not already exist.
-      if (await promisify(exists)('temp/schema-archive-test.log')) {
-        await promisify(unlink)('temp/schema-archive-test.log');
+      if (await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/schema-archive-test.log`)) {
+        await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/schema-archive-test.log`);
       }
 
       const targets: string[] = [];
@@ -451,19 +451,19 @@ describe('content-item-schema archive command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        logFile: createLog('temp/schema-archive-test.log'),
+        logFile: createLog(`temp_${process.env.JEST_WORKER_ID}/schema-archive-test.log`),
         schemaId: '/schemaMatch/',
         force: true
       };
       await handler(argv);
 
-      const logExists = await promisify(exists)('temp/schema-archive-test.log');
+      const logExists = await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/schema-archive-test.log`);
 
       expect(logExists).toBeTruthy();
 
       // Log should contain the two schema that match.
 
-      const log = await promisify(readFile)('temp/schema-archive-test.log', 'utf8');
+      const log = await promisify(readFile)(`temp_${process.env.JEST_WORKER_ID}/schema-archive-test.log`, 'utf8');
 
       const logLines = log.split('\n');
       let total = 0;
@@ -479,13 +479,13 @@ describe('content-item-schema archive command', () => {
 
       expect(total).toEqual(2);
 
-      await promisify(unlink)('temp/schema-archive-test.log');
+      await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/schema-archive-test.log`);
     });
 
     it('should report a failed archive in the provided --logFile and exit immediately', async () => {
       // First, ensure the log does not already exist.
-      if (await promisify(exists)('temp/schema-archive-failed.log')) {
-        await promisify(unlink)('temp/schema-archive-failed.log');
+      if (await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/schema-archive-failed.log`)) {
+        await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/schema-archive-failed.log`);
       }
 
       const targets: string[] = [];
@@ -509,19 +509,19 @@ describe('content-item-schema archive command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        logFile: createLog('temp/schema-archive-failed.log'),
+        logFile: createLog(`temp_${process.env.JEST_WORKER_ID}/schema-archive-failed.log`),
         schemaId: '/schemaMatch/',
         force: true
       };
       await handler(argv);
 
-      const logExists = await promisify(exists)('temp/schema-archive-failed.log');
+      const logExists = await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/schema-archive-failed.log`);
 
       expect(logExists).toBeTruthy();
 
       // Log should contain the two schema that match (as failures)
 
-      const log = await promisify(readFile)('temp/schema-archive-failed.log', 'utf8');
+      const log = await promisify(readFile)(`temp_${process.env.JEST_WORKER_ID}/schema-archive-failed.log`, 'utf8');
 
       const logLines = log.split('\n');
       let total = 0;
@@ -533,13 +533,13 @@ describe('content-item-schema archive command', () => {
 
       expect(total).toEqual(1); // Does not continue to archive the next one
 
-      await promisify(unlink)('temp/schema-archive-failed.log');
+      await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/schema-archive-failed.log`);
     });
 
     it('should skip failed archives when --ignoreError is provided, but log all failures', async () => {
       // First, ensure the log does not already exist.
-      if (await promisify(exists)('temp/schema-archive-skip.log')) {
-        await promisify(unlink)('temp/schema-archive-skip.log');
+      if (await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/schema-archive-skip.log`)) {
+        await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/schema-archive-skip.log`);
       }
 
       const targets: string[] = [];
@@ -563,20 +563,20 @@ describe('content-item-schema archive command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        logFile: createLog('temp/schema-archive-skip.log'),
+        logFile: createLog(`temp_${process.env.JEST_WORKER_ID}/schema-archive-skip.log`),
         schemaId: '/schemaMatch/',
         ignoreError: true,
         force: true
       };
       await handler(argv);
 
-      const logExists = await promisify(exists)('temp/schema-archive-skip.log');
+      const logExists = await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/schema-archive-skip.log`);
 
       expect(logExists).toBeTruthy();
 
       // Log should contain the two schema that match (as failures)
 
-      const log = await promisify(readFile)('temp/schema-archive-skip.log', 'utf8');
+      const log = await promisify(readFile)(`temp_${process.env.JEST_WORKER_ID}/schema-archive-skip.log`, 'utf8');
 
       const logLines = log.split('\n');
       let total = 0;
@@ -588,7 +588,7 @@ describe('content-item-schema archive command', () => {
 
       expect(total).toEqual(2); // Fails to archive each matching type.
 
-      await promisify(unlink)('temp/schema-archive-skip.log');
+      await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/schema-archive-skip.log`);
     });
 
     it('should exit cleanly when no content can be archived', async () => {

--- a/src/commands/content-type-schema/unarchive.spec.ts
+++ b/src/commands/content-type-schema/unarchive.spec.ts
@@ -359,7 +359,7 @@ describe('content-item-schema unarchive command', () => {
       const targets: (() => Promise<ContentTypeSchema>)[] = [];
       const skips: (() => Promise<ContentTypeSchema>)[] = [];
 
-      const logFileName = 'temp/schema-unarchive-revert.log';
+      const logFileName = `temp_${process.env.JEST_WORKER_ID}/schema-unarchive-revert.log`;
       const log =
         '// Schema log test file\n' +
         'ARCHIVE http://schemas.com/schemaMatch1\n' +
@@ -406,7 +406,7 @@ describe('content-item-schema unarchive command', () => {
     });
 
     it('should output archived content to a well formatted log file with specified path in --logFile', async () => {
-      const logFileName = 'temp/type-unarchive-test.log';
+      const logFileName = `temp_${process.env.JEST_WORKER_ID}/type-unarchive-test.log`;
 
       // First, ensure the log does not already exist.
       if (await promisify(exists)(logFileName)) {
@@ -466,8 +466,8 @@ describe('content-item-schema unarchive command', () => {
 
     it('should report a failed unarchive in the provided --logFile and exit immediately', async () => {
       // First, ensure the log does not already exist.
-      if (await promisify(exists)('temp/schema-unarchive-failed.log')) {
-        await promisify(unlink)('temp/schema-unarchive-failed.log');
+      if (await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/schema-unarchive-failed.log`)) {
+        await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/schema-unarchive-failed.log`);
       }
 
       const targets: string[] = [];
@@ -491,19 +491,19 @@ describe('content-item-schema unarchive command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        logFile: 'temp/schema-unarchive-failed.log',
+        logFile: `temp_${process.env.JEST_WORKER_ID}/schema-unarchive-failed.log`,
         schemaId: '/schemaMatch/',
         force: true
       };
       await handler(argv);
 
-      const logExists = await promisify(exists)('temp/schema-unarchive-failed.log');
+      const logExists = await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/schema-unarchive-failed.log`);
 
       expect(logExists).toBeTruthy();
 
       // Log should contain the two schema that match (as failures)
 
-      const log = await promisify(readFile)('temp/schema-unarchive-failed.log', 'utf8');
+      const log = await promisify(readFile)(`temp_${process.env.JEST_WORKER_ID}/schema-unarchive-failed.log`, 'utf8');
 
       const logLines = log.split('\n');
       let total = 0;
@@ -515,13 +515,13 @@ describe('content-item-schema unarchive command', () => {
 
       expect(total).toEqual(1); // Does not continue to archive the next one
 
-      await promisify(unlink)('temp/schema-unarchive-failed.log');
+      await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/schema-unarchive-failed.log`);
     });
 
     it('should skip failed unarchives when --ignoreError is provided, but log all failures', async () => {
       // First, ensure the log does not already exist.
-      if (await promisify(exists)('temp/schema-unarchive-skip.log')) {
-        await promisify(unlink)('temp/schema-unarchive-skip.log');
+      if (await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/schema-unarchive-skip.log`)) {
+        await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/schema-unarchive-skip.log`);
       }
 
       const targets: string[] = [];
@@ -545,20 +545,20 @@ describe('content-item-schema unarchive command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        logFile: 'temp/schema-unarchive-skip.log',
+        logFile: `temp_${process.env.JEST_WORKER_ID}/schema-unarchive-skip.log`,
         schemaId: '/schemaMatch/',
         ignoreError: true,
         force: true
       };
       await handler(argv);
 
-      const logExists = await promisify(exists)('temp/schema-unarchive-skip.log');
+      const logExists = await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/schema-unarchive-skip.log`);
 
       expect(logExists).toBeTruthy();
 
       // Log should contain the two schema that match (as failures)
 
-      const log = await promisify(readFile)('temp/schema-unarchive-skip.log', 'utf8');
+      const log = await promisify(readFile)(`temp_${process.env.JEST_WORKER_ID}/schema-unarchive-skip.log`, 'utf8');
 
       const logLines = log.split('\n');
       let total = 0;
@@ -570,7 +570,7 @@ describe('content-item-schema unarchive command', () => {
 
       expect(total).toEqual(2); // Fails to archive each matching type.
 
-      await promisify(unlink)('temp/schema-unarchive-skip.log');
+      await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/schema-unarchive-skip.log`);
     });
 
     it('should exit cleanly when no content can be unarchived', async () => {

--- a/src/commands/content-type/archive.spec.ts
+++ b/src/commands/content-type/archive.spec.ts
@@ -401,7 +401,7 @@ describe('content-type archive command', () => {
       const targets: (() => Promise<ContentType>)[] = [];
       const skips: (() => Promise<ContentType>)[] = [];
 
-      const logFileName = 'temp/type-archive-revert.log';
+      const logFileName = `temp_${process.env.JEST_WORKER_ID}/type-archive-revert.log`;
       const log = '// Type log test file\n' + 'UNARCHIVE id1\n' + 'UNARCHIVE id2\n' + 'UNARCHIVE idMissing';
 
       const dir = dirname(logFileName);
@@ -444,8 +444,8 @@ describe('content-type archive command', () => {
 
     it('should output archived content to a well formatted log file with specified path in --logFile', async () => {
       // First, ensure the log does not already exist.
-      if (await promisify(exists)('temp/type-archive-test.log')) {
-        await promisify(unlink)('temp/type-archive-test.log');
+      if (await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/type-archive-test.log`)) {
+        await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/type-archive-test.log`);
       }
 
       const targets: string[] = [];
@@ -468,19 +468,19 @@ describe('content-type archive command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        logFile: createLog('temp/type-archive-test.log'),
+        logFile: createLog(`temp_${process.env.JEST_WORKER_ID}/type-archive-test.log`),
         schemaId: '/schemaMatch/',
         force: true
       };
       await handler(argv);
 
-      const logExists = await promisify(exists)('temp/type-archive-test.log');
+      const logExists = await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/type-archive-test.log`);
 
       expect(logExists).toBeTruthy();
 
       // Log should contain the two schema that match.
 
-      const log = await promisify(readFile)('temp/type-archive-test.log', 'utf8');
+      const log = await promisify(readFile)(`temp_${process.env.JEST_WORKER_ID}/type-archive-test.log`, 'utf8');
 
       const logLines = log.split('\n');
       let total = 0;
@@ -496,13 +496,13 @@ describe('content-type archive command', () => {
 
       expect(total).toEqual(2);
 
-      await promisify(unlink)('temp/type-archive-test.log');
+      await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/type-archive-test.log`);
     });
 
     it('should report a failed archive in the provided --logFile and exit immediately', async () => {
       // First, ensure the log does not already exist.
-      if (await promisify(exists)('temp/type-archive-failed.log')) {
-        await promisify(unlink)('temp/type-archive-failed.log');
+      if (await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/type-archive-failed.log`)) {
+        await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/type-archive-failed.log`);
       }
 
       const targets: string[] = [];
@@ -526,19 +526,19 @@ describe('content-type archive command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        logFile: createLog('temp/type-archive-failed.log'),
+        logFile: createLog(`temp_${process.env.JEST_WORKER_ID}/type-archive-failed.log`),
         schemaId: '/schemaMatch/',
         force: true
       };
       await handler(argv);
 
-      const logExists = await promisify(exists)('temp/type-archive-failed.log');
+      const logExists = await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/type-archive-failed.log`);
 
       expect(logExists).toBeTruthy();
 
       // Log should contain the two schema that match (as failures)
 
-      const log = await promisify(readFile)('temp/type-archive-failed.log', 'utf8');
+      const log = await promisify(readFile)(`temp_${process.env.JEST_WORKER_ID}/type-archive-failed.log`, 'utf8');
 
       const logLines = log.split('\n');
       let total = 0;
@@ -550,13 +550,13 @@ describe('content-type archive command', () => {
 
       expect(total).toEqual(1); // Does not continue to archive the next one
 
-      await promisify(unlink)('temp/type-archive-failed.log');
+      await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/type-archive-failed.log`);
     });
 
     it('should skip failed archives when --ignoreError is provided, but log all failures', async () => {
       // First, ensure the log does not already exist.
-      if (await promisify(exists)('temp/type-archive-skip.log')) {
-        await promisify(unlink)('temp/type-archive-skip.log');
+      if (await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/type-archive-skip.log`)) {
+        await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/type-archive-skip.log`);
       }
 
       const targets: string[] = [];
@@ -580,20 +580,20 @@ describe('content-type archive command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        logFile: createLog('temp/type-archive-skip.log'),
+        logFile: createLog(`temp_${process.env.JEST_WORKER_ID}/type-archive-skip.log`),
         schemaId: '/schemaMatch/',
         ignoreError: true,
         force: true
       };
       await handler(argv);
 
-      const logExists = await promisify(exists)('temp/type-archive-skip.log');
+      const logExists = await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/type-archive-skip.log`);
 
       expect(logExists).toBeTruthy();
 
       // Log should contain the two schema that match (as failures)
 
-      const log = await promisify(readFile)('temp/type-archive-skip.log', 'utf8');
+      const log = await promisify(readFile)(`temp_${process.env.JEST_WORKER_ID}/type-archive-skip.log`, 'utf8');
 
       const logLines = log.split('\n');
       let total = 0;
@@ -605,7 +605,7 @@ describe('content-type archive command', () => {
 
       expect(total).toEqual(2); // Fails to archive each matching type.
 
-      await promisify(unlink)('temp/type-archive-skip.log');
+      await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/type-archive-skip.log`);
     });
 
     it('should exit cleanly when no content can be archived', async () => {

--- a/src/commands/content-type/unarchive.spec.ts
+++ b/src/commands/content-type/unarchive.spec.ts
@@ -387,7 +387,7 @@ describe('content-type unarchive command', () => {
       const targets: (() => Promise<ContentType>)[] = [];
       const skips: (() => Promise<ContentType>)[] = [];
 
-      const logFileName = 'temp/type-unarchive-revert.log';
+      const logFileName = `temp_${process.env.JEST_WORKER_ID}/type-unarchive-revert.log`;
       const log = '// Type log test file\n' + 'ARCHIVE id1\n' + 'ARCHIVE id2\n' + 'ARCHIVE missing';
 
       const dir = dirname(logFileName);
@@ -431,7 +431,7 @@ describe('content-type unarchive command', () => {
 
     it('should output unarchived content to a well formatted log file with specified path in --logFile', async () => {
       // First, ensure the log does not already exist.
-      const logFileName = 'temp/type-unarchive-test.log';
+      const logFileName = `temp_${process.env.JEST_WORKER_ID}/type-unarchive-test.log`;
 
       if (await promisify(exists)(logFileName)) {
         await promisify(unlink)(logFileName);
@@ -490,8 +490,8 @@ describe('content-type unarchive command', () => {
 
     it('should report a failed unarchive in the provided --logFile and exit immediately', async () => {
       // First, ensure the log does not already exist.
-      if (await promisify(exists)('temp/type-unarchive-failed.log')) {
-        await promisify(unlink)('temp/type-unarchive-failed.log');
+      if (await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/type-unarchive-failed.log`)) {
+        await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/type-unarchive-failed.log`);
       }
 
       const targets: string[] = [];
@@ -515,19 +515,19 @@ describe('content-type unarchive command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        logFile: 'temp/type-unarchive-failed.log',
+        logFile: `temp_${process.env.JEST_WORKER_ID}/type-unarchive-failed.log`,
         schemaId: '/schemaMatch/',
         force: true
       };
       await handler(argv);
 
-      const logExists = await promisify(exists)('temp/type-unarchive-failed.log');
+      const logExists = await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/type-unarchive-failed.log`);
 
       expect(logExists).toBeTruthy();
 
       // Log should contain the two schema that match (as failures)
 
-      const log = await promisify(readFile)('temp/type-unarchive-failed.log', 'utf8');
+      const log = await promisify(readFile)(`temp_${process.env.JEST_WORKER_ID}/type-unarchive-failed.log`, 'utf8');
 
       const logLines = log.split('\n');
       let total = 0;
@@ -539,13 +539,13 @@ describe('content-type unarchive command', () => {
 
       expect(total).toEqual(1); // Does not continue to archive the next one
 
-      await promisify(unlink)('temp/type-unarchive-failed.log');
+      await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/type-unarchive-failed.log`);
     });
 
     it('should skip failed unarchives when --ignoreError is provided, but log all failures', async () => {
       // First, ensure the log does not already exist.
-      if (await promisify(exists)('temp/type-unarchive-skip.log')) {
-        await promisify(unlink)('temp/type-unarchive-skip.log');
+      if (await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/type-unarchive-skip.log`)) {
+        await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/type-unarchive-skip.log`);
       }
 
       const targets: string[] = [];
@@ -569,20 +569,20 @@ describe('content-type unarchive command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        logFile: 'temp/type-unarchive-skip.log',
+        logFile: `temp_${process.env.JEST_WORKER_ID}/type-unarchive-skip.log`,
         schemaId: '/schemaMatch/',
         ignoreError: true,
         force: true
       };
       await handler(argv);
 
-      const logExists = await promisify(exists)('temp/type-unarchive-skip.log');
+      const logExists = await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/type-unarchive-skip.log`);
 
       expect(logExists).toBeTruthy();
 
       // Log should contain the two schema that match (as failures)
 
-      const log = await promisify(readFile)('temp/type-unarchive-skip.log', 'utf8');
+      const log = await promisify(readFile)(`temp_${process.env.JEST_WORKER_ID}/type-unarchive-skip.log`, 'utf8');
 
       const logLines = log.split('\n');
       let total = 0;
@@ -594,7 +594,7 @@ describe('content-type unarchive command', () => {
 
       expect(total).toEqual(2); // Fails to archive each matching type.
 
-      await promisify(unlink)('temp/type-unarchive-skip.log');
+      await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/type-unarchive-skip.log`);
     });
 
     it('should exit cleanly when no content can be unarchived', async () => {

--- a/src/commands/event/archive.spec.ts
+++ b/src/commands/event/archive.spec.ts
@@ -577,7 +577,7 @@ describe('event archive command', () => {
         status: 'DRAFT'
       });
 
-      const logFile = 'tmp/event-archive.log';
+      const logFile = `temp_${process.env.JEST_WORKER_ID}/event-archive.log`;
 
       const argv = {
         ...yargArgs,
@@ -655,8 +655,8 @@ describe('event archive command', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (readline as any).setResponses(['y']);
 
-      if (await promisify(exists)('temp/event-archive.log')) {
-        await promisify(unlink)('temp/event-archive.log');
+      if (await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/event-archive.log`)) {
+        await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/event-archive.log`);
       }
 
       const { mockGet, mockEditionsList, archiveMock } = mockValues({ status: 'SHCEDULED' });
@@ -665,7 +665,7 @@ describe('event archive command', () => {
         ...yargArgs,
         ...config,
         silent: false,
-        logFile: new FileLog('temp/event-archive.log'),
+        logFile: new FileLog(`temp_${process.env.JEST_WORKER_ID}/event-archive.log`),
         id: '1'
       };
 
@@ -675,11 +675,11 @@ describe('event archive command', () => {
       expect(mockEditionsList).toHaveBeenCalled();
       expect(archiveMock).toHaveBeenCalled();
 
-      const logExists = await promisify(exists)('temp/event-archive.log');
+      const logExists = await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/event-archive.log`);
 
       expect(logExists).toBeTruthy();
 
-      const log = await promisify(readFile)('temp/event-archive.log', 'utf8');
+      const log = await promisify(readFile)(`temp_${process.env.JEST_WORKER_ID}/event-archive.log`, 'utf8');
 
       const logLines = log.split('\n');
       let total = 0;
@@ -691,7 +691,7 @@ describe('event archive command', () => {
 
       expect(total).toEqual(1);
 
-      await promisify(unlink)('temp/event-archive.log');
+      await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/event-archive.log`);
     });
   });
 });

--- a/src/commands/hub/clean.spec.ts
+++ b/src/commands/hub/clean.spec.ts
@@ -134,11 +134,11 @@ describe('hub clean command', () => {
     };
 
     beforeAll(async () => {
-      await rimraf('temp/clean/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/clean/`);
     });
 
     afterAll(async () => {
-      await rimraf('temp/clean/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/clean/`);
     });
 
     it('should call all steps in order with given parameters', async () => {
@@ -149,7 +149,7 @@ describe('hub clean command', () => {
         ...yargArgs,
         ...config,
 
-        logFile: createLog('temp/clean/steps/all.log'),
+        logFile: createLog(`temp_${process.env.JEST_WORKER_ID}/clean/steps/all.log`),
         force: true
       };
 
@@ -166,7 +166,7 @@ describe('hub clean command', () => {
       });
 
       const loadLog = new FileLog();
-      await loadLog.loadFromFile('temp/clean/steps/all.log');
+      await loadLog.loadFromFile(`temp_${process.env.JEST_WORKER_ID}/clean/steps/all.log`);
     });
 
     it('should handle false returns from each of the steps by stopping the process', async () => {
@@ -178,7 +178,7 @@ describe('hub clean command', () => {
           ...yargArgs,
           ...config,
 
-          logFile: createLog('temp/clean/steps/fail' + i + '.log'),
+          logFile: createLog(`temp_${process.env.JEST_WORKER_ID}/clean/steps/fail` + i + '.log'),
           force: true
         };
 
@@ -197,7 +197,7 @@ describe('hub clean command', () => {
         });
 
         const loadLog = new FileLog();
-        await loadLog.loadFromFile('temp/clean/steps/fail' + i + '.log');
+        await loadLog.loadFromFile(`temp_${process.env.JEST_WORKER_ID}/clean/steps/fail` + i + '.log');
       }
     });
 
@@ -211,7 +211,7 @@ describe('hub clean command', () => {
           ...config,
 
           step: steps[i].getId(),
-          logFile: createLog('temp/clean/steps/step' + i + '.log'),
+          logFile: createLog(`temp_${process.env.JEST_WORKER_ID}/clean/steps/step` + i + '.log'),
           force: true
         };
 
@@ -230,7 +230,7 @@ describe('hub clean command', () => {
         });
 
         const loadLog = new FileLog();
-        await loadLog.loadFromFile('temp/clean/steps/step' + i + '.log');
+        await loadLog.loadFromFile(`temp_${process.env.JEST_WORKER_ID}/clean/steps/step` + i + '.log');
       }
     });
 

--- a/src/commands/hub/clone.spec.ts
+++ b/src/commands/hub/clone.spec.ts
@@ -234,11 +234,11 @@ describe('hub clone command', () => {
     };
 
     beforeAll(async () => {
-      await rimraf('temp/clone/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/clone/`);
     });
 
     afterAll(async () => {
-      await rimraf('temp/clone/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/clone/`);
     });
 
     function makeState(argv: Arguments<CloneHubBuilderOptions & ConfigurationParameters>): CloneHubState {
@@ -269,12 +269,12 @@ describe('hub clone command', () => {
         ...yargArgs,
         ...config,
 
-        dir: 'temp/clone/steps',
+        dir: `temp_${process.env.JEST_WORKER_ID}/clone/steps`,
 
         dstHubId: 'hub2-id',
         dstClientId: 'acc2-id',
         dstSecret: 'acc2-secret',
-        logFile: createLog('temp/clone/steps/all.log'),
+        logFile: createLog(`temp_${process.env.JEST_WORKER_ID}/clone/steps/all.log`),
 
         force: false,
         validate: false,
@@ -297,7 +297,7 @@ describe('hub clone command', () => {
       });
 
       const loadLog = new FileLog();
-      await loadLog.loadFromFile('temp/clone/steps/all.log');
+      await loadLog.loadFromFile(`temp_${process.env.JEST_WORKER_ID}/clone/steps/all.log`);
     });
 
     it('should handle false returns from each of the steps by stopping the process', async () => {
@@ -309,14 +309,14 @@ describe('hub clone command', () => {
           ...yargArgs,
           ...config,
 
-          dir: 'temp/clone/steps',
+          dir: `temp_${process.env.JEST_WORKER_ID}/clone/steps`,
 
           dstHubId: 'hub2-id',
           dstClientId: 'acc2-id',
           dstSecret: 'acc2-secret',
-          logFile: createLog('temp/clone/steps/fail' + i + '.log'),
+          logFile: createLog(`temp_${process.env.JEST_WORKER_ID}/clone/steps/fail` + i + '.log'),
 
-          mapFile: 'temp/clone/steps/fail' + i + '.json',
+          mapFile: `temp_${process.env.JEST_WORKER_ID}/clone/steps/fail` + i + '.json',
           force: false,
           validate: false,
           skipIncomplete: false,
@@ -340,7 +340,7 @@ describe('hub clone command', () => {
         });
 
         const loadLog = new FileLog();
-        await loadLog.loadFromFile('temp/clone/steps/fail' + i + '.log');
+        await loadLog.loadFromFile(`temp_${process.env.JEST_WORKER_ID}/clone/steps/fail` + i + '.log');
       }
     });
 
@@ -355,14 +355,14 @@ describe('hub clone command', () => {
 
           step: steps[i].getId(),
 
-          dir: 'temp/clone/steps',
+          dir: `temp_${process.env.JEST_WORKER_ID}/clone/steps`,
 
           dstHubId: 'hub2-id',
           dstClientId: 'acc2-id',
           dstSecret: 'acc2-secret',
-          logFile: createLog('temp/clone/steps/step' + i + '.log'),
+          logFile: createLog(`temp_${process.env.JEST_WORKER_ID}/clone/steps/step` + i + '.log'),
 
-          mapFile: 'temp/clone/steps/step' + i + '.json',
+          mapFile: `temp_${process.env.JEST_WORKER_ID}/clone/steps/step` + i + '.json',
           force: false,
           validate: false,
           skipIncomplete: false,
@@ -386,7 +386,7 @@ describe('hub clone command', () => {
         });
 
         const loadLog = new FileLog();
-        await loadLog.loadFromFile('temp/clone/steps/step' + i + '.log');
+        await loadLog.loadFromFile(`temp_${process.env.JEST_WORKER_ID}/clone/steps/step` + i + '.log');
       }
     });
 
@@ -416,11 +416,11 @@ describe('hub clone command', () => {
     };
 
     beforeAll(async () => {
-      await rimraf('temp/clone-revert/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/clone-revert/`);
     });
 
     afterAll(async () => {
-      await rimraf('temp/clone-revert/');
+      await rimraf(`temp_${process.env.JEST_WORKER_ID}/clone-revert/`);
     });
 
     async function prepareFakeLog(path: string): Promise<void> {
@@ -458,22 +458,22 @@ describe('hub clone command', () => {
     it('should revert all steps in order with given parameters', async () => {
       clearMocks();
       success = [true, true, true, true];
-      await ensureDirectoryExists('temp/clone-revert/');
-      await prepareFakeLog('temp/clone-revert/steps.log');
+      await ensureDirectoryExists(`temp_${process.env.JEST_WORKER_ID}/clone-revert/`);
+      await prepareFakeLog(`temp_${process.env.JEST_WORKER_ID}/clone-revert/steps.log`);
 
       const argv: Arguments<CloneHubBuilderOptions & ConfigurationParameters> = {
         ...yargArgs,
         ...config,
 
-        dir: 'temp/clone-revert/steps',
+        dir: `temp_${process.env.JEST_WORKER_ID}/clone-revert/steps`,
 
         dstHubId: 'hub2-id',
         dstClientId: 'acc2-id',
         dstSecret: 'acc2-secret',
-        logFile: createLog('temp/clone-revert/steps/all.log'),
-        revertLog: openRevertLog('temp/clone-revert/steps.log'),
+        logFile: createLog(`temp_${process.env.JEST_WORKER_ID}/clone-revert/steps/all.log`),
+        revertLog: openRevertLog(`temp_${process.env.JEST_WORKER_ID}/clone-revert/steps.log`),
 
-        mapFile: 'temp/clone-revert/steps/all.json',
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/clone-revert/steps/all.json`,
         force: false,
         validate: false,
         skipIncomplete: false,
@@ -493,7 +493,7 @@ describe('hub clone command', () => {
       });
 
       const loadLog = new FileLog();
-      await loadLog.loadFromFile('temp/clone-revert/steps/all.log');
+      await loadLog.loadFromFile(`temp_${process.env.JEST_WORKER_ID}/clone-revert/steps/all.log`);
     });
 
     it('should handle exceptions from each of the revert steps by stopping the process', async () => {
@@ -501,22 +501,22 @@ describe('hub clone command', () => {
         clearMocks();
         success = [i != 0, i != 1, i != 2, i != 3];
 
-        await ensureDirectoryExists('temp/clone-revert/');
-        await prepareFakeLog('temp/clone-revert/fail.log');
+        await ensureDirectoryExists(`temp_${process.env.JEST_WORKER_ID}/clone-revert/`);
+        await prepareFakeLog(`temp_${process.env.JEST_WORKER_ID}/clone-revert/fail.log`);
 
         const argv: Arguments<CloneHubBuilderOptions & ConfigurationParameters> = {
           ...yargArgs,
           ...config,
 
-          dir: 'temp/clone-revert/fail',
+          dir: `temp_${process.env.JEST_WORKER_ID}/clone-revert/fail`,
 
           dstHubId: 'hub2-id',
           dstClientId: 'acc2-id',
           dstSecret: 'acc2-secret',
-          logFile: createLog('temp/clone-revert/fail/fail' + i + '.log'),
-          revertLog: openRevertLog('temp/clone-revert/fail.log'),
+          logFile: createLog(`temp_${process.env.JEST_WORKER_ID}/clone-revert/fail/fail` + i + '.log'),
+          revertLog: openRevertLog(`temp_${process.env.JEST_WORKER_ID}/clone-revert/fail.log`),
 
-          mapFile: 'temp/clone-revert/fail/fail' + i + '.json',
+          mapFile: `temp_${process.env.JEST_WORKER_ID}/clone-revert/fail/fail` + i + '.json',
           force: false,
           validate: false,
           skipIncomplete: false,
@@ -540,28 +540,28 @@ describe('hub clone command', () => {
         });
 
         const loadLog = new FileLog();
-        await loadLog.loadFromFile('temp/clone-revert/fail/fail' + i + '.log');
+        await loadLog.loadFromFile(`temp_${process.env.JEST_WORKER_ID}/clone-revert/fail/fail` + i + '.log');
       }
     });
 
     it('should exit early if revert log cannot be read', async () => {
       clearMocks();
       success = [true, true, true, true];
-      await ensureDirectoryExists('temp/clone-revert/');
+      await ensureDirectoryExists(`temp_${process.env.JEST_WORKER_ID}/clone-revert/`);
 
       const argv: Arguments<CloneHubBuilderOptions & ConfigurationParameters> = {
         ...yargArgs,
         ...config,
 
-        dir: 'temp/clone-revert/steps',
+        dir: `temp_${process.env.JEST_WORKER_ID}/clone-revert/steps`,
 
         dstHubId: 'hub2-id',
         dstClientId: 'acc2-id',
         dstSecret: 'acc2-secret',
-        logFile: createLog('temp/clone-revert/steps/early.log'),
-        revertLog: openRevertLog('temp/clone-revert/missing.log'),
+        logFile: createLog(`temp_${process.env.JEST_WORKER_ID}/clone-revert/steps/early.log`),
+        revertLog: openRevertLog(`temp_${process.env.JEST_WORKER_ID}/clone-revert/missing.log`),
 
-        mapFile: 'temp/clone-revert/steps/all.json',
+        mapFile: `temp_${process.env.JEST_WORKER_ID}/clone-revert/steps/all.json`,
         force: false,
         validate: false,
         skipIncomplete: false,
@@ -579,7 +579,7 @@ describe('hub clone command', () => {
       });
 
       const loadLog = new FileLog();
-      await loadLog.loadFromFile('temp/clone-revert/steps/early.log');
+      await loadLog.loadFromFile(`temp_${process.env.JEST_WORKER_ID}/clone-revert/steps/early.log`);
     });
 
     it('should start reverting from the step given as a parameter (steps in decreasing order)', async () => {
@@ -587,8 +587,8 @@ describe('hub clone command', () => {
         clearMocks();
         success = [true, true, true, true];
 
-        await ensureDirectoryExists('temp/clone-revert/');
-        await prepareFakeLog('temp/clone-revert/step.log');
+        await ensureDirectoryExists(`temp_${process.env.JEST_WORKER_ID}/clone-revert/`);
+        await prepareFakeLog(`temp_${process.env.JEST_WORKER_ID}/clone-revert/step.log`);
 
         const argv: Arguments<CloneHubBuilderOptions & ConfigurationParameters> = {
           ...yargArgs,
@@ -596,15 +596,15 @@ describe('hub clone command', () => {
 
           step: steps[i].getId(),
 
-          dir: 'temp/clone-revert/step',
+          dir: `temp_${process.env.JEST_WORKER_ID}/clone-revert/step`,
 
           dstHubId: 'hub2-id',
           dstClientId: 'acc2-id',
           dstSecret: 'acc2-secret',
-          logFile: createLog('temp/clone-revert/step/step' + i + '.log'),
-          revertLog: openRevertLog('temp/clone-revert/step.log'),
+          logFile: createLog(`temp_${process.env.JEST_WORKER_ID}/clone-revert/step/step` + i + '.log'),
+          revertLog: openRevertLog(`temp_${process.env.JEST_WORKER_ID}/clone-revert/step.log`),
 
-          mapFile: 'temp/clone-revert/step/step' + i + '.json',
+          mapFile: `temp_${process.env.JEST_WORKER_ID}/clone-revert/step/step` + i + '.json',
           force: false,
           validate: false,
           skipIncomplete: false,
@@ -628,7 +628,7 @@ describe('hub clone command', () => {
         });
 
         const loadLog = new FileLog();
-        await loadLog.loadFromFile('temp/clone-revert/step/step' + i + '.log');
+        await loadLog.loadFromFile(`temp_${process.env.JEST_WORKER_ID}/clone-revert/step/step` + i + '.log');
       }
     });
   });

--- a/src/commands/hub/steps/content-clean-step.spec.ts
+++ b/src/commands/hub/steps/content-clean-step.spec.ts
@@ -55,7 +55,7 @@ describe('content clean step', () => {
   });
 
   it('should call the copy command with arguments from the state', async () => {
-    const argv = generateState('temp/clean-content/run/', 'run');
+    const argv = generateState(`temp_${process.env.JEST_WORKER_ID}/clean-content/run/`, 'run');
 
     (archive.handler as jest.Mock).mockResolvedValue(true);
 
@@ -70,7 +70,7 @@ describe('content clean step', () => {
   });
 
   it('should return false when the copy command fails', async () => {
-    const argv = generateState('temp/clean-content/fail/', 'fail');
+    const argv = generateState(`temp_${process.env.JEST_WORKER_ID}/clean-content/fail/`, 'fail');
 
     (archive.handler as jest.Mock).mockRejectedValue(false);
 

--- a/src/commands/hub/steps/content-clone-step.spec.ts
+++ b/src/commands/hub/steps/content-clone-step.spec.ts
@@ -83,7 +83,7 @@ describe('content clone step', () => {
   });
 
   it('should call the copy command with arguments from the state', async () => {
-    const state = generateState('temp/clone-content/run/', 'run');
+    const state = generateState(`temp_${process.env.JEST_WORKER_ID}/clone-content/run/`, 'run');
 
     const copyCalls: Arguments<CopyItemBuilderOptions & ConfigurationParameters>[] = copierAny.calls;
     copyCalls.splice(0, copyCalls.length);
@@ -105,7 +105,7 @@ describe('content clone step', () => {
   });
 
   it('should return false when the copy command fails', async () => {
-    const state = generateState('temp/clone-content/fail/', 'fail');
+    const state = generateState(`temp_${process.env.JEST_WORKER_ID}/clone-content/fail/`, 'fail');
 
     const copyCalls: Arguments<CopyItemBuilderOptions & ConfigurationParameters>[] = copierAny.calls;
     copyCalls.splice(0, copyCalls.length);
@@ -119,7 +119,7 @@ describe('content clone step', () => {
   });
 
   it('should call the copy revert command with arguments from the state', async () => {
-    const state = generateState('temp/clone-content/run/', 'run');
+    const state = generateState(`temp_${process.env.JEST_WORKER_ID}/clone-content/run/`, 'run');
     state.revertLog = new FileLog();
 
     const copyCalls: Arguments<CopyItemBuilderOptions & ConfigurationParameters>[] = copierAny.calls;
@@ -142,7 +142,7 @@ describe('content clone step', () => {
   });
 
   it('should return false when the copy revert command fails', async () => {
-    const state = generateState('temp/clone-content/fail/', 'fail');
+    const state = generateState(`temp_${process.env.JEST_WORKER_ID}/clone-content/fail/`, 'fail');
     state.revertLog = new FileLog();
 
     const copyCalls: Arguments<CopyItemBuilderOptions & ConfigurationParameters>[] = copierAny.calls;

--- a/src/commands/hub/steps/schema-clean-step.spec.ts
+++ b/src/commands/hub/steps/schema-clean-step.spec.ts
@@ -55,7 +55,7 @@ describe('schema clean step', () => {
   });
 
   it('should call the copy command with arguments from the state', async () => {
-    const argv = generateState('temp/clean-schema/run/', 'run');
+    const argv = generateState(`temp_${process.env.JEST_WORKER_ID}/clean-schema/run/`, 'run');
 
     (archive.handler as jest.Mock).mockResolvedValue(true);
 
@@ -70,7 +70,7 @@ describe('schema clean step', () => {
   });
 
   it('should return false when the copy command fails', async () => {
-    const argv = generateState('temp/clean-schema/fail/', 'fail');
+    const argv = generateState(`temp_${process.env.JEST_WORKER_ID}/clean-schema/fail/`, 'fail');
 
     (archive.handler as jest.Mock).mockRejectedValue(false);
 

--- a/src/commands/hub/steps/schema-clone-step.spec.ts
+++ b/src/commands/hub/steps/schema-clone-step.spec.ts
@@ -54,11 +54,11 @@ describe('schema clone step', () => {
   });
 
   beforeAll(async () => {
-    await rimraf('temp/clone-schema/');
+    await rimraf(`temp_${process.env.JEST_WORKER_ID}/clone-schema/`);
   });
 
   afterAll(async () => {
-    await rimraf('temp/clone-schema/');
+    await rimraf(`temp_${process.env.JEST_WORKER_ID}/clone-schema/`);
   });
 
   function generateState(directory: string, logName: string): CloneHubState {
@@ -105,7 +105,7 @@ describe('schema clone step', () => {
   });
 
   it('should call export on the source and import to the destination', async () => {
-    const state = generateState('temp/clone-schema/run/', 'run');
+    const state = generateState(`temp_${process.env.JEST_WORKER_ID}/clone-schema/run/`, 'run');
 
     (schemaImport.handler as jest.Mock).mockResolvedValue(true);
     (schemaExport.handler as jest.Mock).mockResolvedValue(true);
@@ -130,7 +130,7 @@ describe('schema clone step', () => {
   });
 
   it('should fail the step when the export or import fails', async () => {
-    const state = generateState('temp/clone-schema/run/', 'run');
+    const state = generateState(`temp_${process.env.JEST_WORKER_ID}/clone-schema/run/`, 'run');
 
     (schemaExport.handler as jest.Mock).mockRejectedValue(false);
 
@@ -159,7 +159,7 @@ describe('schema clone step', () => {
     fakeLog.addAction('CREATE', 'type');
     fakeLog.addAction('CREATE', 'type3'); // is archived
 
-    const state = generateState('temp/clone-schema/revert-create/', 'revert-create');
+    const state = generateState(`temp_${process.env.JEST_WORKER_ID}/clone-schema/revert-create/`, 'revert-create');
 
     const client = dynamicContentClientFactory(config);
     await (await client.contentTypeSchemas.get('type3')).related.archive();
@@ -174,14 +174,14 @@ describe('schema clone step', () => {
   });
 
   it('should attempt to fetch and revert to the version of the schema in the revert log', async () => {
-    const state = generateState('temp/clone-schema/revert-update/', 'revert-update');
+    const state = generateState(`temp_${process.env.JEST_WORKER_ID}/clone-schema/revert-update/`, 'revert-update');
 
     const fakeLog = new FileLog();
     fakeLog.switchGroup('Clone Content Type Schemas');
     fakeLog.addAction('CREATE', 'type');
     fakeLog.addAction('UPDATE', 'type2 0 1');
 
-    await ensureDirectoryExists('temp/clone-schema/revert-update/oldType');
+    await ensureDirectoryExists(`temp_${process.env.JEST_WORKER_ID}/clone-schema/revert-update/oldType`);
 
     state.revertLog = fakeLog;
 
@@ -195,14 +195,14 @@ describe('schema clone step', () => {
   });
 
   it('should return true when importing types for revert fails (ignore)', async () => {
-    const state = generateState('temp/clone-schema/revert-fail/', 'revert-fail');
+    const state = generateState(`temp_${process.env.JEST_WORKER_ID}/clone-schema/revert-fail/`, 'revert-fail');
 
     const fakeLog = new FileLog();
     fakeLog.switchGroup('Clone Content Type Schemas');
     fakeLog.addAction('CREATE', 'type');
     fakeLog.addAction('UPDATE', 'type2 0 1');
 
-    await ensureDirectoryExists('temp/clone-schema/revert-fail/oldType');
+    await ensureDirectoryExists(`temp_${process.env.JEST_WORKER_ID}/clone-schema/revert-fail/oldType`);
 
     state.revertLog = fakeLog;
     mockContent.failSchemaActions = 'all';

--- a/src/commands/hub/steps/settings-clone-step.spec.ts
+++ b/src/commands/hub/steps/settings-clone-step.spec.ts
@@ -82,7 +82,7 @@ describe('settings clone step', () => {
   });
 
   it('should call the settings commands with arguments from the state, importing the result of the export and performing a backup', async () => {
-    const state = generateState('temp/clone-settings/run/', 'run');
+    const state = generateState(`temp_${process.env.JEST_WORKER_ID}/clone-settings/run/`, 'run');
 
     (settingsImport.handler as jest.Mock).mockResolvedValue(true);
     (settingsExport.handler as jest.Mock).mockResolvedValue(true);
@@ -122,7 +122,7 @@ describe('settings clone step', () => {
   });
 
   it('should return false when exporting fails, the exported file is missing or import fails', async () => {
-    const state = generateState('temp/clone-settings/fail/', 'fail');
+    const state = generateState(`temp_${process.env.JEST_WORKER_ID}/clone-settings/fail/`, 'fail');
     const step = new SettingsCloneStep();
 
     (settingsImport.handler as jest.Mock).mockResolvedValue(true);
@@ -176,7 +176,7 @@ describe('settings clone step', () => {
   });
 
   it('should import saved settings in the given directory when reverting', async () => {
-    const state = generateState('temp/clone-settings/revert/', 'revert');
+    const state = generateState(`temp_${process.env.JEST_WORKER_ID}/clone-settings/revert/`, 'revert');
 
     (settingsImport.handler as jest.Mock).mockResolvedValue(true);
 
@@ -198,7 +198,7 @@ describe('settings clone step', () => {
   });
 
   it('should fail revert if the saved settings are missing, or the import of them fails', async () => {
-    const state = generateState('temp/clone-settings/revert-fail/', 'revert-fail');
+    const state = generateState(`temp_${process.env.JEST_WORKER_ID}/clone-settings/revert-fail/`, 'revert-fail');
     const step = new SettingsCloneStep();
 
     (settingsImport.handler as jest.Mock).mockResolvedValue(true);

--- a/src/commands/hub/steps/type-clean-step.spec.ts
+++ b/src/commands/hub/steps/type-clean-step.spec.ts
@@ -55,7 +55,7 @@ describe('type clean step', () => {
   });
 
   it('should call the copy command with arguments from the state', async () => {
-    const argv = generateState('temp/clean-schema/run/', 'run');
+    const argv = generateState(`temp_${process.env.JEST_WORKER_ID}/clean-schema/run/`, 'run');
 
     (archive.handler as jest.Mock).mockResolvedValue(true);
 
@@ -70,7 +70,7 @@ describe('type clean step', () => {
   });
 
   it('should return false when the copy command fails', async () => {
-    const argv = generateState('temp/clean-schema/fail/', 'fail');
+    const argv = generateState(`temp_${process.env.JEST_WORKER_ID}/clean-schema/fail/`, 'fail');
 
     (archive.handler as jest.Mock).mockRejectedValue(false);
 

--- a/src/commands/hub/steps/type-clone-step.spec.ts
+++ b/src/commands/hub/steps/type-clone-step.spec.ts
@@ -54,11 +54,11 @@ describe('type clone step', () => {
   });
 
   beforeAll(async () => {
-    await rimraf('temp/clone-type/');
+    await rimraf(`temp_${process.env.JEST_WORKER_ID}/clone-type/`);
   });
 
   afterAll(async () => {
-    await rimraf('temp/clone-type/');
+    await rimraf(`temp_${process.env.JEST_WORKER_ID}/clone-type/`);
   });
 
   function generateState(directory: string, logName: string): CloneHubState {
@@ -105,7 +105,7 @@ describe('type clone step', () => {
   });
 
   it('should call export on the source, backup and import to the destination', async () => {
-    const state = generateState('temp/clone-type/run/', 'run');
+    const state = generateState(`temp_${process.env.JEST_WORKER_ID}/clone-type/run/`, 'run');
 
     (typeImport.handler as jest.Mock).mockResolvedValue(true);
     (typeExport.handler as jest.Mock).mockResolvedValue(true);
@@ -139,7 +139,7 @@ describe('type clone step', () => {
   });
 
   it('should fail the step when the export, backup or import fails', async () => {
-    const state = generateState('temp/clone-type/run/', 'run');
+    const state = generateState(`temp_${process.env.JEST_WORKER_ID}/clone-type/run/`, 'run');
 
     (typeExport.handler as jest.Mock).mockRejectedValue(false);
 
@@ -179,9 +179,9 @@ describe('type clone step', () => {
     fakeLog.addAction('CREATE', 'type');
     fakeLog.addAction('CREATE', 'type3'); // is archived
 
-    const state = generateState('temp/clone-type/revert-create/', 'revert-create');
+    const state = generateState(`temp_${process.env.JEST_WORKER_ID}/clone-type/revert-create/`, 'revert-create');
 
-    await ensureDirectoryExists('temp/clone-type/revert-create/oldType');
+    await ensureDirectoryExists(`temp_${process.env.JEST_WORKER_ID}/clone-type/revert-create/oldType`);
     const client = dynamicContentClientFactory(config);
     await (await client.contentTypes.get('type3')).related.archive();
 
@@ -196,14 +196,14 @@ describe('type clone step', () => {
   });
 
   it('should pass types with the UPDATE action to the type import command on revert, in the oldType folder', async () => {
-    const state = generateState('temp/clone-type/revert-update/', 'revert-update');
+    const state = generateState(`temp_${process.env.JEST_WORKER_ID}/clone-type/revert-update/`, 'revert-update');
 
     const fakeLog = new FileLog();
     fakeLog.switchGroup('Clone Content Types');
     fakeLog.addAction('CREATE', 'type');
     fakeLog.addAction('UPDATE', 'type2 0 1');
 
-    await ensureDirectoryExists('temp/clone-type/revert-update/oldType');
+    await ensureDirectoryExists(`temp_${process.env.JEST_WORKER_ID}/clone-type/revert-update/oldType`);
 
     state.revertLog = fakeLog;
 
@@ -225,14 +225,14 @@ describe('type clone step', () => {
   });
 
   it('should return false when importing types for revert fails', async () => {
-    const state = generateState('temp/clone-type/revert-update/', 'revert-update');
+    const state = generateState(`temp_${process.env.JEST_WORKER_ID}/clone-type/revert-update/`, 'revert-update');
 
     const fakeLog = new FileLog();
     fakeLog.switchGroup('Clone Content Types');
     fakeLog.addAction('CREATE', 'type');
     fakeLog.addAction('UPDATE', 'type2 0 1');
 
-    await ensureDirectoryExists('temp/clone-type/revert-update/oldType');
+    await ensureDirectoryExists(`temp_${process.env.JEST_WORKER_ID}/clone-type/revert-update/oldType`);
 
     state.revertLog = fakeLog;
     (typeImport.handler as jest.Mock).mockRejectedValue(false);

--- a/src/common/archive/archive-log.spec.ts
+++ b/src/common/archive/archive-log.spec.ts
@@ -22,7 +22,7 @@ describe('archive-log', () => {
     });
 
     it('should recover the exit code when loading from file', async () => {
-      await ensureDirectoryExists('temp/');
+      await ensureDirectoryExists(`temp_${process.env.JEST_WORKER_ID}/`);
 
       // Code -1 is when the file is closed without an error type.
 
@@ -33,7 +33,7 @@ describe('archive-log', () => {
         const errorStr = LogErrorLevel[errorType];
         const closingStr = resultCodes[errorType];
 
-        const path = `temp/exit-${errorStr}.log`;
+        const path = `temp_${process.env.JEST_WORKER_ID}/exit-${errorStr}.log`;
 
         await promisify(writeFile)(path, `// File Title\nACTION 1\n${closingStr}`);
 

--- a/src/common/archive/archive-log.spec.ts
+++ b/src/common/archive/archive-log.spec.ts
@@ -6,8 +6,8 @@ import { ensureDirectoryExists } from '../import/directory-utils';
 
 describe('archive-log', () => {
   describe('archive-log tests', () => {
-    beforeEach(() => {
-      jest.resetAllMocks();
+    afterEach(() => {
+      jest.restoreAllMocks();
     });
 
     it('should return false when writing to file fails', async () => {

--- a/src/common/file-log.spec.ts
+++ b/src/common/file-log.spec.ts
@@ -25,20 +25,14 @@ describe('file-log', () => {
 
     it('should embed the date in the filename', async () => {
       jest.spyOn(Date, 'now').mockImplementation(() => 1234);
-      await ensureDirectoryExists('temp/');
+      await ensureDirectoryExists(`temp_${process.env.JEST_WORKER_ID}/`);
 
-      const log = new FileLog('temp/FileWithDate-<DATE>.log').open();
+      const log = new FileLog(`temp_${process.env.JEST_WORKER_ID}/FileWithDate-<DATE>.log`).open();
       log.appendLine('Test Message');
       await log.close();
 
-      expect(await promisify(exists)('temp/FileWithDate-1234.log')).toBeTruthy();
-      expect(await promisify(readFile)('temp/FileWithDate-1234.log', { encoding: 'utf-8' })).toMatchInlineSnapshot(`
-        "// temp/FileWithDate-1234.log
-        // Test Message
-        SUCCESS"
-      `);
-
-      await promisify(unlink)('temp/FileWithDate-1234.log');
+      expect(await promisify(exists)(`temp_${process.env.JEST_WORKER_ID}/FileWithDate-1234.log`)).toBeTruthy();
+      await promisify(unlink)(`temp_${process.env.JEST_WORKER_ID}/FileWithDate-1234.log`);
     });
 
     it('should only save the log after it has been closed as many times as it was opened', async () => {


### PR DESCRIPTION
Updated all tests that write temp files to use the jest WORKER_ID, to allow the tests to run in parallel.

Fixes another issue with spying on `ensureDirectoryExists`, where it wasn't reset after the spy.