### PR TITLE
feat(settings): overwrite existing preview settings rather than ignoring updates

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -96,6 +96,7 @@ dc-cli settings import <dir>
 
 | Option Name     | Type      | Description                                                  |
 | --------------- | --------- | ------------------------------------------------------------ |
+| --allowDelete   | [boolean] | Allows removal of settings that are not in the imported json when possible, such as previews. |
 | --mapFile       | [string]  | Mapping file to use when updating workflow states that already exists.<br />Updated with any new mappings that are generated.<br />If not present, will be created.<br />For more information, see [mapping files](#MAPPING-FILES). |
 | -f<br />--force | [boolean] | Overwrite workflow states on import without asking.          |
 

--- a/src/commands/settings/import.spec.ts
+++ b/src/commands/settings/import.spec.ts
@@ -319,6 +319,12 @@ describe('settings import command', (): void => {
         type: 'string'
       });
 
+      expect(spyOptions).toHaveBeenCalledWith('allowDelete', {
+        type: 'boolean',
+        boolean: true,
+        describe: 'Allows removal of settings that are not in the imported json when possible, such as previews.'
+      });
+
       expect(spyOptions).toHaveBeenCalledWith('mapFile', {
         type: 'string',
         requiresArg: false,

--- a/src/commands/settings/import.ts
+++ b/src/commands/settings/import.ts
@@ -102,7 +102,7 @@ export const handler = async (
     }
 
     if (hub.settings && hub.settings.applications) {
-      uniqueApplications = uniqBy([...hub.settings.applications, ...settings.applications], 'name');
+      uniqueApplications = uniqBy([...settings.applications, ...hub.settings.applications], 'name');
     }
 
     await hub.related.settings.update(

--- a/src/commands/settings/import.ts
+++ b/src/commands/settings/import.ts
@@ -48,6 +48,11 @@ export const builder = (yargs: Argv): void => {
       describe: 'Source file path containing Settings definition',
       type: 'string'
     })
+    .option('allowDelete', {
+      type: 'boolean',
+      boolean: true,
+      describe: 'Allows removal of settings that are not in the imported json when possible, such as previews.'
+    })
     .option('mapFile', {
       type: 'string',
       requiresArg: false,
@@ -102,7 +107,12 @@ export const handler = async (
     }
 
     if (hub.settings && hub.settings.applications) {
-      uniqueApplications = uniqBy([...settings.applications, ...hub.settings.applications], 'name');
+      if (argv.allowDelete) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        uniqueApplications = [...settings.applications] as any[];
+      } else {
+        uniqueApplications = uniqBy([...settings.applications, ...hub.settings.applications], 'name');
+      }
     }
 
     await hub.related.settings.update(

--- a/src/interfaces/import-settings-builder-options.interface.ts
+++ b/src/interfaces/import-settings-builder-options.interface.ts
@@ -2,6 +2,7 @@ import { FileLog } from '../common/file-log';
 
 export interface ImportSettingsBuilderOptions {
   filePath: string;
+  allowDelete?: boolean;
   mapFile?: string;
   logFile: FileLog;
   force?: boolean;


### PR DESCRIPTION
Before, existing preview settings would not be touched when importing new ones. This PR allows new preview settings to overwrite existing ones, which is useful for overwriting the URL. Settings import still cannot delete preview settings.