### PR TITLE
feat: facet argument for content item commands 

### DIFF
--- a/HOW_TO_USE.md
+++ b/HOW_TO_USE.md
@@ -15,6 +15,31 @@ By default the configuration file is saved into the directory `<HOME_DIR>/.ampli
 
 See `dc-cli configure --help` for more information.
 
+## FACETS
+The content item export, copy, move archive and unarchive commands allow the user to provide a facet string to filter the content that the commands work on. Multiple of these can be applied at a time, and you can even match on regex string. Note that you will need to surround your facet in quotes if it contains a space, which will change how backslash escaping works.
+
+- `name`: Filter on content item label. Example: `--facet "name:exact name match"`
+- `schema`: Filter on schema ids. Example: `--facet schema:http://example.com/schema.json`
+- `locale`: Filter on content item locale. Example: `--facet locale:en-GB`
+- `lastModifiedDate`: Filter on last modified date. Example: `--facet "lastModifiedDate:Last 7 days"`
+
+Multiple facets can be applied at once when separated by a comma. Example:
+`--facet "schema:http://example.com/schema.json, name:/name regex/"`
+
+Commas can be escaped with a backslash, if they are used in your values. The whitespace after a comma is optional.
+
+### PRESET DATE RANGES
+The preset date ranges are the same as DC provides:
+- `Last 7 days`
+- `Last 14 days`
+- `Last 30 days`
+- `Last 60 days`
+- `Over 60 days`
+
+### REGEX
+You can use regex values on string fields when filtering content. They cannot be used on date ranges. Regex are surronded by two forward slashes:
+`--facet "name:/ends with this$/"`
+
 ## SEE ALSO
 * `dc-cli --help`
 * `dc-cli <command> --help`

--- a/src/commands/content-item/archive.spec.ts
+++ b/src/commands/content-item/archive.spec.ts
@@ -265,16 +265,10 @@ describe('content-item archive command', () => {
         requiresArg: false
       });
 
