### PR TITLE
fix(content-item): only assume links will be published, not references

### DIFF
--- a/src/commands/content-item/__mocks__/dependant-content-helper.ts
+++ b/src/commands/content-item/__mocks__/dependant-content-helper.ts
@@ -1,9 +1,12 @@
-import { ContentDependancy } from '../../../common/content-item/content-dependancy-tree';
+import { ContentDependancy, DependancyContentTypeSchema } from '../../../common/content-item/content-dependancy-tree';
 
-function dependancy(id: string): ContentDependancy {
+function dependancy(
+  id: string,
+  type = 'http://bigcontent.io/cms/schema/v1/core#/definitions/content-link'
+): ContentDependancy {
   return {
     _meta: {
-      schema: 'http://bigcontent.io/cms/schema/v1/core#/definitions/content-link',
+      schema: type as DependancyContentTypeSchema,
       name: 'content-link'
     },
     contentType: 'https://dev-solutions.s3.amazonaws.com/DynamicContentTypes/Accelerators/blog.json',
@@ -21,12 +24,33 @@ function dependProps(itemProps: [string, string][]): object {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function dependsOn(itemIds: string[], itemProps?: [string, string][]): any {
+export function dependsOn(itemIds: string[], type?: string, itemProps?: [string, string][]): any {
   itemProps = itemProps || [];
   return {
-    links: itemIds.map(id => dependancy(id)),
+    links: itemIds.map(id => dependancy(id, type)),
     ...dependProps(itemProps)
   };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function hierarchyParent(parentId: string, itemProps?: [string, string][]): any {
+  itemProps = itemProps || [];
+  const item = {
+    ...dependProps(itemProps)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+
+  if (!item._meta) {
+    item._meta = {};
+  }
+
+  if (!item._meta.hierarchy) {
+    item._meta.hierarchy = {};
+  }
+
+  item._meta.hierarchy.parentId = parentId;
+
+  return item;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/common/content-item/content-dependancy-tree.ts
+++ b/src/common/content-item/content-dependancy-tree.ts
@@ -336,20 +336,23 @@ export class ContentDependancyTree {
   public traverseDependants(
     item: ItemContentDependancies,
     action: (item: ItemContentDependancies) => void,
-    ignoreHier = false,
+    onlyLinks = false,
     traversed?: Set<ItemContentDependancies>
   ): void {
     const traversedSet = traversed || new Set<ItemContentDependancies>();
     traversedSet.add(item);
     action(item);
     item.dependants.forEach(dependant => {
-      if (ignoreHier && dependant.dependancy._meta.schema == '_hierarchy') {
+      if (
+        onlyLinks &&
+        dependant.dependancy._meta.schema !== 'http://bigcontent.io/cms/schema/v1/core#/definitions/content-link'
+      ) {
         return;
       }
 
       const resolved = dependant.resolved as ItemContentDependancies;
       if (!traversedSet.has(resolved)) {
-        this.traverseDependants(resolved, action, ignoreHier, traversedSet);
+        this.traverseDependants(resolved, action, onlyLinks, traversedSet);
       }
     });
   }


### PR DESCRIPTION
The code to skip publishing child items assumed that both content links and content references would be followed and published when their parent is, but that is only the case for links. This fixes the issue, and adds a test to verify that traversal only follows links when asked to.