### PR TITLE
fix(event): fix event slots list pagination

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3378,8 +3378,8 @@
       "dev": true
     },
     "dc-management-sdk-js": {
-      "version": "git+ssh://git@github.com/rs-amp/dc-management-sdk-js.git#76f4202b91b264aee648de2e5518134ae5631297",
-      "from": "git+ssh://git@github.com/rs-amp/dc-management-sdk-js.git#fix/edition-slot-list",
+      "version": "git+https://github.com/rs-amp/dc-management-sdk-js.git#76f4202b91b264aee648de2e5518134ae5631297",
+      "from": "git+https://github.com/rs-amp/dc-management-sdk-js.git#fix/edition-slot-list",
       "requires": {
         "axios": "^0.21.1",
         "url-template": "^2.0.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3378,8 +3378,9 @@
       "dev": true
     },
     "dc-management-sdk-js": {
-      "version": "git+https://github.com/rs-amp/dc-management-sdk-js.git#76f4202b91b264aee648de2e5518134ae5631297",
-      "from": "git+https://github.com/rs-amp/dc-management-sdk-js.git#fix/edition-slot-list",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/dc-management-sdk-js/-/dc-management-sdk-js-1.17.1.tgz",
+      "integrity": "sha512-k8xxZoMHGt36xtmhujisGAMvFZ91ddqJ/AXcv4Mjv7eZy6dSpWmI8IIBS8GblA920GCApaQuxky3xUYKJFR6yg==",
       "requires": {
         "axios": "^0.21.1",
         "url-template": "^2.0.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3378,9 +3378,8 @@
       "dev": true
     },
     "dc-management-sdk-js": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/dc-management-sdk-js/-/dc-management-sdk-js-1.17.0.tgz",
-      "integrity": "sha512-nY7YobFSCHCQrl0+6Q7/1xqsGDRaCrsm4FRW5iOSkeJJHSOSv9M28mmKQI7DaE4tMIx+//KdJFSucdshwjjEQg==",
+      "version": "git+ssh://git@github.com/rs-amp/dc-management-sdk-js.git#76f4202b91b264aee648de2e5518134ae5631297",
+      "from": "git+ssh://git@github.com/rs-amp/dc-management-sdk-js.git#fix/edition-slot-list",
       "requires": {
         "axios": "^0.21.1",
         "url-template": "^2.0.8"

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "ajv": "^6.12.3",
     "axios": "^0.21.1",
     "chalk": "^2.4.2",
-    "dc-management-sdk-js": "git+https://github.com/rs-amp/dc-management-sdk-js.git#fix/edition-slot-list",
+    "dc-management-sdk-js": "^1.17.1",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.1",
     "promise-retry": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "ajv": "^6.12.3",
     "axios": "^0.21.1",
     "chalk": "^2.4.2",
-    "dc-management-sdk-js": "git+ssh://git@github.com/rs-amp/dc-management-sdk-js.git#fix/edition-slot-list",
+    "dc-management-sdk-js": "git+https://github.com/rs-amp/dc-management-sdk-js.git#fix/edition-slot-list",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.1",
     "promise-retry": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "ajv": "^6.12.3",
     "axios": "^0.21.1",
     "chalk": "^2.4.2",
-    "dc-management-sdk-js": "^1.17.0",
+    "dc-management-sdk-js": "git+ssh://git@github.com/rs-amp/dc-management-sdk-js.git#fix/edition-slot-list",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.1",
     "promise-retry": "^2.0.1",


### PR DESCRIPTION
Fixes two issues with the `dc-management-sdk-js` that were causing events with more than 20 slots to make the same request infinitely, as when requesting pages after the 0th it would just get page 0 back. There was no way to get anything after the first 20 slots.