### PR TITLE
feat(search-index): add retry for search index create and settings update

### DIFF
--- a/src/commands/search-index/__snapshots__/import.spec.ts.snap
+++ b/src/commands/search-index/__snapshots__/import.spec.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`search-index import command doCreate should error if the index never appears after a 504 1`] = `"Error creating index index-name: Error: waitOnTimeout"`;
+
 exports[`search-index import command doCreate should throw an error when enrichIndex fails 1`] = `"Error creating index index-name: The update-index action is not available, ensure you have permission to perform this action."`;
 
 exports[`search-index import command doCreate should throw an error when index create fails 1`] = `"Error creating index index-name: Error: Error creating index"`;

--- a/src/common/content-item/__mocks__/retry-helpers.ts
+++ b/src/common/content-item/__mocks__/retry-helpers.ts
@@ -1,0 +1,27 @@
+import { FileLog } from '../../file-log';
+
+let testCheck = false;
+
+export const setTestCheck = (value: boolean): void => {
+  testCheck = value;
+};
+
+export const waitOnTimeout = async (
+  log: FileLog,
+  request: () => Promise<unknown>,
+  finishedCheck: () => Promise<boolean>
+): Promise<void> => {
+  if (testCheck) {
+    try {
+      await request();
+    } catch {}
+  } else {
+    await request();
+  }
+
+  if (testCheck) {
+    if (!(await finishedCheck())) {
+      throw new Error('waitOnTimeout');
+    }
+  }
+};

