### PR TITLE
fix(search-index): fix replica name rewriting

### DIFF
--- a/src/commands/search-index/__snapshots__/import.spec.ts.snap
+++ b/src/commands/search-index/__snapshots__/import.spec.ts.snap
@@ -1,28 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`search-index import command doCreate should throw an error when enrichIndex fails 1`] = `
-"Error creating index index-name:
+exports[`search-index import command doCreate should throw an error when enrichIndex fails 1`] = `"Error creating index index-name: The update-index action is not available, ensure you have permission to perform this action."`;
 
-The update-index action is not available, ensure you have permission to perform this action."
-`;
+exports[`search-index import command doCreate should throw an error when index create fails 1`] = `"Error creating index index-name: Error: Error creating index"`;
 
-exports[`search-index import command doCreate should throw an error when index create fails 1`] = `
-"Error creating index index-name:
+exports[`search-index import command doCreate should throw an error when index create fails if a string error is returned by the sdk 1`] = `"Error creating index index-name: The create-index action is not available, ensure you have permission to perform this action."`;
 
-Error: Error creating index"
-`;
+exports[`search-index import command doUpdate should throw an error when unable to get index during update 1`] = `"Error updating index matched-name: Error: Error retrieving index"`;
 
-exports[`search-index import command doCreate should throw an error when index create fails if a string error is returned by the sdk 1`] = `
-"Error creating index index-name:
+exports[`search-index import command doUpdate should throw an error when unable to update index during update 1`] = `"Error updating index not-matched-name: Error: Error saving index"`;
 
-The create-index action is not available, ensure you have permission to perform this action."
-`;
-
-exports[`search-index import command doUpdate should throw an error when unable to get index during update 1`] = `"Error updating index matched-name: Error retrieving index"`;
-
-exports[`search-index import command doUpdate should throw an error when unable to update index during update 1`] = `"Error updating index not-matched-name: Error saving index"`;
-
-exports[`search-index import command doUpdate should throw an error when unable to update index during update if a string error is returned by sdk 1`] = `"Error updating index not-matched-name: undefined"`;
+exports[`search-index import command doUpdate should throw an error when unable to update index during update if a string error is returned by sdk 1`] = `"Error updating index not-matched-name: The update action is not available, ensure you have permission to perform this action."`;
 
 exports[`search-index import command handler tests should throw an error when no content found in import directory 1`] = `"No indexes found in my-empty-dir"`;
 

