### PR TITLE
feat: concurrent publish queue with --batchPublish option

### DIFF
--- a/docs/CONTENT-ITEM.md
+++ b/docs/CONTENT-ITEM.md
@@ -164,6 +164,7 @@ dc-cli content-item import <dir>
 | -v<br />--validate | [boolean]                                  | Only recreate folder structure - content is validated but not imported. |
 | --skipIncomplete   | [boolean]                                  | Skip any content items that has one or more missing dependancy. |
 | --publish          | [boolean]                                  | Publish any content items that have an existing publish status in their JSON. |
+| --batchPublish     | [boolean]                                  | Batch publish requests up to the rate limit. (100/min) |
 | --republish        | [boolean]                                  | Republish content items regardless of whether the import changed them or not.<br />(--publish not required) |
 | --excludeKeys      | [boolean]                                  | Exclude delivery keys when importing content items.          |
 | --media            | [boolean]                                  | Detect and rewrite media links to match assets in the target account's Content Hub. Your client must have Content Hub permissions configured. |
@@ -212,6 +213,7 @@ dc-cli content-item copy <dir>
 | --skipIncomplete   | [boolean]                                  | Skip any content item that has one or more missing dependancy. |
 | --lastPublish      | [boolean]                                  | When available, export the last published version of a content item rather than its newest version. |
 | --publish          | [boolean]                                  | Publish any content items that have an existing publish status in their JSON. |
+| --batchPublish     | [boolean]                                  | Batch publish requests up to the rate limit. (100/min) |
 | --republish        | [boolean]                                  | Republish content items regardless of whether the import changed them or not.<br />(--publish not required) |
 | --excludeKeys      | [boolean]                                  | Exclude delivery keys when importing content items.          |
 | --media            | [boolean]                                  | Detect and rewrite media links to match assets in the target account's DAM.<br />Your client must have DAM permissions configured. |
@@ -260,6 +262,7 @@ dc-cli content-item move <dir>
 | --skipIncomplete   | [boolean]                                  | Skip any content item that has one or more missing dependancy. |
 | --lastPublish      | [boolean]                                  | When available, export the last published version of a content item rather than its newest version. |
 | --publish          | [boolean]                                  | Publish any content items that have an existing publish status in their JSON. |
+| --batchPublish     | [boolean]                                  | Batch publish requests up to the rate limit. (100/min) |
 | --republish        | [boolean]                                  | Republish content items regardless of whether the import changed them or not.<br />(--publish not required) |
 | --excludeKeys      | [boolean]                                  | Exclude delivery keys when importing content items.          |
 | --media            | [boolean]                                  | Detect and rewrite media links to match assets in the target account's DAM.<br />Your client must have DAM permissions configured. |

--- a/docs/CONTENT-ITEM.md
+++ b/docs/CONTENT-ITEM.md
@@ -164,7 +164,7 @@ dc-cli content-item import <dir>
 | -v<br />--validate | [boolean]                                  | Only recreate folder structure - content is validated but not imported. |
 | --skipIncomplete   | [boolean]                                  | Skip any content items that has one or more missing dependancy. |
 | --publish          | [boolean]                                  | Publish any content items that have an existing publish status in their JSON. |
-| --batchPublish     | [boolean]                                  | Batch publish requests up to the rate limit. (100/min) |
+| --batchPublish     | [boolean]                                  | Batch publish requests up to the rate limit. (35/min) |
 | --republish        | [boolean]                                  | Republish content items regardless of whether the import changed them or not.<br />(--publish not required) |
 | --excludeKeys      | [boolean]                                  | Exclude delivery keys when importing content items.          |
 | --media            | [boolean]                                  | Detect and rewrite media links to match assets in the target account's Content Hub. Your client must have Content Hub permissions configured. |
@@ -213,7 +213,7 @@ dc-cli content-item copy <dir>
 | --skipIncomplete   | [boolean]                                  | Skip any content item that has one or more missing dependancy. |
 | --lastPublish      | [boolean]                                  | When available, export the last published version of a content item rather than its newest version. |
 | --publish          | [boolean]                                  | Publish any content items that have an existing publish status in their JSON. |
