### PR TITLE
fix(events): correctly archive events with unscheduled editions

### DIFF
--- a/src/commands/event/archive.ts
+++ b/src/commands/event/archive.ts
@@ -216,7 +216,17 @@ export const processItems = async ({
 
     for (let i = 0; i < events.length; i++) {
       try {
-        await Promise.all(events[i].unscheduleEditions.map(edition => edition.related.unschedule()));
+        await Promise.all(
+          events[i].unscheduleEditions.map(async edition => {
+            await edition.related.unschedule();
+
+            if (events[i].command === 'ARCHIVE') {
+              // Unscheduled editions need to be deleted before the event can be archived.
+              const unscheduled = await client.editions.get(edition.id as string);
+              await unscheduled.related.delete();
+            }
+          })
+        );
 
         if (events[i].command === 'ARCHIVE') {
           await Promise.all(events[i].deleteEditions.map(edition => edition.related.delete()));

--- a/src/commands/event/archive.ts
+++ b/src/commands/event/archive.ts
@@ -4,7 +4,7 @@ import dynamicContentClientFactory from '../../services/dynamic-content-client-f
 import paginator from '../../common/dc-management-sdk-js/paginator';
 import { confirmArchive } from '../../common/archive/archive-helpers';
 import ArchiveEventOptions from '../../common/archive/archive-event-options';
-import { Edition, Event, DynamicContent } from 'dc-management-sdk-js';
+import { Edition, Event, DynamicContent, HalResource } from 'dc-management-sdk-js';
 import { equalsOrRegex } from '../../common/filter/filter';
 import { createLog, getDefaultLogPath } from '../../common/log-helpers';
 import { FileLog } from '../../common/file-log';
@@ -50,6 +50,30 @@ export const builder = (yargs: Argv): void => {
     });
 };
 
+const getResourceUntilSuccess = async ({
+  id = '',
+  resource = 'archive',
+  getter
+}: {
+  id: string;
+  resource: string;
+  getter: (id: string) => Promise<HalResource>
+}): Promise<HalResource | undefined> => {
+  let resourceEvent;
+
+  for (let i = 0; i < maxAttempts; i++) {
+    const obj: HalResource = await getter(id);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const link = obj._links && (obj._links as any)[resource];
+    if (link) {
+      resourceEvent = obj;
+      break;
+    }
+  }
+
+  return resourceEvent;
+};
+
 const getEventUntilSuccess = async ({
   id = '',
   resource = 'archive',
@@ -59,19 +83,19 @@ const getEventUntilSuccess = async ({
   resource: string;
   client: DynamicContent;
 }): Promise<Event | undefined> => {
-  let resourceEvent;
+  return await getResourceUntilSuccess({id, resource, getter: client.events.get}) as (Event | undefined);
+};
 
-  for (let i = 0; i < maxAttempts; i++) {
-    const event: Event = await client.events.get(id);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const link = event._links && (event._links as any)[resource];
-    if (link) {
-      resourceEvent = event;
-      break;
-    }
-  }
-
-  return resourceEvent;
+const getEditionUntilSuccess = async ({
+  id = '',
+  resource = 'archive',
+  client
+}: {
+  id: string;
+  resource: string;
+  client: DynamicContent;
+}): Promise<Edition | undefined> => {
+  return await getResourceUntilSuccess({id, resource, getter: client.editions.get}) as (Edition | undefined);
 };
 
 export const getEvents = async ({
@@ -224,8 +248,18 @@ export const processItems = async ({
 
             if (events[index].command === 'ARCHIVE') {
               // Unscheduled editions need to be deleted before the event can be archived.
-              const unscheduled = await client.editions.get(edition.id as string);
-              await unscheduled.related.delete();
+              const unscheduled = await getEditionUntilSuccess({
+                id: edition.id as string,
+                resource: 'delete',
+                client
+              });
+
+              if (unscheduled) {
+                await unscheduled.related.delete();
+              } else {
+                log.addComment(`UNSCHEDULE+DELETE FAILED: ${edition.id}`);
+                log.addComment(`The edition may have taken too long to unschedule. Try again later or contact support.`);
+              }
             }
           })
         );

--- a/src/commands/event/archive.ts
+++ b/src/commands/event/archive.ts
@@ -57,7 +57,7 @@ const getResourceUntilSuccess = async ({
 }: {
   id: string;
   resource: string;
-  getter: (id: string) => Promise<HalResource>
+  getter: (id: string) => Promise<HalResource>;
 }): Promise<HalResource | undefined> => {
   let resourceEvent;
 
@@ -83,7 +83,7 @@ const getEventUntilSuccess = async ({
   resource: string;
   client: DynamicContent;
 }): Promise<Event | undefined> => {
-  return await getResourceUntilSuccess({id, resource, getter: client.events.get}) as (Event | undefined);
+  return (await getResourceUntilSuccess({ id, resource, getter: client.events.get })) as (Event | undefined);
 };
 
 const getEditionUntilSuccess = async ({
@@ -95,7 +95,7 @@ const getEditionUntilSuccess = async ({
   resource: string;
   client: DynamicContent;
 }): Promise<Edition | undefined> => {
-  return await getResourceUntilSuccess({id, resource, getter: client.editions.get}) as (Edition | undefined);
+  return (await getResourceUntilSuccess({ id, resource, getter: client.editions.get })) as (Edition | undefined);
 };
 
 export const getEvents = async ({
@@ -258,7 +258,9 @@ export const processItems = async ({
                 await unscheduled.related.delete();
               } else {
                 log.addComment(`UNSCHEDULE+DELETE FAILED: ${edition.id}`);
-                log.addComment(`The edition may have taken too long to unschedule. Try again later or contact support.`);
+                log.addComment(
+                  `The edition may have taken too long to unschedule. Try again later or contact support.`
+                );
               }
             }
           })

--- a/src/commands/event/archive.ts
+++ b/src/commands/event/archive.ts
@@ -216,11 +216,13 @@ export const processItems = async ({
 
     for (let i = 0; i < events.length; i++) {
       try {
+        const index = i;
+
         await Promise.all(
           events[i].unscheduleEditions.map(async edition => {
             await edition.related.unschedule();
 
-            if (events[i].command === 'ARCHIVE') {
+            if (events[index].command === 'ARCHIVE') {
               // Unscheduled editions need to be deleted before the event can be archived.
               const unscheduled = await client.editions.get(edition.id as string);
               await unscheduled.related.delete();


### PR DESCRIPTION
To archive events, all contained editions must be archived. However, if an edition has never been published (its scheduled time never arrived) then it cannot be archived. The correct process here is unscheduling the edition, then _deleting_ it, though only the first part was done which would result in an error. This PR fixes the issue.