--- a/src/commands/search-index/import.spec.ts
+++ b/src/commands/search-index/import.spec.ts
@@ -855,7 +855,12 @@ describe('search-index import command', (): void => {
     it("should rewrite index names to contain the given hub's name", () => {
       const indexesToProcess = {
         'file-1': new EnrichedSearchIndex({
-          name: 'oldHub.index-name-1'
+          name: 'oldHub.index-name-1',
+          replicas: [
+            new EnrichedReplica({
+              name: 'oldHub.index-name-1_sort-example'
+            })
+          ]
         }),
         'file-2': new EnrichedSearchIndex({
           name: 'index-name-2'
@@ -868,6 +873,7 @@ describe('search-index import command', (): void => {
 
       expect(indexesToProcess['file-1'].name).toEqual('newHub.index-name-1');
       expect(indexesToProcess['file-2'].name).toEqual('newHub.index-name-2');
+      expect(indexesToProcess['file-1'].replicas[0].name).toEqual('newHub.index-name-1_sort-example');
     });
   });
 

--- a/src/commands/search-index/import.spec.ts
+++ b/src/commands/search-index/import.spec.ts
@@ -860,7 +860,10 @@ describe('search-index import command', (): void => {
             new EnrichedReplica({
               name: 'oldHub.index-name-1_sort-example'
             })
-          ]
+          ],
+          settings: {
+            replicas: ['oldHub.index-name-1_sort-example']
+          }
         }),
         'file-2': new EnrichedSearchIndex({
           name: 'index-name-2'
@@ -874,6 +877,7 @@ describe('search-index import command', (): void => {
       expect(indexesToProcess['file-1'].name).toEqual('newHub.index-name-1');
       expect(indexesToProcess['file-2'].name).toEqual('newHub.index-name-2');
       expect(indexesToProcess['file-1'].replicas[0].name).toEqual('newHub.index-name-1_sort-example');
+      expect(indexesToProcess['file-1'].settings.replicas[0]).toEqual('newHub.index-name-1_sort-example');
     });
   });
 

--- a/src/commands/search-index/import.spec.ts
+++ b/src/commands/search-index/import.spec.ts
@@ -177,7 +177,7 @@ describe('search-index import command', (): void => {
         ]
       `);
       expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ ...indexBase, assignedContentTypes }));
-      expect(importModule.enrichIndex).toHaveBeenCalledWith(newIndex, index, webhooks);
+      expect(importModule.enrichIndex).toHaveBeenCalledWith(mockHub, newIndex, index, webhooks);
       expect(result).toEqual(newIndex);
     });
 
@@ -237,7 +237,7 @@ describe('search-index import command', (): void => {
       ).rejects.toThrowErrorMatchingSnapshot();
 
       expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ ...indexBase, assignedContentTypes }));
-      expect(importModule.enrichIndex).toHaveBeenCalledWith(newIndex, index, webhooks);
+      expect(importModule.enrichIndex).toHaveBeenCalledWith(mockHub, newIndex, index, webhooks);
       expect(log.getData('CREATE')).toEqual([]);
     });
   });
@@ -251,7 +251,10 @@ describe('search-index import command', (): void => {
     }
 
     it('should fetch settings, content types for comparison with the index to be enriched', async () => {
+      const mockHub = new Hub();
+
       const index = new SearchIndex({
+        id: 'id-1',
         name: 'index-1',
         label: 'index-1'
       });
@@ -266,17 +269,24 @@ describe('search-index import command', (): void => {
       index.related.assignedContentTypes.list = jest.fn().mockResolvedValue(new MockPage(AssignedContentType, []));
       index.related.assignedContentTypes.create = jest.fn();
 
-      await enrichIndex(index, enrichedIndex, undefined);
+      mockHub.related.searchIndexes.get = jest.fn().mockResolvedValue(index);
+
+      await enrichIndex(mockHub, index, enrichedIndex, undefined);
 
       expect(enrichedIndex.settings.replicas).toEqual([]);
       expect(index.related.settings.get).toHaveBeenCalled();
       expect(index.related.settings.update).toHaveBeenCalledWith(enrichedIndex.settings, false);
       expect(index.related.assignedContentTypes.list).toHaveBeenCalled();
       expect(index.related.assignedContentTypes.create).not.toHaveBeenCalled();
+
+      expect(mockHub.related.searchIndexes.get).toHaveBeenCalledWith('id-1');
     });
 
     it("should update settings with a union of both source and destination replicas, then update each replica's settings", async () => {
+      const mockHub = new Hub();
+
       const index = new SearchIndex({
+        id: 'id-1',
         name: 'index-1',
         label: 'index-1'
       });
@@ -314,7 +324,9 @@ describe('search-index import command', (): void => {
       index.related.assignedContentTypes.list = jest.fn().mockResolvedValue(new MockPage(AssignedContentType, []));
       index.related.assignedContentTypes.create = jest.fn();
 
-      await enrichIndex(index, enrichedIndex, undefined);
+      mockHub.related.searchIndexes.get = jest.fn().mockResolvedValue(index);
+
+      await enrichIndex(mockHub, index, enrichedIndex, undefined);
 
       expect(enrichedIndex.settings.replicas).toEqual(expect.arrayContaining(['replica-1', 'replica-2', 'replica-3']));
       expect(enrichedIndex.settings.replicas.length).toEqual(3);
@@ -329,10 +341,15 @@ describe('search-index import command', (): void => {
 
       expect(index.related.assignedContentTypes.list).toHaveBeenCalled();
       expect(index.related.assignedContentTypes.create).not.toHaveBeenCalled();
+
+      expect(mockHub.related.searchIndexes.get).toHaveBeenCalledWith('id-1');
     });
 
     it('should assign any content types that are not yet assigned on the destination index, removing any that are no longer present', async () => {
+      const mockHub = new Hub();
+
       const index = new SearchIndex({
+        id: 'id-1',
         name: 'index-1',
         label: 'index-1'
       });
@@ -365,7 +382,9 @@ describe('search-index import command', (): void => {
         return type;
       });
 
-      await enrichIndex(index, enrichedIndex, undefined);
+      mockHub.related.searchIndexes.get = jest.fn().mockResolvedValue(index);
+
+      await enrichIndex(mockHub, index, enrichedIndex, undefined);
 
       expect(created).toEqual([enrichedIndex.assignedContentTypes[0]]);
 
@@ -377,10 +396,15 @@ describe('search-index import command', (): void => {
       expect(index.related.settings.get).toHaveBeenCalled();
       expect(index.related.settings.update).toHaveBeenCalledWith(enrichedIndex.settings, false);
       expect(index.related.assignedContentTypes.list).toHaveBeenCalled();
+
+      expect(mockHub.related.searchIndexes.get).toHaveBeenCalledWith('id-1');
     });
 
     it('should update webhooks for the destination index when they are available', async () => {
+      const mockHub = new Hub();
+
       const index = new SearchIndex({
+        id: 'id-1',
         name: 'index-1',
         label: 'index-1'
       });
@@ -411,7 +435,9 @@ describe('search-index import command', (): void => {
       index.related.assignedContentTypes.list = jest.fn().mockResolvedValue(new MockPage(AssignedContentType, [type]));
       index.related.assignedContentTypes.create = jest.fn();
 
-      await enrichIndex(index, enrichedIndex, enrichedWebhooks);
+      mockHub.related.searchIndexes.get = jest.fn().mockResolvedValue(index);
+
+      await enrichIndex(mockHub, index, enrichedIndex, enrichedWebhooks);
 
       expect(type.related.unassign).not.toHaveBeenCalled();
       expect(index.related.assignedContentTypes.create).not.toHaveBeenCalled();
@@ -438,6 +464,8 @@ describe('search-index import command', (): void => {
       expect(index.related.settings.get).toHaveBeenCalled();
       expect(index.related.settings.update).toHaveBeenCalledWith(enrichedIndex.settings, false);
       expect(index.related.assignedContentTypes.list).toHaveBeenCalled();
+
+      expect(mockHub.related.searchIndexes.get).toHaveBeenCalledWith('id-1');
     });
   });
 
@@ -487,7 +515,7 @@ describe('search-index import command', (): void => {
       `);
       expect(hub.related.searchIndexes.get).toHaveBeenCalledWith('stored-id');
       expect(exportModule.enrichIndex).toHaveBeenCalledWith(expect.any(Map), replicas, storedIndex);
-      expect(importModule.enrichIndex).toHaveBeenCalledWith(updatedIndex, mutatedIndex, webhooks);
+      expect(importModule.enrichIndex).toHaveBeenCalledWith(hub, updatedIndex, mutatedIndex, webhooks);
       expect(result).toEqual({ index: updatedIndex, updateStatus: UpdateStatus.UPDATED });
       expect(mockUpdate.mock.calls[0][0].toJSON()).toEqual(expectedIndex.toJSON());
     });

--- a/src/commands/search-index/import.ts
+++ b/src/commands/search-index/import.ts
@@ -89,7 +89,14 @@ export const rewriteIndexNames = (
     [filename: string]: EnrichedSearchIndex;
   }
 ): void | never => {
+  const toRewrite: SearchIndex[] = [...Object.values(importedIndexes)];
   for (const index of Object.values(importedIndexes)) {
+    if (index.replicas) {
+      toRewrite.push(...index.replicas);
+    }
+  }
+
+  for (const index of toRewrite) {
     const name = index.name as string;
     const firstDot = name.indexOf('.');
 


### PR DESCRIPTION
Replica names were not being rewritten when importing into a new hub. This PR should fix that issue.