### PR TITLE
feat(content-item): make --publish flag publish on update when source publish date is more recent

### DIFF
--- a/src/commands/content-item/copy.spec.ts
+++ b/src/commands/content-item/copy.spec.ts
@@ -135,7 +135,7 @@ describe('content-item copy command', () => {
       expect(spyOption).toHaveBeenCalledWith('publish', {
         type: 'boolean',
         boolean: true,
-        describe: 'Publish any content items that have an existing publish status in their JSON.'
+        describe: 'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
       });
 
       expect(spyOption).toHaveBeenCalledWith('republish', {

--- a/src/commands/content-item/copy.spec.ts
+++ b/src/commands/content-item/copy.spec.ts
@@ -135,7 +135,8 @@ describe('content-item copy command', () => {
       expect(spyOption).toHaveBeenCalledWith('publish', {
         type: 'boolean',
         boolean: true,
-        describe: 'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
+        describe:
+          'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
       });
 
       expect(spyOption).toHaveBeenCalledWith('republish', {

--- a/src/commands/content-item/copy.ts
+++ b/src/commands/content-item/copy.ts
@@ -114,7 +114,8 @@ export const builder = (yargs: Argv): void => {
     .option('publish', {
       type: 'boolean',
       boolean: true,
-      describe: 'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
+      describe:
+        'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
     })
 
     .option('republish', {

--- a/src/commands/content-item/copy.ts
+++ b/src/commands/content-item/copy.ts
@@ -114,7 +114,7 @@ export const builder = (yargs: Argv): void => {
     .option('publish', {
       type: 'boolean',
       boolean: true,
-      describe: 'Publish any content items that have an existing publish status in their JSON.'
+      describe: 'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
     })
 
     .option('republish', {

--- a/src/commands/content-item/import.spec.ts
+++ b/src/commands/content-item/import.spec.ts
@@ -107,7 +107,7 @@ describe('content-item import command', () => {
       expect(spyOption).toHaveBeenCalledWith('publish', {
         type: 'boolean',
         boolean: true,
-        describe: 'Publish any content items that have an existing publish status in their JSON.'
+        describe: 'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
       });
 
       expect(spyOption).toHaveBeenCalledWith('republish', {

--- a/src/commands/content-item/import.spec.ts
+++ b/src/commands/content-item/import.spec.ts
@@ -206,6 +206,7 @@ describe('content-item import command', () => {
           folderId: folderId,
           locale: item.locale,
           lastPublishedVersion: item.lastPublishedVersion,
+          lastPublishedDate: item.lastPublishedDate,
 
           body: {
             _meta: {
@@ -1106,18 +1107,18 @@ describe('content-item import command', () => {
       expect((reverter as any).calls[0]).toEqual(argv);
     });
 
-    it('should publish items when --publish is provided, and the items specify a last published version', async () => {
+    it('should publish items when --publish is provided, and the items specify a last published date', async () => {
       // Create content to import
       // 3 out of 4 should publish. item2 publishes item3, so only 2 requests are made.
 
       const templates: ItemTemplate[] = [
-        { label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type', lastPublishedVersion: 1 },
+        { label: 'item1', repoId: 'repo', typeSchemaUri: 'http://type', lastPublishedDate: '2021-06-09T15:51:07.404Z' },
         {
           label: 'item2',
           repoId: 'repo',
           typeSchemaUri: 'http://type',
           folderPath: 'folderTest',
-          lastPublishedVersion: 1,
+          lastPublishedDate: '2021-06-09T15:51:07.404Z',
           body: dependsOn(['id3'])
         },
         {
@@ -1126,7 +1127,8 @@ describe('content-item import command', () => {
           repoId: 'repo',
           typeSchemaUri: 'http://type',
           folderPath: 'folderTest',
-          lastPublishedVersion: 1 // This item is implicitly published by item 2, so it should NOT be published separately.
+          lastPublishedDate: '2021-06-09T15:51:07.404Z'
+          // This item is implicitly published by item 2, so it should NOT be published separately.
         },
         { label: 'item4', repoId: 'repo', typeSchemaUri: 'http://type', folderPath: 'folderTest/nested' }
       ];
@@ -1165,7 +1167,7 @@ describe('content-item import command', () => {
         typeSchemaUri: 'http://type',
         folderPath: 'folderTest',
         body: dependsOn(['id1', 'id3']),
-        lastPublishedVersion: 1 // Test publishing a circular dependancy.
+        lastPublishedDate: '2021-06-09T15:51:07.404Z' // Test publishing a circular dependancy.
       },
       {
         id: 'id3',

--- a/src/commands/content-item/import.spec.ts
+++ b/src/commands/content-item/import.spec.ts
@@ -107,7 +107,8 @@ describe('content-item import command', () => {
       expect(spyOption).toHaveBeenCalledWith('publish', {
         type: 'boolean',
         boolean: true,
-        describe: 'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
+        describe:
+          'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
       });
 
       expect(spyOption).toHaveBeenCalledWith('republish', {

--- a/src/commands/content-item/import.ts
+++ b/src/commands/content-item/import.ts
@@ -101,7 +101,7 @@ export const builder = (yargs: Argv): void => {
     .option('publish', {
       type: 'boolean',
       boolean: true,
-      describe: 'Publish any content items that have an existing publish status in their JSON.'
+      describe: 'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
     })
 
     .option('republish', {

--- a/src/commands/content-item/import.ts
+++ b/src/commands/content-item/import.ts
@@ -101,7 +101,8 @@ export const builder = (yargs: Argv): void => {
     .option('publish', {
       type: 'boolean',
       boolean: true,
-      describe: 'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
+      describe:
+        'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
     })
 
     .option('republish', {

--- a/src/commands/content-item/import.ts
+++ b/src/commands/content-item/import.ts
@@ -269,9 +269,13 @@ const createOrUpdateContent = async (
   return result;
 };
 
-const itemShouldPublish = (item: ContentItem): boolean => {
+const itemShouldPublish = (item: ContentItem, newItem: ContentItem, updated: boolean): boolean => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (item as any).publish; // Added when creating the filtered content.
+  const sourceDate = (item as any).lastPublish;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const targetDate = (newItem as any).lastPublishedDate;
+
+  return sourceDate && (updated || !targetDate || new Date(targetDate) < new Date(sourceDate)); // Added when creating the filtered content.
 };
 
 const trySaveMapping = async (mapFile: string | undefined, mapping: ContentMapping, log: FileLog): Promise<void> => {
@@ -384,7 +388,7 @@ const prepareContentForImport = async (
         body: contentJSON.body,
         deliveryId: contentJSON.deliveryId == contentJSON.Id || argv.excludeKeys ? undefined : contentJSON.deliveryId,
         folderId: folder == null ? null : folder.id,
-        publish: contentJSON.lastPublishedVersion != null
+        lastPublish: contentJSON.lastPublishedDate
       };
 
       if (argv.excludeKeys) {
@@ -757,7 +761,7 @@ const importTree = async (
         (newItem.id || 'unknown') + (updated ? ` ${oldVersion} ${newItem.version}` : '')
       );
 
-      if (itemShouldPublish(content) && (newItem.version != oldVersion || argv.republish)) {
+      if (itemShouldPublish(content, newItem, argv.republish || newItem.version != oldVersion)) {
         publishable.push({ item: newItem, node: item });
       }
 
@@ -838,7 +842,7 @@ const importTree = async (
         mapping.registerContentItem(originalId as string, newItem.id as string);
         mapping.registerContentItem(newItem.id as string, newItem.id as string);
       } else {
-        if (itemShouldPublish(content) && (newItem.version != oldVersion || argv.republish)) {
+        if (itemShouldPublish(content, newItem, argv.republish || newItem.version != oldVersion)) {
           publishable.push({ item: newItem, node: item });
         }
       }

--- a/src/commands/content-item/move.ts
+++ b/src/commands/content-item/move.ts
@@ -109,7 +109,8 @@ export const builder = (yargs: Argv): void => {
     .option('publish', {
       type: 'boolean',
       boolean: true,
-      describe: 'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
+      describe:
+        'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
     })
 
     .option('republish', {

--- a/src/commands/content-item/move.ts
+++ b/src/commands/content-item/move.ts
@@ -109,7 +109,7 @@ export const builder = (yargs: Argv): void => {
     .option('publish', {
       type: 'boolean',
       boolean: true,
-      describe: 'Publish any content items that have an existing publish status in their JSON.'
+      describe: 'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
     })
 
     .option('republish', {

--- a/src/commands/hub/clone.spec.ts
+++ b/src/commands/hub/clone.spec.ts
@@ -180,7 +180,8 @@ describe('hub clone command', () => {
       expect(spyOption).toHaveBeenCalledWith('publish', {
         type: 'boolean',
         boolean: true,
-        describe: 'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
+        describe:
+          'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
       });
 
       expect(spyOption).toHaveBeenCalledWith('republish', {

--- a/src/commands/hub/clone.spec.ts
+++ b/src/commands/hub/clone.spec.ts
@@ -180,7 +180,7 @@ describe('hub clone command', () => {
       expect(spyOption).toHaveBeenCalledWith('publish', {
         type: 'boolean',
         boolean: true,
-        describe: 'Publish any content items that have an existing publish status in their JSON.'
+        describe: 'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
       });
 
       expect(spyOption).toHaveBeenCalledWith('republish', {

--- a/src/commands/hub/clone.ts
+++ b/src/commands/hub/clone.ts
@@ -113,7 +113,7 @@ export const builder = (yargs: Argv): void => {
     .option('publish', {
       type: 'boolean',
       boolean: true,
-      describe: 'Publish any content items that have an existing publish status in their JSON.'
+      describe: 'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
     })
 
     .option('republish', {

--- a/src/commands/hub/clone.ts
+++ b/src/commands/hub/clone.ts
@@ -113,7 +113,8 @@ export const builder = (yargs: Argv): void => {
     .option('publish', {
       type: 'boolean',
       boolean: true,
-      describe: 'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
+      describe:
+        'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
     })
 
     .option('republish', {

--- a/src/common/dc-management-sdk-js/mock-content.ts
+++ b/src/common/dc-management-sdk-js/mock-content.ts
@@ -24,6 +24,7 @@ export interface ItemTemplate {
   status?: string;
   locale?: string;
   lastPublishedVersion?: number;
+  lastPublishedDate?: string;
 
   body?: any;
   dependancy?: string;
@@ -504,6 +505,7 @@ export class MockContent {
         folderId: folderNullOrEmpty ? null : folderId,
         version: template.version,
         lastPublishedVersion: template.lastPublishedVersion,
+        lastPublishedDate: template.lastPublishedDate,
         locale: template.locale,
         body: {
           ...template.body,


### PR DESCRIPTION
This catches two cases which forced people to use the `--republish` command, unnecessarily publishing all assets instead of just the ones they're interested in:

- Running `--publish` after importing without it. Before, it would only publish content that was updated (uploading the content resulted in version increase), so it would not publish the content that wasn't published the first time. This meant that people that took this workflow had to use `--republish` to avoid issues.
- Running `--publish` after republishing content in the source will also republish in the destination, even if it hasn't changed. This can also be triggered manually by fudging the publish date in the file.

This does cause a small functional change in that the `lastPublishedDate` is now the source of truth for a publish rather than the `lastPublishedVersion`, but this information was not readily documented or encouraged for manual modification that people use it so I wouldn't call it breaking.