### PR TITLE
fix: content-item import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dlillyatx/dc-cli",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dlillyatx/dc-cli",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^17.0.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.13.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@types/node": "^17.0.21",
         "ajv": "^6.12.3",
         "axios": "^0.21.1",
         "chalk": "^2.4.2",
         "dc-management-sdk-js": "^1.14.0",
+        "http-status-codes": "^2.2.0",
         "lodash": "^4.17.21",
         "node-fetch": "^2.6.1",
         "promise-retry": "^2.0.1",
@@ -2559,10 +2561,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "12.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
-      "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==",
-      "dev": true
+      "version": "17.0.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
+      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.5.7",
@@ -5895,6 +5896,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.0",
@@ -14277,10 +14283,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
-      "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==",
-      "dev": true
+      "version": "17.0.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
+      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ=="
     },
     "@types/node-fetch": {
       "version": "2.5.7",
@@ -16890,6 +16895,11 @@
         "agent-base": "6",
         "debug": "4"
       }
+    },
+    "http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
     },
     "https-proxy-agent": {
       "version": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@amplience/dc-cli",
+  "name": "@dlillyatx/dc-cli",
   "version": "0.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@amplience/dc-cli",
+      "name": "@dlillyatx/dc-cli",
       "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dlillyatx/dc-cli",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dlillyatx/dc-cli",
-      "version": "0.13.2",
+      "version": "0.13.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^17.0.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dlillyatx/dc-cli",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dlillyatx/dc-cli",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^6.12.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@types/node": "^17.0.21",
         "ajv": "^6.12.3",
+        "async": "^3.2.4",
         "axios": "^0.21.1",
         "chalk": "^2.4.2",
         "dc-management-sdk-js": "^1.14.0",
@@ -30,6 +31,7 @@
       "devDependencies": {
         "@commitlint/cli": "^13.1.0",
         "@commitlint/config-conventional": "^8.2.0",
+        "@types/async": "^3.2.15",
         "@types/chalk": "^2.2.0",
         "@types/jest": "^24.0.18",
         "@types/lodash": "^4.14.144",
@@ -2414,6 +2416,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@types/async": {
+      "version": "3.2.15",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.15.tgz",
+      "integrity": "sha512-PAmPfzvFA31mRoqZyTVsgJMsvbynR429UTTxhmfsUCrWGh3/fxOrzqBtaTPJsn4UtzTv4Vb0+/O7CARWb69N4g==",
+      "dev": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.1.15",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.15.tgz",
@@ -3053,6 +3061,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/async": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -14137,6 +14150,12 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@types/async": {
+      "version": "3.2.15",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.15.tgz",
+      "integrity": "sha512-PAmPfzvFA31mRoqZyTVsgJMsvbynR429UTTxhmfsUCrWGh3/fxOrzqBtaTPJsn4UtzTv4Vb0+/O7CARWb69N4g==",
+      "dev": true
+    },
     "@types/babel__core": {
       "version": "7.1.15",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.15.tgz",
@@ -14663,6 +14682,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
+    },
+    "async": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "asynckit": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlillyatx/dc-cli",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Dynamic Content CLI Tool",
   "main": "./dist/index.js",
   "man": "./dist/dc-cli.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dc-cli": "./dist/index.js"
   },
   "scripts": {
+    "prepare": "npm run build",
     "precommit": "npm run lint",
     "commit": "npx git-cz",
     "lint": "prettier --check \"**/*.ts\" && eslint \"**/*.ts\"",

--- a/package.json
+++ b/package.json
@@ -49,11 +49,6 @@
       "path": "./node_modules/cz-conventional-changelog"
     }
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm test"
-    }
-  },
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"