-| --batchPublish     | [boolean]                                  | Batch publish requests up to the rate limit. (100/min) |
+| --batchPublish     | [boolean]                                  | Batch publish requests up to the rate limit. (35/min) |
 | --republish        | [boolean]                                  | Republish content items regardless of whether the import changed them or not.<br />(--publish not required) |
 | --excludeKeys      | [boolean]                                  | Exclude delivery keys when importing content items.          |
 | --media            | [boolean]                                  | Detect and rewrite media links to match assets in the target account's DAM.<br />Your client must have DAM permissions configured. |
@@ -262,7 +262,7 @@ dc-cli content-item move <dir>
 | --skipIncomplete   | [boolean]                                  | Skip any content item that has one or more missing dependancy. |
 | --lastPublish      | [boolean]                                  | When available, export the last published version of a content item rather than its newest version. |
 | --publish          | [boolean]                                  | Publish any content items that have an existing publish status in their JSON. |
-| --batchPublish     | [boolean]                                  | Batch publish requests up to the rate limit. (100/min) |
+| --batchPublish     | [boolean]                                  | Batch publish requests up to the rate limit. (35/min) |
 | --republish        | [boolean]                                  | Republish content items regardless of whether the import changed them or not.<br />(--publish not required) |
 | --excludeKeys      | [boolean]                                  | Exclude delivery keys when importing content items.          |
 | --media            | [boolean]                                  | Detect and rewrite media links to match assets in the target account's DAM.<br />Your client must have DAM permissions configured. |

--- a/docs/HUB.md
+++ b/docs/HUB.md
@@ -103,6 +103,7 @@ dc-cli hub clone <dir>
 | --skipIncomplete       | [boolean]                                                    | Skip any content item that has one or more missing dependancy. |
 | --lastPublish          | [boolean]                                                    | When available, export the last published version of a content item rather than its newest version. |
 | --publish              | [boolean]                                                    | Publish any content items that have an existing publish status in their JSON. |
+| --batchPublish         | [boolean]                                                    | Batch publish requests up to the rate limit. (100/min) |
 | --republish            | [boolean]                                                    | Republish content items regardless of whether the import changed them or not.<br />(--publish not required) |
 | --excludeKeys          | [boolean]                                                    | Exclude delivery keys when importing content items.          |
 | --media                | [boolean]                                                    | Detect and rewrite media links to match assets in the target account's DAM.<br />Your client must have DAM permissions configured. |

--- a/docs/HUB.md
+++ b/docs/HUB.md
@@ -103,7 +103,7 @@ dc-cli hub clone <dir>
 | --skipIncomplete       | [boolean]                                                    | Skip any content item that has one or more missing dependancy. |
 | --lastPublish          | [boolean]                                                    | When available, export the last published version of a content item rather than its newest version. |
 | --publish              | [boolean]                                                    | Publish any content items that have an existing publish status in their JSON. |
-| --batchPublish         | [boolean]                                                    | Batch publish requests up to the rate limit. (100/min) |
+| --batchPublish         | [boolean]                                                    | Batch publish requests up to the rate limit. (35/min) |
 | --republish            | [boolean]                                                    | Republish content items regardless of whether the import changed them or not.<br />(--publish not required) |
 | --excludeKeys          | [boolean]                                                    | Exclude delivery keys when importing content items.          |
 | --media                | [boolean]                                                    | Detect and rewrite media links to match assets in the target account's DAM.<br />Your client must have DAM permissions configured. |