--- a/src/common/content-item/retry-helpers.spec.ts
+++ b/src/common/content-item/retry-helpers.spec.ts
@@ -1,0 +1,159 @@
+import { HttpError } from 'dc-management-sdk-js';
+import { FileLog } from '../file-log';
+import { waitOnTimeout } from './retry-helpers';
+import * as retryHelpers from './retry-helpers';
+
+describe('retry-helpers', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const error504 = new HttpError('Error', undefined, { status: 504 } as any);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const error502 = new HttpError('Error', undefined, { status: 502 } as any);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.spyOn(retryHelpers, 'delay').mockResolvedValue();
+  });
+
+  describe('waitOnTimeout', () => {
+    it('should not call check method when the initial request succeeds', async () => {
+      const log = new FileLog();
+      const request = jest.fn();
+      request.mockResolvedValue(null);
+      const finishedCheck = jest.fn();
+      finishedCheck.mockResolvedValue(null);
+
+      await waitOnTimeout(log, request, finishedCheck);
+
+      expect(request).toHaveBeenCalled();
+      expect(finishedCheck).not.toHaveBeenCalled();
+      expect(log.accessGroup.length).toBe(0);
+      expect(retryHelpers.delay).not.toHaveBeenCalled();
+    });
+
+    it('should call check method when the initial request fails with a 504, repeatedly until it returns true', async () => {
+      const log = new FileLog();
+      const request = jest.fn();
+      request.mockRejectedValue(error504);
+      const finishedCheck = jest.fn();
+      finishedCheck.mockResolvedValueOnce(false);
+      finishedCheck.mockResolvedValueOnce(false);
+      finishedCheck.mockResolvedValueOnce(true);
+
+      await waitOnTimeout(log, request, finishedCheck);
+
+      expect(request).toHaveBeenCalled();
+      expect(finishedCheck).toHaveBeenCalledTimes(3);
+      expect(log.accessGroup.length).toBe(3);
+      expect(retryHelpers.delay).toHaveBeenCalledTimes(3);
+    });
+
+    it('should call check method when the initial request fails with a 504, error when the check fails', async () => {
+      const log = new FileLog();
+      const request = jest.fn();
+      request.mockRejectedValue(error504);
+      const finishedCheck = jest.fn();
+      finishedCheck.mockResolvedValue(false);
+
+      await expect(waitOnTimeout(log, request, finishedCheck, true, 10)).rejects.toThrowError(error504);
+
+      expect(request).toHaveBeenCalled();
+      expect(finishedCheck).toHaveBeenCalledTimes(10);
+      expect(log.accessGroup.length).toBe(11);
+      expect(retryHelpers.delay).toHaveBeenCalledTimes(10);
+    });
+
+    it('should error and not call check method when the initial request fails with an error that has no response', async () => {
+      const log = new FileLog();
+      const request = jest.fn();
+      request.mockRejectedValue(error504);
+      const finishedCheck = jest.fn();
+      finishedCheck.mockResolvedValue(false);
+
+      // Still throws even if throwErrors is false.
+      await expect(waitOnTimeout(log, request, finishedCheck, false, 10)).rejects.toThrowError(error504);
+
+      expect(request).toHaveBeenCalled();
+      expect(finishedCheck).toHaveBeenCalledTimes(10);
+      expect(log.accessGroup.length).toBe(11);
+      expect(retryHelpers.delay).toHaveBeenCalledTimes(10);
+    });
+
+    it('should error and not call check method when the initial request fails with a non-504 error', async () => {
+      const log = new FileLog();
+      const request = jest.fn();
+      request.mockRejectedValue(error502);
+      const finishedCheck = jest.fn();
+
+      await expect(waitOnTimeout(log, request, finishedCheck)).rejects.toThrowError(error502);
+
+      expect(request).toHaveBeenCalled();
+      expect(finishedCheck).not.toHaveBeenCalled();
+      expect(log.accessGroup.length).toBe(0);
+      expect(retryHelpers.delay).not.toHaveBeenCalled();
+    });
+
+    it('should call check method when the initial request fails with a non-504 when throwErrors argument is false', async () => {
+      const log = new FileLog();
+      const request = jest.fn();
+      request.mockRejectedValue(error502);
+      const finishedCheck = jest.fn();
+      finishedCheck.mockResolvedValueOnce(false);
+      finishedCheck.mockResolvedValueOnce(false);
+      finishedCheck.mockResolvedValueOnce(true);
+
+      await waitOnTimeout(log, request, finishedCheck, false);
+
+      expect(request).toHaveBeenCalled();
+      expect(finishedCheck).toHaveBeenCalledTimes(3);
+      expect(log.accessGroup.length).toBe(3);
+      expect(retryHelpers.delay).toHaveBeenCalledTimes(3);
+    });
+
+    it('should ignore errors when calling the check method', async () => {
+      const log = new FileLog();
+      const request = jest.fn();
+      request.mockRejectedValue(error504);
+      const finishedCheck = jest.fn();
+      finishedCheck.mockRejectedValueOnce(error502);
+      finishedCheck.mockRejectedValueOnce(new Error('Generic Error'));
+      finishedCheck.mockResolvedValueOnce(true);
+
+      await waitOnTimeout(log, request, finishedCheck, false);
+
+      expect(request).toHaveBeenCalled();
+      expect(finishedCheck).toHaveBeenCalledTimes(3);
+      expect(log.accessGroup.length).toBe(5);
+      expect(retryHelpers.delay).toHaveBeenCalledTimes(3);
+    });
+
+    it('should rethrow the last error when calling the check method and it errors', async () => {
+      const log = new FileLog();
+      const request = jest.fn();
+      request.mockRejectedValue(error504);
+      const finishedCheck = jest.fn();
+      finishedCheck.mockRejectedValueOnce(error502);
+
+      await expect(waitOnTimeout(log, request, finishedCheck, false, 1)).rejects.toThrowError(error502);
+
+      expect(request).toHaveBeenCalled();
+      expect(finishedCheck).toHaveBeenCalledTimes(1);
+      expect(log.accessGroup.length).toBe(1);
+      expect(retryHelpers.delay).toHaveBeenCalledTimes(1);
+    });
+
+    it('should rethrow the initial error when calling the check method and it returns false every time', async () => {
+      const log = new FileLog();
+      const request = jest.fn();
+      request.mockRejectedValue(error504);
+      const finishedCheck = jest.fn();
+      finishedCheck.mockResolvedValue(false);
+
+      await expect(waitOnTimeout(log, request, finishedCheck, false, 1)).rejects.toThrowError(error504);
+
+      expect(request).toHaveBeenCalled();
+      expect(finishedCheck).toHaveBeenCalledTimes(1);
+      expect(log.accessGroup.length).toBe(2);
+      expect(retryHelpers.delay).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/common/content-item/retry-helpers.ts
+++ b/src/common/content-item/retry-helpers.ts
@@ -1,0 +1,54 @@
+import { HttpError } from 'dc-management-sdk-js';
+import { FileLog } from '../file-log';
+
+export const delay = (duration: number): Promise<void> => {
+  return new Promise<void>((resolve): void => {
+    setTimeout(resolve, duration);
+  });
+};
+
+export const waitOnTimeout = async (
+  log: FileLog,
+  request: () => Promise<unknown>,
+  finishedCheck: () => Promise<boolean>,
+  throwErrors = true,
+  retries = 30
+): Promise<void> => {
+  try {
+    await request();
+  } catch (error) {
+    // If the HTTP error indicates a timeout, loop on the finished check until true, or the retry count is reached.
+
+    const httpError = error as HttpError;
+
+    // If the error doesn't have a response and the status is not 504, rethrow the exception.
+    if (httpError.response == null || (throwErrors && httpError.response.status != 504)) {
+      throw error;
+    }
+
+    // The error was a timeout. Periodically run the finished check to determine if the operation has completed.
+    for (let i = 0; i < retries; i++) {
+      try {
+        log.appendLine(`Retrying... ${i + 1}/${retries}`);
+
+        await delay(1000);
+
+        if (await finishedCheck()) {
+          break;
+        }
+      } catch (error) {
+        // Retry failed, somehow.
+        if (retries === i + 1) {
+          throw error;
+        } else {
+          log.appendLine(`Retry failed. Continuing...`);
+        }
+      }
+
+      if (retries === i + 1) {
+        log.appendLine(`Out of retries. Throwing the original error.`);
+        throw httpError;
+      }
+    }
+  }
+};


### PR DESCRIPTION
This PR adds a method that allows requests that create or modify resources and are guaranteed to go through to wait for their results to come through if the initial request is to time out.

This method has been added to:
- search index create - Creating indexes can be slow, but if you make the request you can guarantee the index will be created.
- search index settings update: It can create replicas, this can be slow for a similar reason.

This hasn't been heavily tested since it can be hard to trigger. Will be going though QA to verify.