### PR TITLE
fix: allow empty import without error, fix search index export on accounts where it is disabled

### DIFF
--- a/src/commands/content-type/__snapshots__/import.spec.ts.snap
+++ b/src/commands/content-type/__snapshots__/import.spec.ts.snap
@@ -12,8 +12,6 @@ exports[`content-type import command doUpdate should throw an error when unable 
 
 exports[`content-type import command doUpdate should throw an error when unable to update content type during update if a string error is returned by sdk 1`] = `"Error updating content type stored-id: The update action is not available, ensure you have permission to perform this action."`;
 
-exports[`content-type import command handler tests should throw an error when no content found in import directory 1`] = `"No content types found in my-empty-dir"`;
-
 exports[`content-type import command validateNoDuplicateContentTypeUris should throw and error when there are duplicate uris 1`] = `
 "Content Types must have unique uri values. Duplicate values found:-
   uri: 'type-uri-1' in files: ['file-1', 'file-4']

--- a/src/commands/content-type/import.spec.ts
+++ b/src/commands/content-type/import.spec.ts
@@ -927,12 +927,22 @@ describe('content-type import command', (): void => {
       );
     });
 
-    it('should throw an error when no content found in import directory', async (): Promise<void> => {
+    it('should exit early when no content found in import directory', async (): Promise<void> => {
       const argv = { ...yargArgs, ...config, dir: 'my-empty-dir', sync: false, logFile: new FileLog() };
 
       (loadJsonFromDirectory as jest.Mock).mockReturnValue([]);
 
-      await expect(handler(argv)).rejects.toThrowErrorMatchingSnapshot();
+      await handler(argv);
+
+      expect(argv.logFile.closed).toBeTruthy();
+      expect(argv.logFile.accessGroup).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "comment": true,
+    "data": "No content types found in my-empty-dir",
+  },
+]
+`);
     });
   });
 });

--- a/src/commands/content-type/import.ts
+++ b/src/commands/content-type/import.ts
@@ -320,12 +320,15 @@ export const handler = async (
   idFilter?: string[]
 ): Promise<void> => {
   const { dir, sync, logFile, skipAssign } = argv;
+  const log = logFile.open();
   const importedContentTypes = loadJsonFromDirectory<ContentTypeWithRepositoryAssignments>(
     dir,
     ContentTypeWithRepositoryAssignments
   );
   if (Object.keys(importedContentTypes).length === 0) {
-    throw new Error(`No content types found in ${dir}`);
+    log.appendLine(`No content types found in ${dir}`);
+    await log.close();
+    return;
   }
   validateNoDuplicateContentTypeUris(importedContentTypes);
 
@@ -335,7 +338,6 @@ export const handler = async (
 
   const client = dynamicContentClientFactory(argv);
   const hub = await client.hubs.get(argv.hubId);
-  const log = logFile.open();
 
   const activeContentTypes = await paginator(hub.related.contentTypes.list, { status: Status.ACTIVE });
   const archivedContentTypes = await paginator(hub.related.contentTypes.list, { status: Status.ARCHIVED });

--- a/src/commands/extension/__snapshots__/import.spec.ts.snap
+++ b/src/commands/extension/__snapshots__/import.spec.ts.snap
@@ -18,8 +18,6 @@ exports[`extension import command doUpdate should throw an error when unable to 
 
 exports[`extension import command doUpdate should throw an error when unable to update extension during update if a string error is returned by sdk 1`] = `"Error updating extension not-matched-name: undefined"`;
 
-exports[`extension import command handler tests should throw an error when no content found in import directory 1`] = `"No extensions found in my-empty-dir"`;
-
 exports[`extension import command validateNoDuplicateExtensionNames should throw and error when there are duplicate uris 1`] = `
 "Extensions must have unique name values. Duplicate values found:-
   name: 'extension-name-1' in files: ['file-1', 'file-4']

--- a/src/commands/extension/import.spec.ts
+++ b/src/commands/extension/import.spec.ts
@@ -499,12 +499,22 @@ describe('extension import command', (): void => {
       );
     });
 
-    it('should throw an error when no content found in import directory', async (): Promise<void> => {
+    it('should exit early when no content found in import directory', async (): Promise<void> => {
       const argv = { ...yargArgs, ...config, dir: 'my-empty-dir', logFile: new FileLog() };
 
       (loadJsonFromDirectory as jest.Mock).mockReturnValue([]);
 
-      await expect(handler(argv)).rejects.toThrowErrorMatchingSnapshot();
+      await handler(argv);
+
+      expect(argv.logFile.closed).toBeTruthy();
+      expect(argv.logFile.accessGroup).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "comment": true,
+    "data": "No extensions found in my-empty-dir",
+  },
+]
+`);
     });
   });
 });