--- a/src/commands/content-item/copy.spec.ts
+++ b/src/commands/content-item/copy.spec.ts
@@ -141,7 +141,7 @@ describe('content-item copy command', () => {
       expect(spyOption).toHaveBeenCalledWith('batchPublish', {
         type: 'boolean',
         boolean: true,
-        describe: 'Batch publish requests up to the rate limit. (100/min)'
+        describe: 'Batch publish requests up to the rate limit. (35/min)'
       });
 
       expect(spyOption).toHaveBeenCalledWith('republish', {

--- a/src/commands/content-item/copy.spec.ts
+++ b/src/commands/content-item/copy.spec.ts
@@ -138,6 +138,12 @@ describe('content-item copy command', () => {
           'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
       });
 
+      expect(spyOption).toHaveBeenCalledWith('batchPublish', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'Batch publish requests up to the rate limit. (100/min)'
+      });
+
       expect(spyOption).toHaveBeenCalledWith('republish', {
         type: 'boolean',
         boolean: true,
@@ -247,6 +253,7 @@ describe('content-item copy command', () => {
 
         lastPublish: true,
         publish: true,
+        batchPublish: true,
         republish: true,
 
         excludeKeys: true,
@@ -275,6 +282,7 @@ describe('content-item copy command', () => {
       expect(importCalls[0].skipIncomplete).toEqual(argv.skipIncomplete);
 
       expect(importCalls[0].publish).toEqual(argv.publish);
+      expect(importCalls[0].batchPublish).toEqual(argv.batchPublish);
       expect(importCalls[0].republish).toEqual(argv.republish);
 
       expect(importCalls[0].excludeKeys).toEqual(argv.excludeKeys);

--- a/src/commands/content-item/copy.ts
+++ b/src/commands/content-item/copy.ts
@@ -118,6 +118,12 @@ export const builder = (yargs: Argv): void => {
         'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
     })
 
+    .option('batchPublish', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'Batch publish requests up to the rate limit. (100/min)'
+    })
+
     .option('republish', {
       type: 'boolean',
       boolean: true,
@@ -242,6 +248,7 @@ export const handler = async (argv: Arguments<CopyItemBuilderOptions & Configura
 
         republish: argv.republish,
         publish: argv.publish,
+        batchPublish: argv.batchPublish,
 
         excludeKeys: argv.excludeKeys,
 

--- a/src/commands/content-item/copy.ts
+++ b/src/commands/content-item/copy.ts
@@ -121,7 +121,7 @@ export const builder = (yargs: Argv): void => {
     .option('batchPublish', {
       type: 'boolean',
       boolean: true,
-      describe: 'Batch publish requests up to the rate limit. (100/min)'
+      describe: 'Batch publish requests up to the rate limit. (35/min)'
     })
 
     .option('republish', {

--- a/src/commands/content-item/import.spec.ts
+++ b/src/commands/content-item/import.spec.ts
@@ -111,6 +111,12 @@ describe('content-item import command', () => {
           'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
       });
 
+      expect(spyOption).toHaveBeenCalledWith('batchPublish', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'Batch publish requests up to the rate limit. (100/min)'
+      });
+
       expect(spyOption).toHaveBeenCalledWith('republish', {
         type: 'boolean',
         boolean: true,
@@ -1146,7 +1152,8 @@ describe('content-item import command', () => {
         dir: `temp_${process.env.JEST_WORKER_ID}/import/publish/`,
         mapFile: `temp_${process.env.JEST_WORKER_ID}/import/publish.json`,
         baseRepo: 'targetRepo',
-        publish: true
+        publish: true,
+        batchPublish: true
       };
       await handler(argv);
 
@@ -1200,7 +1207,8 @@ describe('content-item import command', () => {
         dir: `temp_${process.env.JEST_WORKER_ID}/import/circular/`,
         mapFile: `temp_${process.env.JEST_WORKER_ID}/import/circular.json`,
         baseRepo: 'targetRepo',
-        publish: true
+        publish: true,
+        batchPublish: false
       };
       await handler(argv);
 

--- a/src/commands/content-item/import.spec.ts
+++ b/src/commands/content-item/import.spec.ts
@@ -114,7 +114,7 @@ describe('content-item import command', () => {
       expect(spyOption).toHaveBeenCalledWith('batchPublish', {
         type: 'boolean',
         boolean: true,
-        describe: 'Batch publish requests up to the rate limit. (100/min)'
+        describe: 'Batch publish requests up to the rate limit. (35/min)'
       });
 
       expect(spyOption).toHaveBeenCalledWith('republish', {

--- a/src/commands/content-item/import.ts
+++ b/src/commands/content-item/import.ts
@@ -108,7 +108,7 @@ export const builder = (yargs: Argv): void => {
     .option('batchPublish', {
       type: 'boolean',
       boolean: true,
-      describe: 'Batch publish requests up to the rate limit. (100/min)'
+      describe: 'Batch publish requests up to the rate limit. (35/min)'
     })
 
     .option('republish', {

--- a/src/commands/content-item/import.ts
+++ b/src/commands/content-item/import.ts
@@ -105,6 +105,12 @@ export const builder = (yargs: Argv): void => {
         'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
     })
 
+    .option('batchPublish', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'Batch publish requests up to the rate limit. (100/min)'
+    })
+
     .option('republish', {
       type: 'boolean',
       boolean: true,
@@ -853,6 +859,10 @@ const importTree = async (
   if (argv.publish) {
     const pubQueue = new PublishQueue(argv);
     log.appendLine(`Publishing ${publishable.length} items. (${publishChildren} children included)`);
+
+    if (!argv.batchPublish) {
+      pubQueue.maxWaiting = 1;
+    }
 
     for (let i = 0; i < publishable.length; i++) {
       const item = publishable[i].item;

--- a/src/commands/content-item/move.spec.ts
+++ b/src/commands/content-item/move.spec.ts
@@ -148,7 +148,7 @@ describe('content-item move command', () => {
       expect(spyOption).toHaveBeenCalledWith('batchPublish', {
         type: 'boolean',
         boolean: true,
-        describe: 'Batch publish requests up to the rate limit. (100/min)'
+        describe: 'Batch publish requests up to the rate limit. (35/min)'
       });
 
       expect(spyOption).toHaveBeenCalledWith('republish', {

--- a/src/commands/content-item/move.spec.ts
+++ b/src/commands/content-item/move.spec.ts
@@ -132,6 +132,32 @@ describe('content-item move command', () => {
         describe: 'Skip any content item that has one or more missing dependancy.'
       });
 
+      expect(spyOption).toHaveBeenCalledWith('lastPublish', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'When available, export the last published version of a content item rather than its newest version.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('publish', {
+        type: 'boolean',
+        boolean: true,
+        describe:
+          'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('batchPublish', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'Batch publish requests up to the rate limit. (100/min)'
+      });
+
+      expect(spyOption).toHaveBeenCalledWith('republish', {
+        type: 'boolean',
+        boolean: true,
+        describe:
+          'Republish content items regardless of whether the import changed them or not. (--publish not required)'
+      });
+
       expect(spyOption).toHaveBeenCalledWith('excludeKeys', {
         type: 'boolean',
         boolean: true,
@@ -235,6 +261,10 @@ describe('content-item move command', () => {
 
         facet: 'name:/./,schema/./',
 
+        publish: true,
+        lastPublish: true,
+        batchPublish: true,
+
         mapFile: 'map.json',
         force: false,
         validate: false,
@@ -259,6 +289,10 @@ describe('content-item move command', () => {
       expect(copyCalls[0].validate).toEqual(argv.validate);
       expect(copyCalls[0].skipIncomplete).toEqual(argv.skipIncomplete);
       expect(copyCalls[0].media).toEqual(argv.media);
+
+      expect(copyCalls[0].publish).toEqual(argv.publish);
+      expect(copyCalls[0].lastPublish).toEqual(argv.lastPublish);
+      expect(copyCalls[0].batchPublish).toEqual(argv.batchPublish);
 
       expect(argv.exportedIds).toEqual(exportIds);
 

--- a/src/commands/content-item/move.ts
+++ b/src/commands/content-item/move.ts
@@ -111,6 +111,12 @@ export const builder = (yargs: Argv): void => {
         'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
     })
 
+    .option('batchPublish', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'Batch publish requests up to the rate limit. (100/min)'
+    })
+
     .option('republish', {
       type: 'boolean',
       boolean: true,

--- a/src/commands/content-item/move.ts
+++ b/src/commands/content-item/move.ts
@@ -114,7 +114,7 @@ export const builder = (yargs: Argv): void => {
     .option('batchPublish', {
       type: 'boolean',
       boolean: true,
-      describe: 'Batch publish requests up to the rate limit. (100/min)'
+      describe: 'Batch publish requests up to the rate limit. (35/min)'
     })
 
     .option('republish', {

--- a/src/commands/hub/clone.ts
+++ b/src/commands/hub/clone.ts
@@ -123,6 +123,12 @@ export const builder = (yargs: Argv): void => {
         'Publish any content items that either made a new version on import, or were published more recently in the JSON.'
     })
 
+    .option('batchPublish', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'Batch publish requests up to the rate limit. (100/min)'
+    })
+
     .option('republish', {
       type: 'boolean',
       boolean: true,

--- a/src/commands/hub/clone.ts
+++ b/src/commands/hub/clone.ts
@@ -126,7 +126,7 @@ export const builder = (yargs: Argv): void => {
     .option('batchPublish', {
       type: 'boolean',
       boolean: true,
-      describe: 'Batch publish requests up to the rate limit. (100/min)'
+      describe: 'Batch publish requests up to the rate limit. (35/min)'
     })
 
     .option('republish', {

--- a/src/common/import/publish-queue.spec.ts
+++ b/src/common/import/publish-queue.spec.ts
@@ -1,6 +1,7 @@
 import fetch from 'node-fetch';
 import { OAuth2Client, ContentItem, AccessToken } from 'dc-management-sdk-js';
 import { PublishingJob, PublishQueue } from './publish-queue';
+import * as publishQueueModule from './publish-queue';
 
 jest.mock('node-fetch');
 jest.mock('dc-management-sdk-js/build/main/lib/oauth2/services/OAuth2Client');
@@ -34,6 +35,8 @@ describe('publish-queue', () => {
       totalRequests = 0;
       totalPolls = 0;
       authRequests = 0;
+
+      jest.spyOn(publishQueueModule, 'delay').mockResolvedValue();
     });
 
     afterEach((): void => {
@@ -372,6 +375,9 @@ describe('publish-queue', () => {
       await queue.waitForAll();
 
       expect(totalPolls).toEqual(10);
+
+      // Since we process requests instantly, the rate limit delay will be hit for each publish.
+      expect(publishQueueModule.delay).toHaveBeenCalledTimes(5);
     });
 
     it('should error publishes when waiting for a publish job exceeds the maxAttempts number', async () => {

--- a/src/common/import/publish-queue.spec.ts
+++ b/src/common/import/publish-queue.spec.ts
@@ -150,9 +150,10 @@ describe('publish-queue', () => {
       return items;
     }
 
-    function makeQueue(): PublishQueue {
+    function makeQueue(maxWaiting: number): PublishQueue {
       const queue = new PublishQueue({ clientId: 'id', clientSecret: 'secret', hubId: 'hub' });
       queue.attemptDelay = 0;
+      queue.maxWaiting = maxWaiting;
 
       return queue;
     }
@@ -164,7 +165,7 @@ describe('publish-queue', () => {
         progressStepsTemplate('//publishJob-id1', 3)
       ]);
 
-      const queue = makeQueue();
+      const queue = makeQueue(10);
 
       await queue.publish(item1);
 
@@ -175,16 +176,16 @@ describe('publish-queue', () => {
       expect(totalPolls).toEqual(3);
     });
 
-    it('should wait for publish completion when starting a publish and attempting to publish more', async () => {
+    it('should wait for publish completion when hitting the concurrent limit and attempting to publish more', async () => {
       const items = multiMock(10, 1); // 10 items, return success on the first poll (instant publish)
 
-      const queue = makeQueue();
+      const queue = makeQueue(5); // After 5 concurrent requests, start waiting.
 
       for (let i = 0; i < items.length; i++) {
         await queue.publish(items[i]);
 
-        // Starts polling when i == 1, and each time we continue one job has completed.
-        expect(totalPolls).toEqual(Math.max(0, i));
+        // Starts polling when i == 5, and each time we continue one job has completed.
+        expect(totalPolls).toEqual(Math.max(0, i - 4));
       }
 
       await queue.waitForAll();
@@ -192,10 +193,10 @@ describe('publish-queue', () => {
       expect(totalPolls).toEqual(10);
     });
 
-    it('should never wait for publish completion when starting a publish, only when waiting or publishing more', async () => {
-      const items = multiMock(1, 1); // 10 items, return success on the first poll (instant publish)
+    it('should never wait for publish completion between publishes when less than the concurrent limit', async () => {
+      const items = multiMock(10, 1); // 10 items, return success on the first poll (instant publish)
 
-      const queue = makeQueue(); // After 1 concurrent request, start waiting.
+      const queue = makeQueue(15); // After 15 concurrent requests, start waiting.
 
       for (let i = 0; i < items.length; i++) {
         await queue.publish(items[i]);
@@ -205,11 +206,11 @@ describe('publish-queue', () => {
 
       await queue.waitForAll();
 
-      expect(totalPolls).toEqual(1);
+      expect(totalPolls).toEqual(10);
     });
 
     it('should complete immediately when calling waitForAll with no publishes in progress', async () => {
-      const queue = makeQueue();
+      const queue = makeQueue(15); // After 15 concurrent requests, start waiting.
 
       await queue.waitForAll();
 
@@ -225,7 +226,7 @@ describe('publish-queue', () => {
         progressStepsTemplate('//publishJob-id1', 3)
       ]);
 
-      const queue = makeQueue();
+      const queue = makeQueue(15);
 
       let threw = false;
       try {
@@ -257,7 +258,7 @@ describe('publish-queue', () => {
         progressStepsTemplate('//publishJob-id1', 3)
       ]);
 
-      const queue = makeQueue();
+      const queue = makeQueue(15);
 
       let threw = false;
       try {
@@ -288,7 +289,7 @@ describe('publish-queue', () => {
         progressStepsTemplate('//publishJob-id1', 3)
       ]);
 
-      const queue = makeQueue();
+      const queue = makeQueue(15);
 
       let threw = false;
       try {
@@ -312,7 +313,7 @@ describe('publish-queue', () => {
         progressStepsTemplate('//publishJob-id1', 3, 1)
       ]);
 
-      const queue = makeQueue();
+      const queue = makeQueue(15);
 
       await queue.publish(item1);
 
@@ -337,7 +338,7 @@ describe('publish-queue', () => {
         progressStepsTemplate('//publishJob-id3', 1, true)
       ]);
 
-      const queue = makeQueue();
+      const queue = makeQueue(15);
 
       await queue.publish(item1);
       await queue.publish(item2);
@@ -355,7 +356,7 @@ describe('publish-queue', () => {
     it('should still correctly waitForAll if a previous publish is waiting to start', async () => {
       const items = multiMock(10, 1); // 10 items, return success on the first poll (instant publish)
 
-      const queue = makeQueue();
+      const queue = makeQueue(5); // After 5 concurrent requests, start waiting.
 
       for (let i = 0; i < items.length; i++) {
         // Deliberately avoid waiting after starting the first publish that would have to wait.
@@ -374,28 +375,28 @@ describe('publish-queue', () => {
     });
 
     it('should error publishes when waiting for a publish job exceeds the maxAttempts number', async () => {
-      const items = multiMock(3, 5); // 3 items, return success on the 5th poll (after our limit)
+      const items = multiMock(10, 5); // 10 items, return success on the 5th poll (after our limit)
 
-      const queue = makeQueue(); // After 1 concurrent request, start waiting.
-      queue.maxAttempts = 2; // Fail after 2 incomplete polls.
+      const queue = makeQueue(5); // After 5 concurrent requests, start waiting.
+      queue.maxAttempts = 2;
 
       for (let i = 0; i < items.length; i++) {
         await queue.publish(items[i]);
 
         if (queue.failedJobs.length > 0) {
           // The first job should have failed.
-          expect(i).toEqual(1); // We only waited for the first job after the second was put in the queue.
+          expect(i).toEqual(5); // We only waited for the first job after 0-4 were in the queue.
           expect(queue.failedJobs[0].item).toBe(items[0]);
           break;
         }
 
-        expect(i).toBeLessThan(1);
+        expect(i).toBeLessThan(5);
       }
 
       await queue.waitForAll();
 
-      expect(totalPolls).toEqual(4); // 2 total publish requests. 2 waits before each before giving up.
-      expect(queue.failedJobs.length).toEqual(2);
+      expect(totalPolls).toEqual(12); // 6 total publish requests. 2 waits before each before giving up.
+      expect(queue.failedJobs.length).toEqual(6);
     });
   });
 });

--- a/src/common/import/publish-queue.ts
+++ b/src/common/import/publish-queue.ts
@@ -13,11 +13,11 @@ export interface PublishingJob {
   _links?: { [name: string]: HalLink };
 }
 
-async function delay(duration: number): Promise<void> {
+export const delay = (duration: number): Promise<void> => {
   return new Promise<void>((resolve): void => {
     setTimeout(resolve, duration);
   });
-}
+};
 
 export interface JobRequest {
   item: ContentItem;
@@ -25,16 +25,18 @@ export interface JobRequest {
 }
 
 export class PublishQueue {
-  maxWaiting = 10;
+  maxWaiting = 100;
   maxAttempts = 30;
   attemptDelay = 1000;
+  attemptRateLimit = 60000 / 100; // 100 publishes a minute.
   failedJobs: JobRequest[] = [];
 
   private inProgressJobs: JobRequest[] = [];
   private waitingList: { promise: Promise<void>; resolver: () => void }[] = [];
   private auth: OAuth2Client;
   private awaitingAll: boolean;
-
+  private delayUntil: number[] = [];
+  private delayId = 0;
   waitInProgress = false;
 
   constructor(credentials: ConfigurationParameters) {
@@ -138,6 +140,18 @@ export class PublishQueue {
   }
 
   private async rateLimit(): Promise<void> {
+    // Rate limit by time.
+    const now = Date.now();
+
+    if (now < this.delayUntil[this.delayId] || 0) {
+      await delay(this.delayUntil[this.delayId] - now);
+    }
+
+    this.delayUntil[this.delayId] = now + this.attemptRateLimit * this.maxWaiting;
+    this.delayId = (this.delayId + 1) % this.maxWaiting;
+
+    // Rate limit by concurrent volume.
+
     if (this.inProgressJobs.length != this.maxWaiting) {
       return;
     }

--- a/src/common/import/publish-queue.ts
+++ b/src/common/import/publish-queue.ts
@@ -25,10 +25,10 @@ export interface JobRequest {
 }
 
 export class PublishQueue {
-  maxWaiting = 100;
+  maxWaiting = 35;
   maxAttempts = 30;
   attemptDelay = 1000;
-  attemptRateLimit = 60000 / 100; // 100 publishes a minute.
+  attemptRateLimit = 60000 / 35; // 35 publishes a minute.
   failedJobs: JobRequest[] = [];
 
   private inProgressJobs: JobRequest[] = [];

--- a/src/common/import/publish-queue.ts
+++ b/src/common/import/publish-queue.ts
@@ -25,6 +25,7 @@ export interface JobRequest {
 }
 
 export class PublishQueue {
+  maxWaiting = 10;
   maxAttempts = 30;
   attemptDelay = 1000;
   failedJobs: JobRequest[] = [];
@@ -137,7 +138,7 @@ export class PublishQueue {
   }
 
   private async rateLimit(): Promise<void> {
-    if (this.inProgressJobs.length == 0) {
+    if (this.inProgressJobs.length != this.maxWaiting) {
       return;
     }
 

--- a/src/interfaces/clone-hub-builder-options.ts
+++ b/src/interfaces/clone-hub-builder-options.ts
@@ -20,6 +20,7 @@ export interface CloneHubBuilderOptions {
 
   lastPublish?: boolean;
   publish?: boolean;
+  batchPublish?: boolean;
   republish?: boolean;
 
   excludeKeys?: boolean;

--- a/src/interfaces/copy-item-builder-options.interface.ts
+++ b/src/interfaces/copy-item-builder-options.interface.ts
@@ -24,6 +24,7 @@ export interface CopyItemBuilderOptions {
 
   lastPublish?: boolean;
   publish?: boolean;
+  batchPublish?: boolean;
   republish?: boolean;
 
   excludeKeys?: boolean;

--- a/src/interfaces/import-item-builder-options.interface.ts
+++ b/src/interfaces/import-item-builder-options.interface.ts
@@ -6,6 +6,7 @@ export interface ImportItemBuilderOptions {
   baseFolder?: string;
   mapFile?: string;
   publish?: boolean;
+  batchPublish?: boolean;
   republish?: boolean;
   force?: boolean;
   validate?: boolean;


### PR DESCRIPTION
This is an alternative implementation to #145 which extends the existing publishing queue to support concurrent publishes.

Benefits:
- Publish() method actually starts the publish, dispatching is limited by both the rate limit and the concurrency limit.
- Not too much change from the existing publish queue.

Downsides:
- Custom implementation of batching rather than a standard one, though this was technically already in place originally.