--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm test",
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+      "pre-commit": "npm test"
     }
   },
   "commitlint": {
@@ -113,10 +112,12 @@
     "typescript": "^3.9.10"
   },
   "dependencies": {
+    "@types/node": "^17.0.21",
     "ajv": "^6.12.3",
     "axios": "^0.21.1",
     "chalk": "^2.4.2",
     "dc-management-sdk-js": "^1.14.0",
+    "http-status-codes": "^2.2.0",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.1",
     "promise-retry": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
   "devDependencies": {
     "@commitlint/cli": "^13.1.0",
     "@commitlint/config-conventional": "^8.2.0",
+    "@types/async": "^3.2.15",
     "@types/chalk": "^2.2.0",
     "@types/jest": "^24.0.18",
     "@types/lodash": "^4.14.144",
@@ -109,6 +110,7 @@
   "dependencies": {
     "@types/node": "^17.0.21",
     "ajv": "^6.12.3",
+    "async": "^3.2.4",
     "axios": "^0.21.1",
     "chalk": "^2.4.2",
     "dc-management-sdk-js": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlillyatx/dc-cli",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Dynamic Content CLI Tool",
   "main": "./dist/index.js",
   "man": "./dist/dc-cli.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amplience/dc-cli",
+  "name": "@dlillyatx/dc-cli",
   "version": "0.13.0",
   "description": "Dynamic Content CLI Tool",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlillyatx/dc-cli",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "Dynamic Content CLI Tool",
   "main": "./dist/index.js",
   "man": "./dist/dc-cli.1",

--- a/src/common/import/amplience-rest-client.ts
+++ b/src/common/import/amplience-rest-client.ts
@@ -1,0 +1,87 @@
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+import _ from 'lodash';
+import { HttpMethod } from 'dc-management-sdk-js';
+
+export const RATE_LIMIT_BACKOFF = 500; // initial backoff for rate limiter, in ms
+
+export const sleep = (delay: number) => new Promise(resolve => setTimeout(resolve, delay));
+
+type AuthenticationStatus = 'NOT_LOGGED_IN' | 'LOGGING_IN' | 'LOGGED_IN';
+export const AmplienceRestClient = (config: { clientId: string; clientSecret: string }) => {
+  let authenticatedAxios: AxiosInstance;
+  let status: AuthenticationStatus = 'NOT_LOGGED_IN';
+
+  const apiUrl = `https://api.amplience.net/v2/content`;
+  const authUrl = `https://auth.amplience.net/oauth/token?client_id=${config.clientId}&client_secret=${config.clientSecret}&grant_type=client_credentials`;
+
+  const authenticate = async (): Promise<AxiosInstance> => {
+    if (!authenticatedAxios) {
+      const response = await axios.post(
+        authUrl,
+        {},
+        {
+          headers: {
+            'content-type': 'application/x-www-form-urlencoded'
+          }
+        }
+      );
+      const auth = response.data;
+
+      authenticatedAxios = axios.create({
+        baseURL: apiUrl,
+        headers: {
+          Authorization: `${auth.token_type || 'Bearer'} ${auth.access_token}`,
+          'content-type': 'application/x-www-form-urlencoded'
+        }
+      });
+    }
+    return authenticatedAxios;
+  };
+
+  const request = (method: HttpMethod, delay: number = RATE_LIMIT_BACKOFF) => async (
+    config: AxiosRequestConfig | string
+  ): Promise<any> => {
+    if (typeof config === 'string') {
+      config = { url: config };
+    }
+
+    // authentication
+    switch (status) {
+      case 'LOGGING_IN':
+        await sleep(100);
+        return await request(method)(config);
+
+      case 'NOT_LOGGED_IN':
+        authenticatedAxios = await authenticate();
+        status = 'LOGGED_IN';
+
+      case 'LOGGED_IN':
+        break;
+    }
+
+    try {
+      return await authenticatedAxios.request({ method, ...config });
+    } catch (error) {
+      if (error.response.status === 429) {
+        await sleep(delay);
+
+        // dal - implemented exponential backoff for timeout retry
+        return await request(method, delay * 2)(config);
+      } else if (error.response.status === 404) {
+        // don't throw on a 404 just return an empty result set
+        return null;
+      }
+      console.log(`Error while ${method}ing URL [ ${config.url} ]: ${error.message} ${error.code}`);
+    }
+  };
+
+  return {
+    get: request(HttpMethod.GET),
+    delete: request(HttpMethod.DELETE),
+    put: request(HttpMethod.PUT),
+    post: request(HttpMethod.POST),
+    patch: request(HttpMethod.PATCH)
+  };
+};
+
+export default AmplienceRestClient;

--- a/src/common/import/rate-limit-publish-queue.ts
+++ b/src/common/import/rate-limit-publish-queue.ts
@@ -1,0 +1,57 @@
+import { ContentItem } from 'dc-management-sdk-js';
+import _ from 'lodash';
+import { ConfigurationParameters } from '../../commands/configure';
+import async from 'async';
+import { PublishingJob } from './publish-queue';
+import AmplienceRestClient from './amplience-rest-client';
+
+// rate limit is 100 publish requests per minute
+export const RATE_LIMIT_INTERVAL = 60000; // in ms
+export const RATE_LIMIT_THRESHOLD = 100; // chunk size
+
+const sleep = (delay: number) => new Promise(resolve => setTimeout(resolve, delay));
+const RateLimitedPublishQueue = {
+  getInstance: (args: ConfigurationParameters) => {
+    const queue: ContentItem[] = [];
+    const restClient = AmplienceRestClient(args);
+
+    const waitForPublishingJob = async (jobUrl: string): Promise<any> => {
+      const jobStatus: PublishingJob = (await restClient.get(jobUrl)).data;
+      if (jobStatus.state !== 'COMPLETED' && jobStatus.state !== 'FAILED') {
+        await sleep(500);
+        return await waitForPublishingJob(jobUrl);
+      }
+      return jobStatus;
+    };
+
+    const publishContentItem = async (item: ContentItem): Promise<any> => {
+      const response = await restClient.post(`/content-items/${item.id}/publish`);
+      if (response.status != 204) {
+        throw new Error(`Failed to start publish: ${response.statusText} - ${await response.text()}`);
+      }
+      if (!response.headers['location']) {
+        throw new Error('Expected publish job location in header. Has the publish workflow changed?');
+      }
+      return await waitForPublishingJob(response.headers['location']);
+    };
+
+    return {
+      publish: async (item: ContentItem): Promise<any> => {
+        queue.push(item);
+      },
+
+      waitForAll: async (): Promise<PublishingJob[]> => {
+        return await async.mapLimit(queue, RATE_LIMIT_THRESHOLD, async (item: ContentItem) => {
+          const itemStart = new Date().valueOf();
+          const result = await publishContentItem(item);
+
+          // rate limit the next item in the queue
+          const elapsed = new Date().valueOf() - itemStart;
+          await sleep(RATE_LIMIT_INTERVAL - elapsed);
+          return result;
+        });
+      }
+    };
+  }
+};
+export default RateLimitedPublishQueue;


### PR DESCRIPTION
This fix corrects an issue where in certain cases, the CLI attempts to create child content items before their parent item.

Please see attached ZIP file for a minimal set of content items to import to recreate this error.

[import-fix.zip](https://github.com/amplience/dc-cli/files/7892058/import-fix.zip)
