### PR TITLE
feat(config): print helpful error if config file is invalid json

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,10 @@ import { configureCommandOptions, readConfigFile } from './commands/configure';
 import { Arguments, Argv } from 'yargs';
 import errorHandler from './error-handler';
 
+const readConfig = (configFile: string): object => {
+  return readConfigFile(configFile, process.argv[2] === 'configure');
+};
+
 const configureYargs = (yargInstance: Argv): Promise<Arguments> => {
   return new Promise(
     async (resolve): Promise<void> => {
@@ -23,7 +27,7 @@ const configureYargs = (yargInstance: Argv): Promise<Arguments> => {
       const argv = await yargInstance
         .scriptName('dc-cli')
         .options(configureCommandOptions)
-        .config('config', readConfigFile)
+        .config('config', readConfig)
         .commandDir('./commands', YargsCommandBuilderOptions)
         .strict()
         .demandCommand(1, 'Please specify at least one command')

--- a/src/commands/configure.ts
+++ b/src/commands/configure.ts
@@ -44,8 +44,26 @@ const writeConfigFile = (configFile: string, parameters: ConfigurationParameters
   }
 };
 
-export const readConfigFile = (configFile: string): object =>
-  fs.existsSync(configFile) ? JSON.parse(fs.readFileSync(configFile, 'utf-8')) : {};
+export const readConfigFile = (configFile: string, ignoreError?: boolean): object => {
+  if (fs.existsSync(configFile)) {
+    try {
+      return JSON.parse(fs.readFileSync(configFile, 'utf-8'));
+    } catch (e) {
+      if (ignoreError) {
+        console.error(
+          `The configuration file at ${configFile} is invalid, its contents will be ignored.\n${e.message}`
+        );
+      } else {
+        console.error(
+          `FATAL - Could not parse JSON configuration. Inspect the configuration file at ${configFile}\n${e.message}`
+        );
+        process.exit(2);
+      }
+    }
+  }
+
+  return {};
+};
 
 export const handler = (argv: Arguments<ConfigurationParameters & ConfigArgument>): void => {
   const { clientId, clientSecret, hubId } = argv;


### PR DESCRIPTION
This will print a clean error when the config file cannot be parsed. The error is ignored when using the `configure` command, as the goal is to replace the configuration file anyways.