### PR TITLE
fix(content-type-schema): always treat archived schemas as out of date

### DIFF
--- a/src/commands/content-type-schema/import.ts
+++ b/src/commands/content-type-schema/import.ts
@@ -75,7 +75,7 @@ export const doUpdate = async (
 ): Promise<{ contentTypeSchema: ContentTypeSchema; updateStatus: UpdateStatus }> => {
   try {
     let retrievedSchema: ContentTypeSchema = await client.contentTypeSchemas.get(schema.id || '');
-    if (equals(retrievedSchema, schema)) {
+    if (equals(retrievedSchema, schema) && retrievedSchema.status !== Status.ARCHIVED) {
       return { contentTypeSchema: retrievedSchema, updateStatus: UpdateStatus.SKIPPED };
     }
 


### PR DESCRIPTION
Fixes an issue where schema import would report 'UP-TO-DATE' when importing schemas, but the schema on the server was archived. This makes it behave more in line with what is expected in the hub clean / import process.