--- a/src/commands/extension/import.ts
+++ b/src/commands/extension/import.ts
@@ -157,7 +157,9 @@ export const handler = async (
   const log = logFile.open();
   const extensions = loadJsonFromDirectory<Extension>(dir, Extension);
   if (Object.keys(extensions).length === 0) {
-    throw new Error(`No extensions found in ${dir}`);
+    log.appendLine(`No extensions found in ${dir}`);
+    await log.close();
+    return;
   }
 
   validateNoDuplicateExtensionNames(extensions);

--- a/src/commands/search-index/__snapshots__/import.spec.ts.snap
+++ b/src/commands/search-index/__snapshots__/import.spec.ts.snap
@@ -12,8 +12,6 @@ exports[`search-index import command doUpdate should throw an error when unable 
 
 exports[`search-index import command doUpdate should throw an error when unable to update index during update if a string error is returned by sdk 1`] = `"Error updating index not-matched-name: The update action is not available, ensure you have permission to perform this action."`;
 
-exports[`search-index import command handler tests should throw an error when no content found in import directory 1`] = `"No indexes found in my-empty-dir"`;
-
 exports[`search-index import command validateNoDuplicateIndexNames should throw and error when there are duplicate uris 1`] = `
 "Indexes must have unique name values. Duplicate values found:-
   name: 'index-name-1' in files: ['file-1', 'file-4']

--- a/src/commands/search-index/export.ts
+++ b/src/commands/search-index/export.ts
@@ -440,7 +440,15 @@ export const handler = async (argv: Arguments<ExportBuilderOptions & Configurati
   const previouslyExportedIndexes = loadJsonFromDirectory<EnrichedSearchIndex>(dir, EnrichedSearchIndex);
   validateNoDuplicateIndexNames(previouslyExportedIndexes);
 
-  const allStoredIndexes = await paginator(searchIndexList(hub));
+  let allStoredIndexes: SearchIndex[];
+  try {
+    allStoredIndexes = await paginator(searchIndexList(hub));
+  } catch (e) {
+    log.warn('Could not get Search Indexes for the given hub - they may be disabled.', e);
+    await log.close();
+    return;
+  }
+
   const { storedIndexes, allReplicas } = separateReplicas(allStoredIndexes);
 
   const idArray: string[] = id ? (Array.isArray(id) ? id : [id]) : [];

--- a/src/commands/search-index/import.spec.ts
+++ b/src/commands/search-index/import.spec.ts
@@ -1110,12 +1110,22 @@ describe('search-index import command', (): void => {
       );
     });
 
-    it('should throw an error when no content found in import directory', async (): Promise<void> => {
+    it('should exit early when no content found in import directory', async (): Promise<void> => {
       const argv = { ...yargArgs, ...config, dir: 'my-empty-dir', logFile: new FileLog() };
 
       (loadJsonFromDirectory as jest.Mock).mockReturnValue([]);
 
-      await expect(handler(argv)).rejects.toThrowErrorMatchingSnapshot();
+      await handler(argv);
+
+      expect(argv.logFile.closed).toBeTruthy();
+      expect(argv.logFile.accessGroup).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "comment": true,
+    "data": "No search indexes found in my-empty-dir",
+  },
+]
+`);
     });
   });
 });

--- a/src/commands/search-index/import.ts
+++ b/src/commands/search-index/import.ts
@@ -353,7 +353,9 @@ export const handler = async (
   const log = logFile.open();
   const indexes = loadJsonFromDirectory<EnrichedSearchIndex>(dir, EnrichedSearchIndex);
   if (Object.keys(indexes).length === 0) {
-    throw new Error(`No indexes found in ${dir}`);
+    log.appendLine(`No search indexes found in ${dir}`);
+    await log.close();
+    return;
   }
 
   validateNoDuplicateIndexNames(indexes);


### PR DESCRIPTION
This PR fixes an issue where empty import on certain commands would cause the command to error out, which would interrupt the clone command despite the import technically succeeding (as it didn't have to do anything).

This also fixes an issue where search index list would throw an exception if it is disabled on the target account. In this case, the export is now simply skipped.