-      expect(spyOption).toHaveBeenCalledWith('name', {
+      expect(spyOption).toHaveBeenCalledWith('facet', {
         type: 'string',
         describe:
-          'The name of a Content Item to be archived.\nA regex can be provided to select multiple items with similar or matching names (eg /.header/).\nA single --name option may be given to match a single content item pattern.\nMultiple --name options may be given to match multiple content items patterns at the same time, or even multiple regex.'
-      });
-
-      expect(spyOption).toHaveBeenCalledWith('contentType', {
-        type: 'string',
-        describe:
-          'A pattern which will only archive content items with a matching Content Type Schema ID. A single --contentType option may be given to match a single schema id pattern.\\nMultiple --contentType options may be given to match multiple schema patterns at the same time.'
+          "Archive content matching the given facets. Provide facets in the format 'label:example name,locale:en-GB', spaces are allowed between values. A regex can be provided for text filters, surrounded with forward slashes. For more examples, see the readme."
       });
 
       expect(spyOption).toHaveBeenCalledWith('revertLog', {
@@ -459,7 +453,7 @@ describe('content-item archive command', () => {
         ...yargArgs,
         ...config,
         folderId: 'folder1',
-        name: 'item1'
+        facet: 'name:item1'
       };
       await handler(argv);
 
@@ -468,7 +462,7 @@ describe('content-item archive command', () => {
       expect(mockArchive).toBeCalledTimes(1);
     });
 
-    it('should ented', async () => {
+    it('should exit if a facet AND id are provided', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (readline as any).setResponses(['y']);
 
@@ -478,7 +472,7 @@ describe('content-item archive command', () => {
         ...yargArgs,
         ...config,
         id: '123',
-        name: 'item1'
+        facet: 'name:item1'
       };
       await handler(argv);
 
@@ -497,7 +491,7 @@ describe('content-item archive command', () => {
         ...yargArgs,
         ...config,
         folderId: 'folder1',
-        name: ['item3']
+        facet: 'name:item3'
       };
       await handler(argv);
 
@@ -553,7 +547,7 @@ describe('content-item archive command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        contentType: 'http://test.com'
+        facet: 'schema:http://test.com'
       };
       await handler(argv);
 
@@ -572,7 +566,7 @@ describe('content-item archive command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        contentType: '/test/'
+        facet: 'schema:/test/'
       };
       await handler(argv);
 
@@ -591,7 +585,7 @@ describe('content-item archive command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        contentType: '/test123/'
+        facet: 'schema:/test123/'
       };
       await handler(argv);
 
@@ -872,7 +866,7 @@ describe('content-item archive command', () => {
 
       const result = await filterContentItems({
         contentItems,
-        contentType: '/test.com/'
+        facet: 'schema:/test\\.com/'
       });
 
       expect(result).toMatchObject({
@@ -886,7 +880,7 @@ describe('content-item archive command', () => {
 
       const result = await filterContentItems({
         contentItems,
-        contentType: ['/test.com/', '/test1.com/']
+        facet: 'schema:/test.?\\.com/'
       });
 
       expect(result).toMatchObject({
@@ -900,7 +894,7 @@ describe('content-item archive command', () => {
 
       const result = await filterContentItems({
         contentItems,
-        name: ['/item1/']
+        facet: 'name:/item1/'
       });
 
       if (result) {

--- a/src/commands/content-item/archive.ts
+++ b/src/commands/content-item/archive.ts
@@ -8,7 +8,7 @@ import ArchiveOptions from '../../common/archive/archive-options';
 import { ContentItem, DynamicContent, Status } from 'dc-management-sdk-js';
 import { getDefaultLogPath, createLog } from '../../common/log-helpers';
 import { FileLog } from '../../common/file-log';
-import { applyFacet } from '../../common/filter/facet';
+import { applyFacet, withOldFilters } from '../../common/filter/facet';
 
 export const command = 'archive [id]';
 
@@ -69,6 +69,14 @@ export const builder = (yargs: Argv): void => {
       default: LOG_FILENAME,
       describe: 'Path to a log file to write to.',
       coerce: coerceLog
+    })
+    .option('name', {
+      type: 'string',
+      hidden: true
+    })
+    .option('schemaId', {
+      type: 'string',
+      hidden: true
     });
 };
 
@@ -267,8 +275,10 @@ export const processItems = async ({
 };
 
 export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationParameters>): Promise<void> => {
-  const { id, logFile, force, silent, ignoreError, hubId, revertLog, repoId, folderId, facet } = argv;
+  const { id, logFile, force, silent, ignoreError, hubId, revertLog, repoId, folderId } = argv;
   const client = dynamicContentClientFactory(argv);
+
+  const facet = withOldFilters(argv.facet, argv);
 
   const allContent = !id && !facet && !revertLog && !folderId && !repoId;
 

--- a/src/commands/content-item/archive.ts
+++ b/src/commands/content-item/archive.ts
@@ -6,9 +6,9 @@ import paginator from '../../common/dc-management-sdk-js/paginator';
 import { confirmArchive } from '../../common/archive/archive-helpers';
 import ArchiveOptions from '../../common/archive/archive-options';
 import { ContentItem, DynamicContent, Status } from 'dc-management-sdk-js';
-import { equalsOrRegex } from '../../common/filter/filter';
 import { getDefaultLogPath, createLog } from '../../common/log-helpers';
 import { FileLog } from '../../common/file-log';
+import { applyFacet } from '../../common/filter/facet';
 
 export const command = 'archive [id]';
 
@@ -36,15 +36,10 @@ export const builder = (yargs: Argv): void => {
       describe: 'The ID of a folder to search items in to be archived.',
       requiresArg: false
     })
-    .option('name', {
+    .option('facet', {
       type: 'string',
       describe:
-        'The name of a Content Item to be archived.\nA regex can be provided to select multiple items with similar or matching names (eg /.header/).\nA single --name option may be given to match a single content item pattern.\nMultiple --name options may be given to match multiple content items patterns at the same time, or even multiple regex.'
-    })
-    .option('contentType', {
-      type: 'string',
-      describe:
-        'A pattern which will only archive content items with a matching Content Type Schema ID. A single --contentType option may be given to match a single schema id pattern.\\nMultiple --contentType options may be given to match multiple schema patterns at the same time.'
+        "Archive content matching the given facets. Provide facets in the format 'label:example name,locale:en-GB', spaces are allowed between values. A regex can be provided for text filters, surrounded with forward slashes. For more examples, see the readme."
     })
     .option('revertLog', {
       type: 'string',
@@ -79,13 +74,11 @@ export const builder = (yargs: Argv): void => {
 
 export const filterContentItems = async ({
   revertLog,
-  name,
-  contentType,
+  facet,
   contentItems
 }: {
   revertLog?: string;
-  name?: string | string[];
-  contentType?: string | string[];
+  facet?: string;
   contentItems: ContentItem[];
 }): Promise<{ contentItems: ContentItem[]; missingContent: boolean } | undefined> => {
   try {
@@ -95,9 +88,8 @@ export const filterContentItems = async ({
       const log = await new ArchiveLog().loadFromFile(revertLog);
       const ids = log.getData('UNARCHIVE');
       const contentItemsFiltered = contentItems.filter(contentItem => ids.indexOf(contentItem.id || '') != -1);
-      if (contentItems.length != ids.length) {
-        missingContent = true;
-      }
+
+      missingContent = contentItems.length !== ids.length;
 
       return {
         contentItems: contentItemsFiltered,
@@ -105,23 +97,8 @@ export const filterContentItems = async ({
       };
     }
 
-    if (name != null) {
-      const itemsArray: string[] = Array.isArray(name) ? name : [name];
-      const contentItemsFiltered = contentItems.filter(
-        item => itemsArray.findIndex(id => equalsOrRegex(item.label || '', id)) != -1
-      );
-
-      return {
-        contentItems: contentItemsFiltered,
-        missingContent
-      };
-    }
-
-    if (contentType != null) {
-      const itemsArray: string[] = Array.isArray(contentType) ? contentType : [contentType];
-      const contentItemsFiltered = contentItems.filter(item => {
-        return itemsArray.findIndex(id => equalsOrRegex(item.body._meta.schema, id)) != -1;
-      });
+    if (facet != null) {
+      const contentItemsFiltered = applyFacet(contentItems, facet);
 
       return {
         contentItems: contentItemsFiltered,
@@ -149,8 +126,7 @@ export const getContentItems = async ({
   repoId,
   folderId,
   revertLog,
-  name,
-  contentType
+  facet
 }: {
   client: DynamicContent;
   id?: string | string[];
@@ -158,8 +134,7 @@ export const getContentItems = async ({
   repoId?: string | string[];
   folderId?: string | string[];
   revertLog?: string;
-  name?: string | string[];
-  contentType?: string | string[];
+  facet?: string;
 }): Promise<{ contentItems: ContentItem[]; missingContent: boolean }> => {
   try {
     const contentItems: ContentItem[] = [];
@@ -202,8 +177,7 @@ export const getContentItems = async ({
     return (
       (await filterContentItems({
         revertLog,
-        name,
-        contentType,
+        facet,
         contentItems
       })) || {
         contentItems: [],
@@ -293,17 +267,17 @@ export const processItems = async ({
 };
 
 export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationParameters>): Promise<void> => {
-  const { id, logFile, force, silent, ignoreError, hubId, revertLog, repoId, folderId, name, contentType } = argv;
+  const { id, logFile, force, silent, ignoreError, hubId, revertLog, repoId, folderId, facet } = argv;
   const client = dynamicContentClientFactory(argv);
 
-  const allContent = !id && !name && !contentType && !revertLog && !folderId && !repoId;
+  const allContent = !id && !facet && !revertLog && !folderId && !repoId;
 
   if (repoId && id) {
     console.log('ID of content item is specified, ignoring repository ID');
   }
 
-  if (id && name) {
-    console.log('Please specify either a item name or an ID - not both.');
+  if (id && facet) {
+    console.log('Please specify either a facet or an ID - not both.');
     return;
   }
 
@@ -322,8 +296,7 @@ export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationPara
     repoId,
     folderId,
     revertLog,
-    contentType,
-    name
+    facet
   });
 
   await processItems({

--- a/src/commands/content-item/copy.spec.ts
+++ b/src/commands/content-item/copy.spec.ts
@@ -95,6 +95,12 @@ describe('content-item copy command', () => {
         describe: "Destination account's secret. Must be used alongside dstClientId."
       });
 
+      expect(spyOption).toHaveBeenCalledWith('facet', {
+        type: 'string',
+        describe:
+          "Copy content matching the given facets. Provide facets in the format 'label:example name,locale:en-GB', spaces are allowed between values. A regex can be provided for text filters, surrounded with forward slashes. For more examples, see the readme."
+      });
+
       expect(spyOption).toHaveBeenCalledWith('mapFile', {
         type: 'string',
         describe:
@@ -230,8 +236,7 @@ describe('content-item copy command', () => {
         dstClientId: 'acc2-id',
         dstSecret: 'acc2-secret',
 
-        schemaId: '/./',
-        name: '/./',
+        facet: 'name:/./,schema:/./',
 
         mapFile: 'map.json',
         force: false,
@@ -253,8 +258,7 @@ describe('content-item copy command', () => {
       expect(exportCalls[0].clientId).toEqual(config.clientId);
       expect(exportCalls[0].clientSecret).toEqual(config.clientSecret);
       expect(exportCalls[0].hubId).toEqual(config.hubId);
-      expect(exportCalls[0].schemaId).toEqual(argv.schemaId);
-      expect(exportCalls[0].name).toEqual(argv.name);
+      expect(exportCalls[0].facet).toEqual(argv.facet);
       expect(exportCalls[0].repoId).toEqual(argv.srcRepo);
       expect(exportCalls[0].publish).toEqual(argv.lastPublish);
 
@@ -350,8 +354,7 @@ describe('content-item copy command', () => {
         clientId: 'acc2-id',
         clientSecret: 'acc2-secret',
 
-        schemaId: '/./',
-        name: '/./',
+        facet: 'name:/./,schema:/./',
 
         mapFile: 'map.json',
         force: false,
@@ -433,8 +436,7 @@ describe('content-item copy command', () => {
 
         copyConfig: copyConfig,
 
-        schemaId: '/./',
-        name: '/./',
+        facet: 'name:/./,schema:/./',
 
         mapFile: 'map.json',
         force: false,
@@ -449,8 +451,7 @@ describe('content-item copy command', () => {
       expect(exportCalls[0].clientId).toEqual(copyConfig.srcClientId);
       expect(exportCalls[0].clientSecret).toEqual(copyConfig.srcSecret);
       expect(exportCalls[0].hubId).toEqual(copyConfig.srcHubId);
-      expect(exportCalls[0].schemaId).toEqual(argv.schemaId);
-      expect(exportCalls[0].name).toEqual(argv.name);
+      expect(exportCalls[0].facet).toEqual(argv.facet);
       expect(exportCalls[0].repoId).toEqual(argv.srcRepo);
 
       expect(importCalls[0].clientId).toEqual(copyConfig.dstClientId);

--- a/src/commands/content-item/copy.spec.ts
+++ b/src/commands/content-item/copy.spec.ts
@@ -170,6 +170,16 @@ describe('content-item copy command', () => {
         describe: 'Path to a log file to write to.',
         coerce: createLog
       });
+
+      expect(spyOption).toHaveBeenCalledWith('name', {
+        type: 'string',
+        hidden: true
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('schemaId', {
+        type: 'string',
+        hidden: true
+      });
     });
   });
 

--- a/src/commands/content-item/copy.ts
+++ b/src/commands/content-item/copy.ts
@@ -12,6 +12,7 @@ import { revert } from './import-revert';
 import { loadCopyConfig } from '../../common/content-item/copy-config';
 import { FileLog } from '../../common/file-log';
 import { LogErrorLevel } from '../../common/archive/archive-log';
+import { withOldFilters } from '../../common/filter/facet';
 
 export function getTempFolder(name: string, platform: string = process.platform): string {
   return join(process.env[platform == 'win32' ? 'USERPROFILE' : 'HOME'] || __dirname, '.amplience', `copy-${name}/`);
@@ -147,6 +148,16 @@ export const builder = (yargs: Argv): void => {
       default: LOG_FILENAME,
       describe: 'Path to a log file to write to.',
       coerce: createLog
+    })
+
+    .option('name', {
+      type: 'string',
+      hidden: true
+    })
+
+    .option('schemaId', {
+      type: 'string',
+      hidden: true
     });
 };
 
@@ -211,7 +222,7 @@ export const handler = async (argv: Arguments<CopyItemBuilderOptions & Configura
 
         folderId: argv.srcFolder,
         repoId: argv.srcRepo,
-        facet: argv.facet,
+        facet: withOldFilters(argv.facet, argv),
         logFile: log,
 
         dir: tempFolder,

--- a/src/commands/content-item/copy.ts
+++ b/src/commands/content-item/copy.ts
@@ -72,6 +72,12 @@ export const builder = (yargs: Argv): void => {
       describe: "Destination account's secret. Must be used alongside dstClientId."
     })
 
+    .option('facet', {
+      type: 'string',
+      describe:
+        "Copy content matching the given facets. Provide facets in the format 'label:example name,locale:en-GB', spaces are allowed between values. A regex can be provided for text filters, surrounded with forward slashes. For more examples, see the readme."
+    })
+
     .option('mapFile', {
       type: 'string',
       describe:
@@ -205,8 +211,7 @@ export const handler = async (argv: Arguments<CopyItemBuilderOptions & Configura
 
         folderId: argv.srcFolder,
         repoId: argv.srcRepo,
-        schemaId: argv.schemaId,
-        name: argv.name,
+        facet: argv.facet,
         logFile: log,
 
         dir: tempFolder,

--- a/src/commands/content-item/export.spec.ts
+++ b/src/commands/content-item/export.spec.ts
@@ -62,16 +62,10 @@ describe('content-item export command', () => {
           'Export content from within a given folder. Directory structure will start at the specified folder. Can be used in addition to repoId.'
       });
 
-      expect(spyOption).toHaveBeenCalledWith('schemaId', {
+      expect(spyOption).toHaveBeenCalledWith('facet', {
         type: 'string',
         describe:
-          'Export content with a given or matching Schema ID. A regex can be provided, surrounded with forward slashes. Can be used in combination with other filters.'
-      });
-
-      expect(spyOption).toHaveBeenCalledWith('name', {
-        type: 'string',
-        describe:
-          'Export content with a given or matching Name. A regex can be provided, surrounded with forward slashes. Can be used in combination with other filters.'
+          "Export content matching the given facets. Provide facets in the format 'label:example name,locale:en-GB', spaces are allowed between values. A regex can be provided for text filters, surrounded with forward slashes. For more examples, see the readme."
       });
 
       expect(spyOption).toHaveBeenCalledWith('publish', {
@@ -305,7 +299,7 @@ describe('content-item export command', () => {
         ...config,
         dir: `temp_${process.env.JEST_WORKER_ID}/export/typeSpecific/folder1`,
         folderId: 'folder1',
-        schemaId: '/typeMatch/'
+        facet: 'schema:/typeMatch/'
       };
       await handler(argv);
 
@@ -341,7 +335,7 @@ describe('content-item export command', () => {
         ...config,
         dir: `temp_${process.env.JEST_WORKER_ID}/export/nameSpecific/folder1`,
         folderId: 'folder1',
-        name: '/nameMatch/'
+        facet: 'name:/nameMatch/'
       };
       await handler(argv);
 
@@ -399,8 +393,7 @@ describe('content-item export command', () => {
         dir: `temp_${process.env.JEST_WORKER_ID}/export/allFilter/`,
         repoId: 'repo2',
         folderId: 'folder1', // folder1 in addition to repo2
-        name: '/nameMatch/',
-        schemaId: '/typeMatch/' // only content that with name containing nameMatch and type containing typeMatch
+        facet: 'name:/nameMatch/,schema:/typeMatch/' // only content that with name containing nameMatch and type containing typeMatch
       };
       await handler(argv);
 

--- a/src/commands/content-item/export.spec.ts
+++ b/src/commands/content-item/export.spec.ts
@@ -80,6 +80,16 @@ describe('content-item export command', () => {
         describe: 'Path to a log file to write to.',
         coerce: createLog
       });
+
+      expect(spyOption).toHaveBeenCalledWith('name', {
+        type: 'string',
+        hidden: true
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('schemaId', {
+        type: 'string',
+        hidden: true
+      });
     });
   });
 

--- a/src/commands/content-item/export.ts
+++ b/src/commands/content-item/export.ts
@@ -15,7 +15,7 @@ import { ContentDependancyTree, RepositoryContentItem } from '../../common/conte
 import { ContentMapping } from '../../common/content-mapping';
 import { createLog, getDefaultLogPath } from '../../common/log-helpers';
 import { AmplienceSchemaValidator, defaultSchemaLookup } from '../../common/content-item/amplience-schema-validator';
-import { applyFacet } from '../../common/filter/facet';
+import { applyFacet, withOldFilters } from '../../common/filter/facet';
 
 interface PublishedContentItem {
   lastPublishedVersion?: number;
@@ -61,6 +61,14 @@ export const builder = (yargs: Argv): void => {
       default: LOG_FILENAME,
       describe: 'Path to a log file to write to.',
       coerce: createLog
+    })
+    .option('name', {
+      type: 'string',
+      hidden: true
+    })
+    .option('schemaId', {
+      type: 'string',
+      hidden: true
     });
 };
 
@@ -211,7 +219,9 @@ const getContentItems = async (
 };
 
 export const handler = async (argv: Arguments<ExportItemBuilderOptions & ConfigurationParameters>): Promise<void> => {
-  const { dir, repoId, folderId, facet, logFile, publish } = argv;
+  const { dir, repoId, folderId, logFile, publish } = argv;
+
+  const facet = withOldFilters(argv.facet, argv);
 
   const dummyRepo = new ContentRepository();
 

--- a/src/commands/content-item/move.spec.ts
+++ b/src/commands/content-item/move.spec.ts
@@ -102,6 +102,12 @@ describe('content-item move command', () => {
         describe: "Destination account's secret. Must be used alongside dstClientId."
       });
 
+      expect(spyOption).toHaveBeenCalledWith('facet', {
+        type: 'string',
+        describe:
+          "Move content matching the given facets. Provide facets in the format 'label:example name,locale:en-GB', spaces are allowed between values. A regex can be provided for text filters, surrounded with forward slashes. For more examples, see the readme."
+      });
+
       expect(spyOption).toHaveBeenCalledWith('mapFile', {
         type: 'string',
         describe:
@@ -220,8 +226,7 @@ describe('content-item move command', () => {
         dstClientId: 'acc2-id',
         dstSecret: 'acc2-secret',
 
-        schemaId: '/./',
-        name: '/./',
+        facet: 'name:/./,schema/./',
 
         mapFile: 'map.json',
         force: false,
@@ -467,8 +472,7 @@ describe('content-item move command', () => {
         clientId: 'acc2-id',
         clientSecret: 'acc2-secret',
 
-        schemaId: '/./',
-        name: '/./',
+        facet: 'name:/./,schema/./',
 
         mapFile: 'map.json',
         force: false,

--- a/src/commands/content-item/move.spec.ts
+++ b/src/commands/content-item/move.spec.ts
@@ -152,6 +152,16 @@ describe('content-item move command', () => {
         describe: 'Path to a log file to write to.',
         coerce: createLog
       });
+
+      expect(spyOption).toHaveBeenCalledWith('name', {
+        type: 'string',
+        hidden: true
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('schemaId', {
+        type: 'string',
+        hidden: true
+      });
     });
   });
 

--- a/src/commands/content-item/move.ts
+++ b/src/commands/content-item/move.ts
@@ -67,6 +67,12 @@ export const builder = (yargs: Argv): void => {
       describe: "Destination account's secret. Must be used alongside dstClientId."
     })
 
+    .option('facet', {
+      type: 'string',
+      describe:
+        "Move content matching the given facets. Provide facets in the format 'label:example name,locale:en-GB', spaces are allowed between values. A regex can be provided for text filters, surrounded with forward slashes. For more examples, see the readme."
+    })
+
     .option('mapFile', {
       type: 'string',
       describe:

--- a/src/commands/content-item/move.ts
+++ b/src/commands/content-item/move.ts
@@ -142,6 +142,16 @@ export const builder = (yargs: Argv): void => {
       default: LOG_FILENAME,
       describe: 'Path to a log file to write to.',
       coerce: createLog
+    })
+
+    .option('name', {
+      type: 'string',
+      hidden: true
+    })
+
+    .option('schemaId', {
+      type: 'string',
+      hidden: true
     });
 };
 

--- a/src/commands/content-item/unarchive.spec.ts
+++ b/src/commands/content-item/unarchive.spec.ts
@@ -288,6 +288,16 @@ describe('content-item unarchive command', () => {
         default: LOG_FILENAME,
         describe: 'Path to a log file to write to.'
       });
+
+      expect(spyOption).toHaveBeenCalledWith('name', {
+        type: 'string',
+        hidden: true
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('schemaId', {
+        type: 'string',
+        hidden: true
+      });
     });
   });
 

--- a/src/commands/content-item/unarchive.spec.ts
+++ b/src/commands/content-item/unarchive.spec.ts
@@ -252,16 +252,10 @@ describe('content-item unarchive command', () => {
         requiresArg: false
       });
 
-      expect(spyOption).toHaveBeenCalledWith('name', {
+      expect(spyOption).toHaveBeenCalledWith('facet', {
         type: 'string',
         describe:
-          'The name of a Content Item to be unarchived.\nA regex can be provided to select multiple items with similar or matching names (eg /.header/).\nA single --name option may be given to match a single content item pattern.\nMultiple --name options may be given to match multiple content items patterns at the same time, or even multiple regex.'
-      });
-
-      expect(spyOption).toHaveBeenCalledWith('contentType', {
-        type: 'string',
-        describe:
-          'A pattern which will only unarchive content items with a matching Content Type Schema ID. A single --contentType option may be given to match a single schema id pattern.\\nMultiple --contentType options may be given to match multiple schema patterns at the same time.'
+          "Unarchive content matching the given facets. Provide facets in the format 'label:example name,locale:en-GB', spaces are allowed between values. A regex can be provided for text filters, surrounded with forward slashes. For more examples, see the readme."
       });
 
       expect(spyOption).toHaveBeenCalledWith('revertLog', {
@@ -432,7 +426,7 @@ describe('content-item unarchive command', () => {
         ...yargArgs,
         ...config,
         folderId: 'folder1',
-        name: 'item1'
+        facet: 'name:item1'
       };
       await handler(argv);
 
@@ -441,7 +435,7 @@ describe('content-item unarchive command', () => {
       expect(mockUnarchive).toBeCalledTimes(1);
     });
 
-    it('should ented', async () => {
+    it('should exit if a facet AND id are provided', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (readline as any).setResponses(['y']);
 
@@ -451,7 +445,7 @@ describe('content-item unarchive command', () => {
         ...yargArgs,
         ...config,
         id: '123',
-        name: 'item1'
+        facet: 'name:item1'
       };
       await handler(argv);
 
@@ -470,7 +464,7 @@ describe('content-item unarchive command', () => {
         ...yargArgs,
         ...config,
         folderId: 'folder1',
-        name: ['item3']
+        facet: 'name:item3'
       };
       await handler(argv);
 
@@ -489,7 +483,7 @@ describe('content-item unarchive command', () => {
         ...yargArgs,
         ...config,
         folderId: 'folder1',
-        name: 'item1'
+        facet: 'name:item1'
       };
       await handler(argv);
 
@@ -507,7 +501,7 @@ describe('content-item unarchive command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        name: '/item/'
+        facet: 'name:/item/'
       };
       await handler(argv);
 
@@ -526,7 +520,7 @@ describe('content-item unarchive command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        contentType: 'http://test.com'
+        facet: 'schema:http://test.com'
       };
       await handler(argv);
 
@@ -545,7 +539,7 @@ describe('content-item unarchive command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        contentType: '/test/'
+        facet: 'schema:/test/'
       };
       await handler(argv);
 
@@ -564,7 +558,7 @@ describe('content-item unarchive command', () => {
       const argv = {
         ...yargArgs,
         ...config,
-        contentType: '/test123/'
+        facet: 'schema:/test123/'
       };
       await handler(argv);
 
@@ -842,7 +836,7 @@ describe('content-item unarchive command', () => {
 
       const result = await filterContentItems({
         contentItems,
-        contentType: '/test.com/'
+        facet: 'schema:/test.com/'
       });
 
       expect(result).toMatchObject({
@@ -856,7 +850,7 @@ describe('content-item unarchive command', () => {
 
       const result = await filterContentItems({
         contentItems,
-        contentType: ['/test.com/', '/test1.com/']
+        facet: 'schema:/test.?\\.com/'
       });
 
       expect(result).toMatchObject({
@@ -870,7 +864,7 @@ describe('content-item unarchive command', () => {
 
       const result = await filterContentItems({
         contentItems,
-        name: ['/item1/']
+        facet: 'name:/item1/'
       });
 
       if (result) {

--- a/src/commands/content-item/unarchive.ts
+++ b/src/commands/content-item/unarchive.ts
@@ -7,7 +7,7 @@ import { confirmArchive } from '../../common/archive/archive-helpers';
 import UnarchiveOptions from '../../common/archive/unarchive-options';
 import { ContentItem, DynamicContent, Status } from 'dc-management-sdk-js';
 import { getDefaultLogPath } from '../../common/log-helpers';
-import { applyFacet } from '../../common/filter/facet';
+import { applyFacet, withOldFilters } from '../../common/filter/facet';
 
 export const command = 'unarchive [id]';
 
@@ -65,6 +65,14 @@ export const builder = (yargs: Argv): void => {
       type: 'string',
       default: LOG_FILENAME,
       describe: 'Path to a log file to write to.'
+    })
+    .option('name', {
+      type: 'string',
+      hidden: true
+    })
+    .option('schemaId', {
+      type: 'string',
+      hidden: true
     });
 };
 
@@ -278,7 +286,8 @@ export const processItems = async ({
 };
 
 export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationParameters>): Promise<void> => {
-  const { id, logFile, force, silent, ignoreError, hubId, revertLog, repoId, folderId, facet } = argv;
+  const { id, logFile, force, silent, ignoreError, hubId, revertLog, repoId, folderId } = argv;
+  const facet = withOldFilters(argv.facet, argv);
   const client = dynamicContentClientFactory(argv);
 
   const allContent = !id && !facet && !revertLog && !folderId && !repoId;

--- a/src/commands/content-item/unarchive.ts
+++ b/src/commands/content-item/unarchive.ts
@@ -6,7 +6,6 @@ import paginator from '../../common/dc-management-sdk-js/paginator';
 import { confirmArchive } from '../../common/archive/archive-helpers';
 import UnarchiveOptions from '../../common/archive/unarchive-options';
 import { ContentItem, DynamicContent, Status } from 'dc-management-sdk-js';
-import { equalsOrRegex } from '../../common/filter/filter';
 import { getDefaultLogPath } from '../../common/log-helpers';
 import { applyFacet } from '../../common/filter/facet';
 

--- a/src/commands/content-item/unarchive.ts
+++ b/src/commands/content-item/unarchive.ts
@@ -8,6 +8,7 @@ import UnarchiveOptions from '../../common/archive/unarchive-options';
 import { ContentItem, DynamicContent, Status } from 'dc-management-sdk-js';
 import { equalsOrRegex } from '../../common/filter/filter';
 import { getDefaultLogPath } from '../../common/log-helpers';
+import { applyFacet } from '../../common/filter/facet';
 
 export const command = 'unarchive [id]';
 
@@ -33,15 +34,10 @@ export const builder = (yargs: Argv): void => {
       describe: 'The ID of a folder to search items in to be unarchived.',
       requiresArg: false
     })
-    .option('name', {
+    .option('facet', {
       type: 'string',
       describe:
-        'The name of a Content Item to be unarchived.\nA regex can be provided to select multiple items with similar or matching names (eg /.header/).\nA single --name option may be given to match a single content item pattern.\nMultiple --name options may be given to match multiple content items patterns at the same time, or even multiple regex.'
-    })
-    .option('contentType', {
-      type: 'string',
-      describe:
-        'A pattern which will only unarchive content items with a matching Content Type Schema ID. A single --contentType option may be given to match a single schema id pattern.\\nMultiple --contentType options may be given to match multiple schema patterns at the same time.'
+        "Unarchive content matching the given facets. Provide facets in the format 'label:example name,locale:en-GB', spaces are allowed between values. A regex can be provided for text filters, surrounded with forward slashes. For more examples, see the readme."
     })
     .option('revertLog', {
       type: 'string',
@@ -75,13 +71,11 @@ export const builder = (yargs: Argv): void => {
 
 export const filterContentItems = async ({
   revertLog,
-  name,
-  contentType,
+  facet,
   contentItems
 }: {
   revertLog?: string;
-  name?: string | string[];
-  contentType?: string | string[];
+  facet?: string;
   contentItems: ContentItem[];
 }): Promise<{ contentItems: ContentItem[]; missingContent: boolean } | undefined> => {
   try {
@@ -106,9 +100,7 @@ export const filterContentItems = async ({
         })
         .filter(contentItem => !!contentItem);
 
-      if (contentItemsFiltered.length != archived.length) {
-        missingContent = true;
-      }
+      missingContent = contentItems.length !== archived.length;
 
       return {
         contentItems: contentItemsFiltered as ContentItem[],
@@ -119,23 +111,8 @@ export const filterContentItems = async ({
     // Delete the delivery keys, as the unarchive will attempt to reassign them if present.
     contentItems.forEach(item => delete item.body._meta.deliveryKey);
 
-    if (name != null) {
-      const itemsArray: string[] = Array.isArray(name) ? name : [name];
-      const contentItemsFiltered = contentItems.filter(
-        item => itemsArray.findIndex(id => equalsOrRegex(item.label || '', id)) != -1
-      );
-
-      return {
-        contentItems: contentItemsFiltered,
-        missingContent
-      };
-    }
-
-    if (contentType != null) {
-      const itemsArray: string[] = Array.isArray(contentType) ? contentType : [contentType];
-      const contentItemsFiltered = contentItems.filter(item => {
-        return itemsArray.findIndex(id => equalsOrRegex(item.body._meta.schema, id)) != -1;
-      });
+    if (facet != null) {
+      const contentItemsFiltered = applyFacet(contentItems, facet);
 
       return {
         contentItems: contentItemsFiltered,
@@ -163,8 +140,7 @@ export const getContentItems = async ({
   repoId,
   folderId,
   revertLog,
-  name,
-  contentType
+  facet
 }: {
   client: DynamicContent;
   id?: string;
@@ -172,8 +148,7 @@ export const getContentItems = async ({
   repoId?: string | string[];
   folderId?: string | string[];
   revertLog?: string;
-  name?: string | string[];
-  contentType?: string | string[];
+  facet?: string;
 }): Promise<{ contentItems: ContentItem[]; missingContent: boolean }> => {
   try {
     const contentItems: ContentItem[] = [];
@@ -213,8 +188,7 @@ export const getContentItems = async ({
     return (
       (await filterContentItems({
         revertLog,
-        name,
-        contentType,
+        facet,
         contentItems
       })) || {
         contentItems: [],
@@ -305,17 +279,17 @@ export const processItems = async ({
 };
 
 export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationParameters>): Promise<void> => {
-  const { id, logFile, force, silent, ignoreError, hubId, revertLog, repoId, folderId, name, contentType } = argv;
+  const { id, logFile, force, silent, ignoreError, hubId, revertLog, repoId, folderId, facet } = argv;
   const client = dynamicContentClientFactory(argv);
 
-  const allContent = !id && !name && !contentType && !revertLog && !folderId && !repoId;
+  const allContent = !id && !facet && !revertLog && !folderId && !repoId;
 
   if (repoId && id) {
     console.log('ID of content item is specified, ignoring repository ID');
   }
 
-  if (id && name) {
-    console.log('Please specify either a item name or an ID - not both.');
+  if (id && facet) {
+    console.log('Please specify either a facet or an ID - not both.');
     return;
   }
 
@@ -334,8 +308,7 @@ export const handler = async (argv: Arguments<UnarchiveOptions & ConfigurationPa
     repoId,
     folderId,
     revertLog,
-    contentType,
-    name
+    facet
   });
 
   await processItems({

--- a/src/commands/event/archive.ts
+++ b/src/commands/event/archive.ts
@@ -3,7 +3,7 @@ import { ConfigurationParameters } from '../configure';
 import dynamicContentClientFactory from '../../services/dynamic-content-client-factory';
 import paginator from '../../common/dc-management-sdk-js/paginator';
 import { confirmArchive } from '../../common/archive/archive-helpers';
-import ArchiveOptions from '../../common/archive/archive-options';
+import ArchiveEventOptions from '../../common/archive/archive-event-options';
 import { Edition, Event, DynamicContent } from 'dc-management-sdk-js';
 import { equalsOrRegex } from '../../common/filter/filter';
 import { createLog, getDefaultLogPath } from '../../common/log-helpers';
@@ -259,7 +259,7 @@ export const processItems = async ({
   }
 };
 
-export const handler = async (argv: Arguments<ArchiveOptions & ConfigurationParameters>): Promise<void> => {
+export const handler = async (argv: Arguments<ArchiveEventOptions & ConfigurationParameters>): Promise<void> => {
   const { id, logFile, force, silent, name, hubId } = argv;
   const client = dynamicContentClientFactory(argv);
 

--- a/src/common/archive/archive-event-options.ts
+++ b/src/common/archive/archive-event-options.ts
@@ -1,0 +1,10 @@
+export default interface ArchiveOptions {
+  id?: string | string[];
+
+  name?: string | string[];
+
+  logFile?: string;
+  force?: boolean;
+  silent?: boolean;
+  ignoreError?: boolean;
+}

--- a/src/common/archive/archive-event-options.ts
+++ b/src/common/archive/archive-event-options.ts
@@ -1,9 +1,11 @@
+import { FileLog } from '../file-log';
+
 export default interface ArchiveOptions {
   id?: string | string[];
 
   name?: string | string[];
 
-  logFile?: string;
+  logFile: FileLog;
   force?: boolean;
   silent?: boolean;
   ignoreError?: boolean;

--- a/src/common/archive/archive-options.ts
+++ b/src/common/archive/archive-options.ts
@@ -6,8 +6,8 @@ export default interface ArchiveOptions {
   revertLog?: string;
   repoId?: string | string[];
   folderId?: string | string[];
-  name?: string | string[];
-  contentType?: string | string[];
+  facet?: string;
+
   logFile: FileLog;
   force?: boolean;
   silent?: boolean;

--- a/src/common/archive/unarchive-options.ts
+++ b/src/common/archive/unarchive-options.ts
@@ -1,13 +1,14 @@
 export default interface UnarchiveOptions {
   id?: string;
   schemaId?: string | string[];
-  revertLog?: string;
-  silent?: boolean;
-  ignoreError?: boolean;
   repoId?: string | string[];
   folderId?: string | string[];
-  name?: string | string[];
-  contentType?: string | string[];
-  force?: boolean;
+  revertLog?: string;
+
+  facet?: string;
+
   logFile?: string;
+  force?: boolean;
+  silent?: boolean;
+  ignoreError?: boolean;
 }

--- a/src/common/filter/facet.spec.ts
+++ b/src/common/filter/facet.spec.ts
@@ -155,8 +155,8 @@ describe('facet', () => {
     });
   });
 
-  const schemaContentItem = (schemaId: string, label?: string): ContentItem => {
-    return new ContentItem({ body: { _meta: { schemaId } }, label });
+  const schemaContentItem = (schema: string, label?: string): ContentItem => {
+    return new ContentItem({ body: { _meta: { schema } }, label });
   };
 
   describe('applyFilter tests', () => {

--- a/src/common/filter/facet.spec.ts
+++ b/src/common/filter/facet.spec.ts
@@ -1,0 +1,241 @@
+import { applyFacet, parseFacet, dateRangeMatch, relativeDate, parseDateRange, DatePreset } from './facet';
+import { ContentItem } from 'dc-management-sdk-js';
+
+describe('facet', () => {
+  describe('parseFilter tests', () => {
+    it('should parse an empty string as an empty facet', () => {
+      expect(parseFacet('')).toEqual({});
+    });
+
+    it('should parse straightforward filters', () => {
+      expect(parseFacet('locale:en-GB')).toEqual({ locale: 'en-GB' });
+      expect(parseFacet('name:name with space')).toEqual({ name: 'name with space' });
+      expect(parseFacet('name:name with space,status:ACTIVE')).toEqual({
+        name: 'name with space',
+        status: 'ACTIVE'
+      });
+      expect(parseFacet('name:space after commas, schema:test.json, lastModifiedDate:Last 7 days')).toEqual({
+        name: 'space after commas',
+        schema: 'test.json',
+        lastModifiedDate: 'Last 7 days'
+      });
+
+      expect(parseFacet('name:/.endName$/, schema:/test.json$/, lastModifiedDate:Last 7 days')).toEqual({
+        name: '/.endName$/',
+        schema: '/test.json$/',
+        lastModifiedDate: 'Last 7 days'
+      });
+    });
+
+    it('should ignore a final key with no value', () => {
+      expect(parseFacet('key')).toEqual({});
+      expect(parseFacet('locale:en-GB, key')).toEqual({ locale: 'en-GB' });
+    });
+
+    it('should parse values with semicolons', () => {
+      expect(parseFacet('name:name:with:colons')).toEqual({ name: 'name:with:colons' });
+      expect(parseFacet('name:colon:name:,status:ACTIVE')).toEqual({ name: 'colon:name:', status: 'ACTIVE' });
+      expect(parseFacet('name:/nameRegex*./, schema:http://example.com/test.json, status:ARCHIVED')).toEqual({
+        name: '/nameRegex*./',
+        schema: 'http://example.com/test.json',
+        status: 'ARCHIVED'
+      });
+    });
+
+    it('should parse empty values', () => {
+      expect(parseFacet('name:')).toEqual({ name: '' });
+      expect(parseFacet('name:,status:ACTIVE')).toEqual({ name: '', status: 'ACTIVE' });
+    });
+
+    it('should allow comma escapes', () => {
+      expect(parseFacet('name:contains\\,comma,status:ARCHIVED')).toEqual({
+        name: 'contains,comma',
+        status: 'ARCHIVED'
+      });
+      expect(parseFacet('name:\\,,status:ACTIVE')).toEqual({ name: ',', status: 'ACTIVE' });
+      expect(parseFacet('name:\\,\\,\\,,status:ACTIVE')).toEqual({ name: ',,,', status: 'ACTIVE' });
+      expect(parseFacet('name:/regex\\,with\\,commas/,status:ACTIVE')).toEqual({
+        name: '/regex,with,commas/',
+        status: 'ACTIVE'
+      });
+
+      expect(parseFacet('name:/\\escapes\\in\\regex\\,but\\,not\\,commas\\\\,/,status:ACTIVE')).toEqual({
+        name: '/\\escapes\\in\\regex,but,not,commas\\,/',
+        status: 'ACTIVE'
+      });
+    });
+  });
+
+  describe('parseDateRange tests', () => {
+    it('should return a given date range object', () => {
+      expect(parseDateRange({ start: 'NOW', end: '-1:DAYS' })).toEqual({ start: 'NOW', end: '-1:DAYS' });
+      expect(parseDateRange({ start: '-2:DAYS', end: '-32:DAYS' })).toEqual({ start: '-2:DAYS', end: '-32:DAYS' });
+    });
+
+    it('should parse from expected DC date range strings', () => {
+      expect(parseDateRange('Last 7 days')).toEqual({ start: 'NOW', end: '-7:DAYS' });
+      expect(parseDateRange('Last 14 days')).toEqual({ start: 'NOW', end: '-14:DAYS' });
+      expect(parseDateRange('Last 30 days')).toEqual({ start: 'NOW', end: '-30:DAYS' });
+      expect(parseDateRange('Last 60 days')).toEqual({ start: 'NOW', end: '-60:DAYS' });
+      expect(parseDateRange('Over 60 days')).toEqual({ start: '-60:DAYS', end: '-100:YEARS' });
+    });
+
+    it('should throw when given a date range string that cannot be parsed', () => {
+      expect(() => parseDateRange(('Last 234 days' as unknown) as DatePreset)).toThrowErrorMatchingInlineSnapshot(
+        `"Unexpected date range string: Last 234 days"`
+      );
+      expect(() => parseDateRange(('Not a date range' as unknown) as DatePreset)).toThrowErrorMatchingInlineSnapshot(
+        `"Unexpected date range string: Not a date range"`
+      );
+      expect(() => parseDateRange(('2' as unknown) as DatePreset)).toThrowErrorMatchingInlineSnapshot(
+        `"Unexpected date range string: 2"`
+      );
+    });
+  });
+
+  describe('relativeDate tests', () => {
+    const fakeDate = new Date('2021-04-15T12:00:00.000Z');
+    const fakeDateM1 = new Date('2021-04-14T12:00:00.000Z');
+    const fakeDateM5 = new Date('2021-04-10T12:00:00.000Z');
+    const fakeDateP3 = new Date('2021-04-18T12:00:00.000Z');
+
+    beforeAll(() => {
+      const realDate = Date;
+      jest.spyOn(global, 'Date').mockImplementation(() => (new realDate(fakeDate) as unknown) as string);
+    });
+
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should return the current date if the value is NOW', () => {
+      expect(relativeDate('NOW').getTime()).toEqual(fakeDate.getTime());
+    });
+
+    it('should return relative days given an input like #:DAYS', () => {
+      expect(relativeDate('-1:DAYS').getTime()).toEqual(fakeDateM1.getTime());
+      expect(relativeDate('-5:DAYS').getTime()).toEqual(fakeDateM5.getTime());
+      expect(relativeDate('3:DAYS').getTime()).toEqual(fakeDateP3.getTime());
+    });
+
+    it('should throw when the input string does not have two values separated by a colon', () => {
+      expect(() => relativeDate('NO COLON')).toThrowErrorMatchingInlineSnapshot(
+        `"Unexpected relative date format: NO COLON"`
+      );
+      expect(() => relativeDate('TOO:MANY:COLONS')).toThrowErrorMatchingInlineSnapshot(
+        `"Unexpected relative date format: TOO:MANY:COLONS"`
+      );
+    });
+
+    it('should throw when the input units are unknown', () => {
+      expect(() => relativeDate('3:BADUNIT')).toThrowErrorMatchingInlineSnapshot(
+        `"Unexpected relative date units: BADUNIT"`
+      );
+      expect(() => relativeDate('-12:CENTURIES')).toThrowErrorMatchingInlineSnapshot(
+        `"Unexpected relative date units: CENTURIES"`
+      );
+    });
+  });
+
+  describe('dateRangeMatch tests', () => {
+    it('should return true if the given date is within the range', () => {
+      const date = new Date();
+      date.setDate(date.getDate() - 1);
+      expect(dateRangeMatch(date.toISOString(), { start: '-2:DAYS', end: 'NOW' })).toBeTruthy();
+    });
+
+    it('should return false if the given date is not within the range', () => {
+      const date = new Date();
+      date.setDate(date.getDate() - 3);
+      expect(dateRangeMatch(date.toISOString(), { start: '-2:DAYS', end: 'NOW' })).toBeFalsy();
+
+      const date2 = new Date();
+      date2.setDate(date2.getDate() + 1);
+      expect(dateRangeMatch(date2.toISOString(), { start: '-2:DAYS', end: 'NOW' })).toBeFalsy();
+    });
+  });
+
+  const schemaContentItem = (schemaId: string, label?: string): ContentItem => {
+    return new ContentItem({ body: { _meta: { schemaId } }, label });
+  };
+
+  describe('applyFilter tests', () => {
+    const fakeDate = new Date('2021-04-15T12:00:00.000Z');
+    const fakeDateM1 = '2021-04-14T12:00:00.000Z';
+    const fakeDateM10 = '2021-04-05T12:00:00.000Z';
+
+    beforeAll(() => {
+      const realDate = Date;
+      jest
+        .spyOn(global, 'Date')
+        .mockImplementation((date?: string) => (new realDate(date || fakeDate) as unknown) as string);
+    });
+
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should filter content items based on the provided facet', () => {
+      const itemsLabel = [new ContentItem({ label: 'example' }), new ContentItem({ label: 'example2' })];
+      expect(applyFacet(itemsLabel, { name: 'example' })).toEqual([itemsLabel[0]]);
+
+      const itemsSchema = [schemaContentItem('http://schemaMiss.json'), schemaContentItem('http://schemaHit.json')];
+      expect(applyFacet(itemsSchema, { schema: 'http://schemaHit.json' })).toEqual([itemsSchema[1]]);
+
+      const itemsLocale = [new ContentItem({ locale: 'en-GB' }), new ContentItem({ locale: 'en-US' })];
+      expect(applyFacet(itemsLocale, { locale: 'en-GB' })).toEqual([itemsLocale[0]]);
+
+      const itemsStatus = [new ContentItem({ status: 'ACTIVE' }), new ContentItem({ status: 'ARCHIVED' })];
+      expect(applyFacet(itemsStatus, { status: 'ARCHIVED' })).toEqual([itemsStatus[1]]);
+
+      const itemsDate = [
+        new ContentItem({ lastModifiedDate: fakeDateM1 }),
+        new ContentItem({ lastModifiedDate: fakeDateM10 })
+      ];
+      expect(applyFacet(itemsDate, { lastModifiedDate: 'Last 7 days' })).toEqual([itemsDate[0]]);
+    });
+
+    it('should filter content items by regex based on the provided facet', () => {
+      const itemsLabel = [
+        new ContentItem({ label: 'example' }),
+        new ContentItem({ label: 'example2' }),
+        new ContentItem({ label: 'other' })
+      ];
+      expect(applyFacet(itemsLabel, { name: '/example/' })).toEqual([itemsLabel[0], itemsLabel[1]]);
+
+      const itemsSchema = [
+        schemaContentItem('http://schemaMiss.json'),
+        schemaContentItem('http://differentMiss.json'),
+        schemaContentItem('http://schemaHit.json')
+      ];
+      expect(applyFacet(itemsSchema, { schema: '/^http://schema.*\\.json$/' })).toEqual([
+        itemsSchema[0],
+        itemsSchema[2]
+      ]);
+
+      const itemsLocale = [
+        new ContentItem({ locale: 'fr-FR' }),
+        new ContentItem({ locale: 'en-GB' }),
+        new ContentItem({ locale: 'en-US' })
+      ];
+      expect(applyFacet(itemsLocale, { locale: '/^en\\-/' })).toEqual([itemsLocale[1], itemsLocale[2]]);
+    });
+
+    it('should combine multiple filters', () => {
+      const itemsSchema = [
+        schemaContentItem('http://schemaMiss.json', 'incorrectName'),
+        schemaContentItem('http://schemaHit.json', 'correctName'),
+        schemaContentItem('http://differentMiss.json', 'correctName')
+      ];
+      expect(applyFacet(itemsSchema, { name: 'correctName', schema: '/^http://schema.*\\.json$/' })).toEqual([
+        itemsSchema[1]
+      ]);
+    });
+
+    it('should convert the facet from a string if a string is provided', () => {
+      const items = [new ContentItem({ label: 'example' }), new ContentItem({ label: 'example2' })];
+
+      expect(applyFacet(items, 'name:example')).toEqual([items[0]]);
+    });
+  });
+});

--- a/src/common/filter/facet.spec.ts
+++ b/src/common/filter/facet.spec.ts
@@ -258,45 +258,45 @@ describe('facet', () => {
 
     it('should return single values directly', () => {
       expect(withOldFilters(undefined, { name: 'testSearch' })).toEqual('name:testSearch');
-      expect(withOldFilters(undefined, { schemaId: 'testSearch' })).toEqual('schemaId:testSearch');
+      expect(withOldFilters(undefined, { schemaId: 'testSearch' })).toEqual('schema:testSearch');
       expect(withOldFilters(undefined, { name: 'testSearch', schemaId: 'testSearch2' })).toEqual(
-        'name:testSearch,schemaId:testSearch2'
+        'name:testSearch,schema:testSearch2'
       );
 
       expect(withOldFilters(undefined, { name: '/regex/' })).toEqual('name:/regex/');
-      expect(withOldFilters(undefined, { schemaId: '/regex/' })).toEqual('schemaId:/regex/');
+      expect(withOldFilters(undefined, { schemaId: '/regex/' })).toEqual('schema:/regex/');
       expect(withOldFilters(undefined, { name: '/regex/', schemaId: '/regex2/' })).toEqual(
-        'name:/regex/,schemaId:/regex2/'
+        'name:/regex/,schema:/regex2/'
       );
     });
 
     it('should combine values and regexes', () => {
-      expect(withOldFilters(undefined, { name: ['one', 'two'] })).toEqual('name:/one|two/');
-      expect(withOldFilters(undefined, { schemaId: ['one', 'two', 'three'] })).toEqual('schemaId:/one|two|three/');
+      expect(withOldFilters(undefined, { name: ['one', 'two'] })).toEqual('name:/^one$|^two$/');
+      expect(withOldFilters(undefined, { schemaId: ['one', 'two', 'three'] })).toEqual('schema:/^one$|^two$|^three$/');
 
       expect(withOldFilters(undefined, { name: ['/regex/', '/regex2/'] })).toEqual('name:/(regex)|(regex2)/');
       expect(withOldFilters(undefined, { schemaId: ['/regex/', '/regex2/', '/regex3/'] })).toEqual(
-        'schemaId:/(regex)|(regex2)|(regex3)/'
+        'schema:/(regex)|(regex2)|(regex3)/'
       );
     });
 
     it('should escape regex characters when combining names into one', () => {
       expect(withOldFilters(undefined, { name: ['reserved.characters*', 'd.(to)'] })).toEqual(
-        'name:/reserved\\.characters\\*|d\\.\\(to\\)/'
+        'name:/^reserved\\.characters\\*$|^d\\.\\(to\\)$/'
       );
     });
 
     it('should escape commas', () => {
       expect(withOldFilters(undefined, { name: 'test,Search' })).toEqual('name:test\\,Search');
-      expect(withOldFilters(undefined, { schemaId: 'test,Search' })).toEqual('schemaId:test\\,Search');
+      expect(withOldFilters(undefined, { schemaId: 'test,Search' })).toEqual('schema:test\\,Search');
       expect(withOldFilters(undefined, { name: 'test,Search', schemaId: 'test,Search2' })).toEqual(
-        'name:test\\,Search,schemaId:test\\,Search2'
+        'name:test\\,Search,schema:test\\,Search2'
       );
 
       expect(withOldFilters(undefined, { name: '/reg,ex/' })).toEqual('name:/reg\\,ex/');
-      expect(withOldFilters(undefined, { schemaId: '/reg,ex/' })).toEqual('schemaId:/reg\\,ex/');
+      expect(withOldFilters(undefined, { schemaId: '/reg,ex/' })).toEqual('schema:/reg\\,ex/');
       expect(withOldFilters(undefined, { name: '/reg,ex/', schemaId: '/reg,ex2/' })).toEqual(
-        'name:/reg\\,ex/,schemaId:/reg\\,ex2/'
+        'name:/reg\\,ex/,schema:/reg\\,ex2/'
       );
     });
   });

--- a/src/common/filter/facet.ts
+++ b/src/common/filter/facet.ts
@@ -1,0 +1,137 @@
+import { ContentItem } from 'dc-management-sdk-js';
+import { equalsOrRegex } from './filter';
+
+interface FacetRange {
+  start: string;
+  end: string;
+}
+
+interface Facet {
+  locale?: string;
+  name?: string;
+  schema?: string;
+  status?: string;
+  lastModifiedDate?: FacetRange | DatePreset;
+}
+
+export type DatePreset = 'Last 7 days' | 'Last 14 days' | 'Last 30 days' | 'Last 60 days' | 'Over 60 days';
+
+export function parseFacet(filter: string): Facet {
+  // The format is rather simple:
+  // "key:value, key:valueWith\,Comma, key:value:with:colon,"
+  // Comma separated key value list. The first colon designates the end of the key. All commas must be escaped.
+  // The space between list items is optional.
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const result: any = {};
+  let searchIndex = 0;
+
+  while (searchIndex < filter.length) {
+    const keyEnd = filter.indexOf(':', searchIndex);
+    if (keyEnd == -1) break;
+
+    const key = filter.substring(searchIndex, keyEnd).trimLeft();
+
+    // Find value end, escape commas with backslash.
+
+    let valueEnd = filter.length;
+    let valueEndSearch = keyEnd;
+
+    while (valueEndSearch < filter.length) {
+      const potentialValueEnd = filter.indexOf(',', valueEndSearch);
+
+      if (potentialValueEnd == -1) {
+        break;
+      } else if (filter[potentialValueEnd - 1] == '\\') {
+        valueEndSearch = potentialValueEnd + 1;
+      } else {
+        valueEnd = potentialValueEnd;
+        break;
+      }
+    }
+
+    const value = filter.substring(keyEnd + 1, valueEnd).replace(/\\\,/g, ',');
+
+    result[key] = value;
+
+    searchIndex = valueEnd + 1;
+  }
+
+  return result as Facet;
+}
+
+export function parseDateRange(range: DatePreset | FacetRange): FacetRange {
+  if (typeof range === 'string') {
+    switch (range) {
+      case 'Last 7 days':
+        return { start: 'NOW', end: '-7:DAYS' };
+      case 'Last 14 days':
+        return { start: 'NOW', end: '-14:DAYS' };
+      case 'Last 30 days':
+        return { start: 'NOW', end: '-30:DAYS' };
+      case 'Last 60 days':
+        return { start: 'NOW', end: '-60:DAYS' };
+      case 'Over 60 days':
+        return { start: '-60:DAYS', end: '-100:YEARS' };
+      default:
+        throw new Error(`Unexpected date range string: ${range}`);
+    }
+  }
+
+  return range;
+}
+
+export function relativeDate(relative: string): Date {
+  if (relative === 'NOW') return new Date();
+
+  const date = new Date();
+
+  const split = relative.split(':');
+  if (split.length != 2) {
+    throw new Error(`Unexpected relative date format: ${relative}`);
+  }
+
+  const unit = split[1];
+  switch (unit) {
+    case 'DAYS':
+      date.setDate(date.getDate() + Number(split[0]));
+      return date;
+    default:
+      throw new Error(`Unexpected relative date units: ${unit}`);
+  }
+}
+
+export function dateRangeMatch(dateString: string, range: DatePreset | FacetRange): boolean {
+  const date = new Date(dateString);
+  range = parseDateRange(range);
+
+  const start = relativeDate(range.start);
+  const end = relativeDate(range.end);
+
+  const inverted = start > end;
+  const lower = inverted ? end : start;
+  const higher = inverted ? start : end;
+
+  return date > lower && date <= higher;
+}
+
+export function applyFacet(items: ContentItem[], facetOrString: Facet | string): ContentItem[] {
+  let facet: Facet;
+  if (typeof facetOrString === 'string') {
+    facet = parseFacet(facetOrString);
+  } else {
+    facet = facetOrString;
+  }
+
+  return items.filter(item => {
+    if (facet.locale && !equalsOrRegex(item.locale, facet.locale)) return false;
+    if (facet.name && !equalsOrRegex(item.label, facet.name)) return false;
+    if (facet.schema && !equalsOrRegex(item.body._meta.schemaId, facet.schema)) return false;
+    if (facet.status && !equalsOrRegex(item.status, facet.status)) return false;
+
+    // Date range checks.
+    if (facet.lastModifiedDate && !dateRangeMatch(item.lastModifiedDate, facet.lastModifiedDate)) return false;
+
+    return true;
+  });
+}

--- a/src/common/filter/facet.ts
+++ b/src/common/filter/facet.ts
@@ -124,9 +124,9 @@ export function applyFacet(items: ContentItem[], facetOrString: Facet | string):
   }
 
   return items.filter(item => {
-    if (facet.locale && !equalsOrRegex(item.locale, facet.locale)) return false;
+    if (facet.locale && (!item.locale || !equalsOrRegex(item.locale, facet.locale))) return false;
     if (facet.name && !equalsOrRegex(item.label, facet.name)) return false;
-    if (facet.schema && !equalsOrRegex(item.body._meta.schemaId, facet.schema)) return false;
+    if (facet.schema && !equalsOrRegex(item.body._meta.schema, facet.schema)) return false;
     if (facet.status && !equalsOrRegex(item.status, facet.status)) return false;
 
     // Date range checks.

--- a/src/common/filter/facet.ts
+++ b/src/common/filter/facet.ts
@@ -151,7 +151,7 @@ function combineFilters(filters: string[] | string): string {
     if (filter.length > 2 && filter[0] === '/' && filter[filter.length - 1] === '/') {
       regexElements.push(`(${filter.substr(1, filter.length - 2)})`);
     } else {
-      regexElements.push(escapeForRegex(filter));
+      regexElements.push(`^${escapeForRegex(filter)}$`);
     }
   }
 
@@ -175,7 +175,7 @@ export function withOldFilters(facet: string | undefined, args: any): string | u
   }
 
   if (args.schemaId) {
-    resultFilters.push(getOldFilter(args.schemaId, 'schemaId'));
+    resultFilters.push(getOldFilter(args.schemaId, 'schema'));
   }
 
   return resultFilters.map(filter => filter.replace(/\,/g, '\\,')).join(',');

--- a/src/interfaces/copy-item-builder-options.interface.ts
+++ b/src/interfaces/copy-item-builder-options.interface.ts
@@ -12,8 +12,7 @@ export interface CopyItemBuilderOptions {
   dstClientId?: string;
   dstSecret?: string;
 
-  schemaId?: string[] | string;
-  name?: string[] | string;
+  facet?: string;
 
   mapFile?: string;
   force?: boolean;

--- a/src/interfaces/export-item-builder-options.interface.ts
+++ b/src/interfaces/export-item-builder-options.interface.ts
@@ -4,8 +4,7 @@ export interface ExportItemBuilderOptions {
   dir: string;
   folderId?: string[] | string;
   repoId?: string[] | string;
-  schemaId?: string[] | string;
-  name?: string[] | string;
+  facet?: string;
   logFile: FileLog;
   publish?: boolean;
 


### PR DESCRIPTION
This PR replaces the existing `--name` and `--schemaId` arguments with an all encompassing `--facet` argument, which adds filtering by locale and date modified.

These filters can be applied to any array of content items, and can currently be used on `content-item` `archive` `unarchive` `copy` `move` and `export`. As of right now, the facets are applied in software after fetching _all_ content items (within the requested hub/repo/folder), though it is possible in the future to extend this to request content with the facets to save time in future. Note that the regex faceting mode will likely not see this treatment.

A full explanation of the `--facet` argument has been added to the `HOW_TO_USE.md` file. I'll dupe it below for ease of access:

## FACETS
The content item export, copy, move, archive and unarchive commands allow the user to provide a facet string to filter the content that the commands work on. Multiple of these can be applied at a time, and you can even match on regex string. Note that you will need to surround your facet in quotes if it contains a space, which will change how backslash escaping works.

- `name`: Filter on content item label. Example: `--facet "name:exact name match"`
- `schema`: Filter on schema ids. Example: `--facet schema:http://example.com/schema.json`
- `locale`: Filter on content item locale. Example: `--facet locale:en-GB`
- `lastModifiedDate`: Filter on last modified date. Example: `--facet "lastModifiedDate:Last 7 days"`

Multiple facets can be applied at once when separated by a comma. Example:
`--facet "schema:http://example.com/schema.json, name:/name regex/"`

Commas can be escaped with a backslash, if they are used in your values. The whitespace after a comma is optional.

### PRESET DATE RANGES
The preset date ranges are the same as DC provides:
- `Last 7 days`
- `Last 14 days`
- `Last 30 days`
- `Last 60 days`
- `Over 60 days`

### REGEX
You can use regex values on string fields when filtering content. They cannot be used on date ranges. Regex are surronded by two forward slashes:
`--facet "name:/ends with this$/"`
